### PR TITLE
Add Fedora 34 support

### DIFF
--- a/lib/beaker-hostgenerator/data.rb
+++ b/lib/beaker-hostgenerator/data.rb
@@ -83,7 +83,7 @@ module BeakerHostGenerator
       result = {}
 
       # Fedora
-      (19..33).each do |release|
+      (19..34).each do |release|
         # 32 bit support was dropped in Fedora 31
         if release < 31
           result["fedora#{release}-32"] = {

--- a/test/fixtures/generated/default/fedora34-64c
+++ b/test/fixtures/generated/default/fedora34-64c
@@ -1,0 +1,21 @@
+---
+arguments_string: fedora34-64c
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    fedora34-64-1:
+      pe_dir:
+      pe_ver:
+      pe_upgrade_dir:
+      pe_upgrade_ver:
+      platform: fedora-34-x86_64
+      hypervisor: vmpooler
+      template: fedora-34-x86_64
+      roles:
+      - agent
+      - dashboard
+  CONFIG:
+    nfs_server: none
+    consoleport: 443
+    pooling_api: http://vmpooler.delivery.puppetlabs.net/
+expected_exception:

--- a/test/fixtures/generated/multiplatform/fedora34-64c-windows2012r2_fr-64-fedora34-64d
+++ b/test/fixtures/generated/multiplatform/fedora34-64c-windows2012r2_fr-64-fedora34-64d
@@ -1,0 +1,46 @@
+---
+arguments_string: fedora34-64c-windows2012r2_fr-64-fedora34-64d
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    fedora34-64-1:
+      pe_dir:
+      pe_ver:
+      pe_upgrade_dir:
+      pe_upgrade_ver:
+      platform: fedora-34-x86_64
+      hypervisor: vmpooler
+      template: fedora-34-x86_64
+      roles:
+      - agent
+      - dashboard
+    windows2012r2_fr-64-1:
+      pe_dir:
+      pe_ver:
+      pe_upgrade_dir:
+      pe_upgrade_ver:
+      platform: windows-2012r2-64
+      packaging_platform: windows-2012-x64
+      ruby_arch: x64
+      template: win-2012r2-fr-x86_64
+      user: Administrateur
+      locale: fr
+      hypervisor: vmpooler
+      roles:
+      - agent
+    fedora34-64-2:
+      pe_dir:
+      pe_ver:
+      pe_upgrade_dir:
+      pe_upgrade_ver:
+      platform: fedora-34-x86_64
+      hypervisor: vmpooler
+      template: fedora-34-x86_64
+      roles:
+      - agent
+      - database
+  CONFIG:
+    nfs_server: none
+    consoleport: 443
+    pooling_api: http://vmpooler.delivery.puppetlabs.net/
+expected_exception:

--- a/test/fixtures/generated/multiplatform/windows2012r2_fr-64d-fedora34-64-windows2012r2_fr-64c
+++ b/test/fixtures/generated/multiplatform/windows2012r2_fr-64d-fedora34-64-windows2012r2_fr-64c
@@ -1,0 +1,50 @@
+---
+arguments_string: windows2012r2_fr-64d-fedora34-64-windows2012r2_fr-64c
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    windows2012r2_fr-64-1:
+      pe_dir:
+      pe_ver:
+      pe_upgrade_dir:
+      pe_upgrade_ver:
+      platform: windows-2012r2-64
+      packaging_platform: windows-2012-x64
+      ruby_arch: x64
+      template: win-2012r2-fr-x86_64
+      user: Administrateur
+      locale: fr
+      hypervisor: vmpooler
+      roles:
+      - agent
+      - database
+    fedora34-64-1:
+      pe_dir:
+      pe_ver:
+      pe_upgrade_dir:
+      pe_upgrade_ver:
+      platform: fedora-34-x86_64
+      hypervisor: vmpooler
+      template: fedora-34-x86_64
+      roles:
+      - agent
+    windows2012r2_fr-64-2:
+      pe_dir:
+      pe_ver:
+      pe_upgrade_dir:
+      pe_upgrade_ver:
+      platform: windows-2012r2-64
+      packaging_platform: windows-2012-x64
+      ruby_arch: x64
+      template: win-2012r2-fr-x86_64
+      user: Administrateur
+      locale: fr
+      hypervisor: vmpooler
+      roles:
+      - agent
+      - dashboard
+  CONFIG:
+    nfs_server: none
+    consoleport: 443
+    pooling_api: http://vmpooler.delivery.puppetlabs.net/
+expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/fedora34-64c
+++ b/test/fixtures/generated/osinfo-version-0/fedora34-64c
@@ -1,0 +1,21 @@
+---
+arguments_string: "--osinfo-version 0 fedora34-64c"
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    fedora34-64-1:
+      pe_dir:
+      pe_ver:
+      pe_upgrade_dir:
+      pe_upgrade_ver:
+      platform: fedora-34-x86_64
+      hypervisor: vmpooler
+      template: fedora-34-x86_64
+      roles:
+      - agent
+      - dashboard
+  CONFIG:
+    nfs_server: none
+    consoleport: 443
+    pooling_api: http://vmpooler.delivery.puppetlabs.net/
+expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/fedora34-64c
+++ b/test/fixtures/generated/osinfo-version-1/fedora34-64c
@@ -1,0 +1,21 @@
+---
+arguments_string: "--osinfo-version 1 fedora34-64c"
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    fedora34-64-1:
+      pe_dir:
+      pe_ver:
+      pe_upgrade_dir:
+      pe_upgrade_ver:
+      platform: fedora-34-x86_64
+      hypervisor: vmpooler
+      template: fedora-34-x86_64
+      roles:
+      - agent
+      - dashboard
+  CONFIG:
+    nfs_server: none
+    consoleport: 443
+    pooling_api: http://vmpooler.delivery.puppetlabs.net/
+expected_exception:


### PR DESCRIPTION
I generated the fixtures without the changes from https://github.com/voxpupuli/beaker-hostgenerator/pull/209, and without the `github_changelog_generator` gem installed.