### PR TITLE
Avoid activesupport deep_merge conflict

### DIFF
--- a/lib/beaker-hostgenerator/data.rb
+++ b/lib/beaker-hostgenerator/data.rb
@@ -1924,9 +1924,9 @@ module BeakerHostGenerator
     def get_osinfo(bhg_version)
       case bhg_version
       when 0
-        {}.deep_merge!(osinfo)
+        {}.deeper_merge!(osinfo)
       when 1
-        {}.deep_merge!(osinfo).deep_merge!(osinfo_bhgv1)
+        {}.deeper_merge!(osinfo).deeper_merge!(osinfo_bhgv1)
       else
         raise "Invalid beaker-hostgenerator version: #{bhg_version}"
       end
@@ -1970,10 +1970,7 @@ module BeakerHostGenerator
     #         }
     def get_platform_info(bhg_version, platform, hypervisor)
       info = get_osinfo(bhg_version)[platform]
-      result = {}
-      result.deep_merge!(info[:general]) if info[:general]
-      result.deep_merge!(info[hypervisor]) if info[hypervisor]
-      result
+      {}.deeper_merge!(info[:general]).deeper_merge!(info[hypervisor])
     end
 
     # Perform any adjustments or modifications necessary to the given node

--- a/lib/beaker-hostgenerator/generator.rb
+++ b/lib/beaker-hostgenerator/generator.rb
@@ -22,7 +22,7 @@ module BeakerHostGenerator
     def generate(layout, options)
       layout = prepare(layout)
       tokens = tokenize_layout(layout)
-      config = {}.deep_merge(BASE_CONFIG)
+      config = {}.deeper_merge(BASE_CONFIG)
       nodeid = Hash.new(1)
       ostype = nil
       bhg_version = options[:osinfo_version] || 0
@@ -51,7 +51,7 @@ module BeakerHostGenerator
         # Delegate to the hypervisor
         hypervisor = BeakerHostGenerator::Hypervisor.create(node_info, options)
         host_config = hypervisor.generate_node(node_info, host_config, bhg_version)
-        config['CONFIG'].deep_merge!(hypervisor.global_config())
+        config['CONFIG'].deeper_merge!(hypervisor.global_config())
 
         # Merge in any arbitrary key-value host settings. Treat the 'hostname'
         # setting specially, and don't merge it in as an arbitrary setting.
@@ -80,7 +80,7 @@ module BeakerHostGenerator
           decoded = "{#{decoded}}"
         end
         global_config = settings_string_to_map(decoded)
-        config['CONFIG'].deep_merge!(global_config)
+        config['CONFIG'].deeper_merge!(global_config)
       end
 
       # Munge non-string scalar values into proper data types
@@ -117,7 +117,7 @@ module BeakerHostGenerator
 
       if not options[:disable_role_config]
         host_config['roles'].each do |role|
-          host_config.deep_merge! get_role_config(role)
+          host_config.deeper_merge! get_role_config(role)
         end
       end
     end

--- a/lib/beaker-hostgenerator/hypervisor.rb
+++ b/lib/beaker-hostgenerator/hypervisor.rb
@@ -94,7 +94,7 @@ module BeakerHostGenerator
       def base_generate_node(node_info, base_config, bhg_version, *hypervisors)
         platform = node_info['platform']
         hypervisors.map do |hypervisor|
-          base_config.deep_merge! get_platform_info(bhg_version, platform, hypervisor)
+          base_config.deeper_merge! get_platform_info(bhg_version, platform, hypervisor)
         end
 
         base_config['hypervisor'] = @name

--- a/lib/beaker-hostgenerator/hypervisor/abs.rb
+++ b/lib/beaker-hostgenerator/hypervisor/abs.rb
@@ -1,6 +1,6 @@
 require 'beaker-hostgenerator/data'
 require 'beaker-hostgenerator/hypervisor'
-require 'deep_merge'
+require 'deep_merge/rails_compat'
 
 module BeakerHostGenerator
   module Hypervisor

--- a/lib/beaker-hostgenerator/hypervisor/docker.rb
+++ b/lib/beaker-hostgenerator/hypervisor/docker.rb
@@ -1,6 +1,6 @@
 require 'beaker-hostgenerator/data'
 require 'beaker-hostgenerator/hypervisor'
-require 'deep_merge'
+require 'deep_merge/rails_compat'
 
 module BeakerHostGenerator
   module Hypervisor

--- a/lib/beaker-hostgenerator/hypervisor/unknown.rb
+++ b/lib/beaker-hostgenerator/hypervisor/unknown.rb
@@ -1,6 +1,6 @@
 require 'beaker-hostgenerator/hypervisor'
 require 'beaker-hostgenerator/data'
-require 'deep_merge'
+require 'deep_merge/rails_compat'
 
 module BeakerHostGenerator::Hypervisor
   class Unknown < BeakerHostGenerator::Hypervisor::Interface

--- a/lib/beaker-hostgenerator/hypervisor/vagrant.rb
+++ b/lib/beaker-hostgenerator/hypervisor/vagrant.rb
@@ -1,6 +1,6 @@
 require 'beaker-hostgenerator/data'
 require 'beaker-hostgenerator/hypervisor'
-require 'deep_merge'
+require 'deep_merge/rails_compat'
 
 module BeakerHostGenerator
   module Hypervisor

--- a/lib/beaker-hostgenerator/hypervisor/vmpooler.rb
+++ b/lib/beaker-hostgenerator/hypervisor/vmpooler.rb
@@ -1,6 +1,6 @@
 require 'beaker-hostgenerator/data'
 require 'beaker-hostgenerator/hypervisor'
-require 'deep_merge'
+require 'deep_merge/rails_compat'
 
 module BeakerHostGenerator
   module Hypervisor

--- a/lib/beaker-hostgenerator/util.rb
+++ b/lib/beaker-hostgenerator/util.rb
@@ -1,7 +1,7 @@
 require 'beaker-hostgenerator/data'
 require 'beaker-hostgenerator/roles'
 require 'beaker-hostgenerator/hypervisor/vmpooler'
-require 'deep_merge'
+require 'deep_merge/rails_compat'
 
 module BeakerHostGenerator
   module Utils
@@ -18,8 +18,8 @@ module BeakerHostGenerator
     def dump_hosts(hosts, path)
       vmpooler_hypervisor = BeakerHostGenerator::Hypervisor::Vmpooler.new
       config = {}
-      config.deep_merge! BeakerHostGenerator::Data.BASE_CONFIG
-      config['CONFIG'].deep_merge! vmpooler_hypervisor.global_config()
+      config.deeper_merge! BeakerHostGenerator::Data.BASE_CONFIG
+      config['CONFIG'].deeper_merge! vmpooler_hypervisor.global_config()
 
       hosts.each do |host|
         config['HOSTS'][host.node_name] = {


### PR DESCRIPTION
github-changelog-generator depends on activesupport which defines `Hash#deep_merge` methods that behave differently and conflict with the ones from the `deep_merge` gem. Use the recommended way of avoiding this conflict, as per the `deep_merge` documentation.[1]

Also, revert the changes from #209 which cause unexpected behavior with generated fixtures.

[1] https://github.com/danielsdeleo/deep_merge#using-deep_merge-in-rails