### PR TITLE
(BKR-1698) Use generic vagrant box for centos6

### DIFF
--- a/lib/beaker-hostgenerator/hypervisor/vagrant.rb
+++ b/lib/beaker-hostgenerator/hypervisor/vagrant.rb
@@ -8,7 +8,7 @@ module BeakerHostGenerator
       include BeakerHostGenerator::Data
 
       def generate_node(node_info, base_config, bhg_version)
-        if node_info['ostype'] =~ /^centos/
+        if node_info['ostype'] =~ /^centos/ and not node_info['ostype'] =~ /6/
           base_config['box'] = node_info['ostype'].sub(/(\d)/, '/\1')
         elsif node_info['ostype'] =~ /^fedora/
           base_config['box'] = node_info['ostype'].sub(/(\d)/, '/\1') + '-cloud-base'

--- a/test/fixtures/per-host-settings/vagrant-hypervisor.yaml
+++ b/test/fixtures/per-host-settings/vagrant-hypervisor.yaml
@@ -8,7 +8,7 @@ expected_hash:
       pe_ver:
       pe_upgrade_dir:
       pe_upgrade_ver:
-      box: centos/6
+      box: generic/centos6
       synced_folder: disabled
       platform: el-6-x86_64
       packaging_platform: el-6-x86_64


### PR DESCRIPTION
The centos organization on vagrant cloud (htttps://app.vagrantup.com/centos)
no longer provides a centos/6 box. This commit switches to the generic base
boxes for centos which are still available and kept up to date.