### PR TITLE
Add support for el-8-ppc64le

### DIFF
--- a/lib/beaker-hostgenerator/data.rb
+++ b/lib/beaker-hostgenerator/data.rb
@@ -936,6 +936,15 @@ module BeakerHostGenerator
             'template' => 'redhat-8-x86_64'
           }
         },
+        'redhat8-POWER' => {
+          :general => {
+            'platform'           => 'el-8-ppc64le',
+            'packaging_platform' => 'el-8-ppc64le'
+          },
+          :abs => {
+            'template' => 'redhat-8-power8'
+          }
+        },
         'scientific5-32' => {
           :general => {
             'platform'           => 'el-5-i386',


### PR DESCRIPTION
FWIW I cannot run the `generate:fixtures` rake task anymore, it fails at `fedora-19-i386`, might be related to the Fedora changes?

```
rake aborted!
TypeError: no implicit conversion of nil into Hash
/home/gabi/.rvm/gems/ruby-2.6.3/gems/activesupport-6.1.3.1/lib/active_support/core_ext/hash/deep_merge.rb:24:in `merge!'
/home/gabi/.rvm/gems/ruby-2.6.3/gems/activesupport-6.1.3.1/lib/active_support/core_ext/hash/deep_merge.rb:24:in `deep_merge!'
/home/gabi/repo/beaker-hostgenerator/lib/beaker-hostgenerator/data.rb:1961:in `get_platform_info'
/home/gabi/repo/beaker-hostgenerator/lib/beaker-hostgenerator/hypervisor.rb:97:in `block in base_generate_node'
/home/gabi/repo/beaker-hostgenerator/lib/beaker-hostgenerator/hypervisor.rb:96:in `map'
/home/gabi/repo/beaker-hostgenerator/lib/beaker-hostgenerator/hypervisor.rb:96:in `base_generate_node'
/home/gabi/repo/beaker-hostgenerator/lib/beaker-hostgenerator/hypervisor/vmpooler.rb:18:in `generate_node'
/home/gabi/repo/beaker-hostgenerator/lib/beaker-hostgenerator/generator.rb:53:in `block in generate'
/home/gabi/repo/beaker-hostgenerator/lib/beaker-hostgenerator/generator.rb:30:in `each'
/home/gabi/repo/beaker-hostgenerator/lib/beaker-hostgenerator/generator.rb:30:in `generate'
/home/gabi/repo/beaker-hostgenerator/lib/beaker-hostgenerator/cli.rb:170:in `execute'
/home/gabi/repo/beaker-hostgenerator/test/util/generator_helpers.rb:11:in `run_cli_with_options'
/home/gabi/repo/beaker-hostgenerator/test/util/generator_helpers.rb:34:in `generate_fixture'
/home/gabi/repo/beaker-hostgenerator/test/util/generator_helpers.rb:59:in `block in generate_fixtures_using_osinfo'
/home/gabi/repo/beaker-hostgenerator/test/util/generator_helpers.rb:56:in `each'
/home/gabi/repo/beaker-hostgenerator/test/util/generator_helpers.rb:56:in `generate_fixtures_using_osinfo'
/home/gabi/repo/beaker-hostgenerator/test/util/generator_helpers.rb:76:in `generate'
/home/gabi/repo/beaker-hostgenerator/Rakefile:46:in `block (2 levels) in <top (required)>'
/home/gabi/.rvm/gems/ruby-2.6.3/gems/rake-13.0.3/exe/rake:27:in `<top (required)>'
/home/gabi/.rvm/gems/ruby-2.6.3/bin/ruby_executable_hooks:24:in `eval'
/home/gabi/.rvm/gems/ruby-2.6.3/bin/ruby_executable_hooks:24:in `<main>'
Tasks: TOP => generate:fixtures
(See full trace by running task with --trace)
```