### PR TITLE
Add support for latest OpenSuSE images

### DIFF
--- a/lib/beaker-hostgenerator/data.rb
+++ b/lib/beaker-hostgenerator/data.rb
@@ -808,6 +808,12 @@ module BeakerHostGenerator
           :general => {
             'platform' => 'opensuse-42-i386'
           },
+          :docker => {
+            'docker_image_commands' => [
+              'cp /bin/true /sbin/agetty',
+              'zypper install -y cron iproute2 tar wget which'
+            ]
+          },
           :vmpooler => {
             'template' => 'opensuse-42-i386'
           }
@@ -815,6 +821,12 @@ module BeakerHostGenerator
         'opensuse42-64' => {
           :general => {
             'platform' => 'opensuse-42-x86_64'
+          },
+          :docker => {
+            'docker_image_commands' => [
+              'cp /bin/true /sbin/agetty',
+              'zypper install -y cron iproute2 tar wget which'
+            ]
           },
           :vmpooler => {
             'template' => 'opensuse-42-x86_64'
@@ -824,6 +836,12 @@ module BeakerHostGenerator
           :general => {
             'platform' => 'opensuse-15-i386'
           },
+          :docker => {
+            'docker_image_commands' => [
+              'cp /bin/true /sbin/agetty',
+              'zypper install -y cron iproute2 tar wget which'
+            ]
+          },
           :vmpooler => {
             'template' => 'opensuse-15-i386'
           }
@@ -831,6 +849,12 @@ module BeakerHostGenerator
         'opensuse15-64' => {
           :general => {
             'platform' => 'opensuse-15-x86_64'
+          },
+          :docker => {
+            'docker_image_commands' => [
+              'cp /bin/true /sbin/agetty',
+              'zypper install -y cron iproute2 tar wget which'
+            ]
           },
           :vmpooler => {
             'template' => 'opensuse-15-x86_64'

--- a/lib/beaker-hostgenerator/data.rb
+++ b/lib/beaker-hostgenerator/data.rb
@@ -804,6 +804,38 @@ module BeakerHostGenerator
             'template' => 'palo-alto-8.1.0-x86_64'
           }
         },
+        'opensuse42-32' => {
+          :general => {
+            'platform' => 'opensuse-42-i386'
+          },
+          :vmpooler => {
+            'template' => 'opensuse-42-i386'
+          }
+        },
+        'opensuse42-64' => {
+          :general => {
+            'platform' => 'opensuse-42-x86_64'
+          },
+          :vmpooler => {
+            'template' => 'opensuse-42-x86_64'
+          }
+        },
+        'opensuse15-32' => {
+          :general => {
+            'platform' => 'opensuse-15-i386'
+          },
+          :vmpooler => {
+            'template' => 'opensuse-15-i386'
+          }
+        },
+        'opensuse15-64' => {
+          :general => {
+            'platform' => 'opensuse-15-x86_64'
+          },
+          :vmpooler => {
+            'template' => 'opensuse-15-x86_64'
+          }
+        },
         'oracle5-32' => {
           :general => {
             'platform'           => 'el-5-i386',

--- a/lib/beaker-hostgenerator/data.rb
+++ b/lib/beaker-hostgenerator/data.rb
@@ -804,22 +804,6 @@ module BeakerHostGenerator
             'template' => 'palo-alto-8.1.0-x86_64'
           }
         },
-        'opensuse11-32' => {
-          :general => {
-            'platform' => 'opensuse-11-i386'
-          },
-          :vmpooler => {
-            'template' => 'opensuse-11-i386'
-          }
-        },
-        'opensuse11-64' => {
-          :general => {
-            'platform' => 'opensuse-11-x86_64'
-          },
-          :vmpooler => {
-            'template' => 'opensuse-11-x86_64'
-          }
-        },
         'oracle5-32' => {
           :general => {
             'platform'           => 'el-5-i386',

--- a/lib/beaker-hostgenerator/hypervisor/docker.rb
+++ b/lib/beaker-hostgenerator/hypervisor/docker.rb
@@ -10,6 +10,7 @@ module BeakerHostGenerator
       def generate_node(node_info, base_config, bhg_version)
         base_config['docker_cmd'] = ['/sbin/init']
         base_config['image'] = node_info['ostype'].sub(/(\d)/, ':\1')
+        base_config['image'].sub!(/(\w+)/, '\1/leap') if node_info['ostype'] =~ /^opensuse/
         base_config['image'].sub!(/(\d{2})/, '\1.') if node_info['ostype'] =~ /^ubuntu/
 
         return base_generate_node(node_info, base_config, bhg_version, :docker)


### PR DESCRIPTION
I would like to use the latest OpenSuSE images to test different Puppet modules using Travis CI. 

At least ```Docker``` and ```Vagrant``` should work without any problemt, but I am not sure if additional ```docker_image_commands``` are necessary. 