### PR TITLE
Fix oracle image name

### DIFF
--- a/lib/beaker-hostgenerator/hypervisor/docker.rb
+++ b/lib/beaker-hostgenerator/hypervisor/docker.rb
@@ -10,6 +10,7 @@ module BeakerHostGenerator
       def generate_node(node_info, base_config, bhg_version)
         base_config['docker_cmd'] = ['/sbin/init']
         base_config['image'] = node_info['ostype'].sub(/(\d)/, ':\1')
+        base_config['image'].sub!(/\w+/, 'oraclelinux') if node_info['ostype'] =~ /^oracle/
         base_config['image'].sub!(/(\w+)/, '\1/leap') if node_info['ostype'] =~ /^opensuse/
         base_config['image'].sub!(/(\d{2})/, '\1.') if node_info['ostype'] =~ /^ubuntu/
         if node_info['bits'] == '64'

--- a/lib/beaker-hostgenerator/hypervisor/docker.rb
+++ b/lib/beaker-hostgenerator/hypervisor/docker.rb
@@ -12,6 +12,9 @@ module BeakerHostGenerator
         base_config['image'] = node_info['ostype'].sub(/(\d)/, ':\1')
         base_config['image'].sub!(/(\w+)/, '\1/leap') if node_info['ostype'] =~ /^opensuse/
         base_config['image'].sub!(/(\d{2})/, '\1.') if node_info['ostype'] =~ /^ubuntu/
+        if node_info['bits'] == '64'
+          base_config['image'] = "amd64/#{base_config['image']}"
+        end
 
         return base_generate_node(node_info, base_config, bhg_version, :docker)
       end

--- a/test/fixtures/per-host-settings/docker-regex-validation.yaml
+++ b/test/fixtures/per-host-settings/docker-regex-validation.yaml
@@ -1,0 +1,54 @@
+arguments_string: --hypervisor=docker oracle7-64-opensuse15-64-ubuntu2004-64
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    oracle7-64-1:
+      pe_dir:
+      pe_ver:
+      pe_upgrade_dir:
+      pe_upgrade_ver:
+      docker_cmd:
+      - "/sbin/init"
+      image: amd64/oraclelinux:7
+      platform: el-7-x86_64
+      packaging_platform: el-7-x86_64
+      hypervisor: docker
+      roles:
+      - agent
+    opensuse15-64-1:
+      pe_dir:
+      pe_ver:
+      pe_upgrade_dir:
+      pe_upgrade_ver:
+      docker_cmd:
+      - "/sbin/init"
+      image: amd64/opensuse/leap:15
+      platform: opensuse-15-x86_64
+      docker_image_commands:
+      - cp /bin/true /sbin/agetty
+      - zypper install -y cron iproute2 tar wget which
+      hypervisor: docker
+      roles:
+      - agent
+    ubuntu2004-64-1:
+      pe_dir:
+      pe_ver:
+      pe_upgrade_dir:
+      pe_upgrade_ver:
+      docker_cmd:
+      - "/sbin/init"
+      image: amd64/ubuntu:20.04
+      platform: ubuntu-20.04-amd64
+      packaging_platform: ubuntu-20.04-amd64
+      docker_image_commands:
+      - cp /bin/true /sbin/agetty
+      - apt-get install -y net-tools wget locales apt-transport-https iproute2 gnupg
+      - locale-gen en_US.UTF-8
+      - echo LANG=en_US.UTF-8 > /etc/default/locale
+      hypervisor: docker
+      roles:
+      - agent
+  CONFIG:
+    nfs_server: none
+    consoleport: 443
+expected_exception:

--- a/test/fixtures/per-host-settings/every-hypervisor.yaml
+++ b/test/fixtures/per-host-settings/every-hypervisor.yaml
@@ -45,7 +45,7 @@ expected_hash:
       hypervisor: docker
       docker_cmd:
       - /sbin/init
-      image: debian:9
+      image: amd64/debian:9
       platform: debian-9-amd64
       packaging_platform: debian-9-amd64
       docker_image_commands:


### PR DESCRIPTION
Prior to this, asking for oracle7-64 via Docker would fail due to the Docker image being named `oraclelinux` instead of just `oracle`.

A test was also added to ensure that the regex substitutions in docker.rb are working as expected.

This PR builds atop #214