### PR TITLE
Debian 11 docker: Install iproute2

### DIFF
--- a/lib/beaker-hostgenerator/data.rb
+++ b/lib/beaker-hostgenerator/data.rb
@@ -645,7 +645,7 @@ module BeakerHostGenerator
             'docker_image_commands' => [
               'cp /bin/true /sbin/agetty',
               'rm -f /usr/sbin/policy-rc.d',
-              'apt-get update && apt-get install -y cron locales-all net-tools wget gnupg'
+              'apt-get update && apt-get install -y cron locales-all net-tools wget gnupg iproute2'
             ]
           },
           :vagrant => {


### PR DESCRIPTION
this package provides ss, which is used by beaker to detect open ports
https://packages.debian.org/bullseye/amd64/iproute2/filelist