### PR TITLE
Ensure amd64 containers are pulled when needed

### DIFF
--- a/lib/beaker-hostgenerator/hypervisor/docker.rb
+++ b/lib/beaker-hostgenerator/hypervisor/docker.rb
@@ -12,6 +12,9 @@ module BeakerHostGenerator
         base_config['image'] = node_info['ostype'].sub(/(\d)/, ':\1')
         base_config['image'].sub!(/(\w+)/, '\1/leap') if node_info['ostype'] =~ /^opensuse/
         base_config['image'].sub!(/(\d{2})/, '\1.') if node_info['ostype'] =~ /^ubuntu/
+        if node_info['bits'] == '64'
+          base_config['image'] = "amd64/#{base_config['image']}"
+        end
 
         return base_generate_node(node_info, base_config, bhg_version, :docker)
       end

--- a/test/fixtures/per-host-settings/every-hypervisor.yaml
+++ b/test/fixtures/per-host-settings/every-hypervisor.yaml
@@ -45,7 +45,7 @@ expected_hash:
       hypervisor: docker
       docker_cmd:
       - /sbin/init
-      image: debian:9
+      image: amd64/debian:9
       platform: debian-9-amd64
       packaging_platform: debian-9-amd64
       docker_image_commands:


### PR DESCRIPTION
Prior to this, asking for a `centos8-64` host while running Beaker on a machine with an ARM processor such the M1 baesd Macs would pull the ARM version of CentOS instead of the x86-64 based one.