### PR TITLE
Drop redundant attributes from generated data

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source ENV['GEM_SOURCE'] || 'https://rubygems.org'
 
 gemspec
 
-if File.exists? "#{__FILE__}.local"
+if File.exist? "#{__FILE__}.local"
   eval(File.read("#{__FILE__}.local"), binding)
 end
 

--- a/lib/beaker-hostgenerator/data.rb
+++ b/lib/beaker-hostgenerator/data.rb
@@ -68,7 +68,7 @@ module BeakerHostGenerator
         'pe_ver' => options[:pe_ver] || pe_version,
         'pe_upgrade_dir' => options[:pe_upgrade_dir] || pe_dir(pe_upgrade_version),
         'pe_upgrade_ver' => options[:pe_upgrade_ver] || pe_upgrade_version,
-      }
+      }.reject { |key, value| value.nil? }
     end
 
     # This is where all the information for all platforms lives, irrespective

--- a/lib/beaker-hostgenerator/data.rb
+++ b/lib/beaker-hostgenerator/data.rb
@@ -152,8 +152,7 @@ module BeakerHostGenerator
       result.merge!({
         'aix53-POWER' => {
           :general => {
-            'platform'           => 'aix-5.3-power',
-            'packaging_platform' => 'aix-5.3-power'
+            'platform' => 'aix-5.3-power'
           },
           :abs => {
             'template' => 'aix-5.3-power'
@@ -161,8 +160,7 @@ module BeakerHostGenerator
         },
         'aix61-POWER' => {
           :general => {
-            'platform'           => 'aix-6.1-power',
-            'packaging_platform' => 'aix-6.1-power'
+            'platform' => 'aix-6.1-power'
           },
           :abs => {
             'template' => 'aix-6.1-power'
@@ -170,8 +168,7 @@ module BeakerHostGenerator
         },
         'aix71-POWER' => {
           :general => {
-            'platform'           => 'aix-7.1-power',
-            'packaging_platform' => 'aix-7.1-power'
+            'platform' => 'aix-7.1-power'
           },
           :abs => {
             'template' => 'aix-7.1-power'
@@ -199,8 +196,7 @@ module BeakerHostGenerator
         },
         'amazon6-64' => {
             :general => {
-                'platform'           => 'el-6-x86_64',
-                'packaging_platform' => 'el-6-x86_64'
+                'platform' => 'el-6-x86_64'
             },
             :abs => {
                 'template' => 'amazon-6-x86_64'
@@ -208,8 +204,7 @@ module BeakerHostGenerator
         },
         'amazon7-64' => {
             :general => {
-                'platform'           => 'el-7-x86_64',
-                'packaging_platform' => 'el-7-x86_64'
+                'platform' => 'el-7-x86_64'
             },
             :abs => {
                 'template' => 'amazon-7-x86_64'
@@ -217,8 +212,7 @@ module BeakerHostGenerator
         },
         'amazon7-ARM64' => {
           :general => {
-            'platform'           => 'el-7-aarch64',
-            'packaging_platform' => 'el-7-aarch64'
+            'platform' => 'el-7-aarch64'
           },
           :abs => {
             'template' => 'amazon-7-arm64'
@@ -237,8 +231,7 @@ module BeakerHostGenerator
         },
         'arista4-32' => {
           :general => {
-            'platform'           => 'eos-4-i386',
-            'packaging_platform' => 'eos-4-i386'
+            'platform' => 'eos-4-i386'
           },
           :vmpooler => {
             'template' => 'arista-4-i386'
@@ -256,14 +249,12 @@ module BeakerHostGenerator
         },
         'centos5-32' => {
           :general => {
-            'platform'           => 'el-5-i386',
-            'packaging_platform' => 'el-5-i386'
+            'platform' => 'el-5-i386'
           }
         },
         'centos5-64' => {
           :general => {
-            'platform'           => 'el-5-x86_64',
-            'packaging_platform' => 'el-5-x86_64'
+            'platform' => 'el-5-x86_64'
           },
           :docker => {
             'docker_image_commands' => [
@@ -275,14 +266,12 @@ module BeakerHostGenerator
         },
         'centos6-32' => {
           :general => {
-            'platform'           => 'el-6-i386',
-            'packaging_platform' => 'el-6-i386'
+            'platform' => 'el-6-i386'
           }
         },
         'centos6-64' => {
           :general => {
-            'platform'           => 'el-6-x86_64',
-            'packaging_platform' => 'el-6-x86_64'
+            'platform' => 'el-6-x86_64'
           },
           :docker => {
             'docker_image_commands' => [
@@ -295,8 +284,7 @@ module BeakerHostGenerator
         },
         'centos7-64' => {
           :general => {
-            'platform'           => 'el-7-x86_64',
-            'packaging_platform' => 'el-7-x86_64'
+            'platform' => 'el-7-x86_64'
           },
           :docker => {
             'docker_image_commands' => [
@@ -307,8 +295,7 @@ module BeakerHostGenerator
         },
         'centos8-64' => {
           :general => {
-            'platform'           => 'el-8-x86_64',
-            'packaging_platform' => 'el-8-x86_64'
+            'platform' => 'el-8-x86_64'
           },
           :docker => {
             'docker_image_commands' => [
@@ -535,8 +522,7 @@ module BeakerHostGenerator
         },
         'debian7-32' => {
           :general => {
-            'platform'           => 'debian-7-i386',
-            'packaging_platform' => 'debian-7-i386'
+            'platform' => 'debian-7-i386'
           },
           :vmpooler => {
             'template' => 'debian-7-i386'
@@ -544,8 +530,7 @@ module BeakerHostGenerator
         },
         'debian7-64' => {
           :general => {
-            'platform'           => 'debian-7-amd64',
-            'packaging_platform' => 'debian-7-amd64'
+            'platform' => 'debian-7-amd64'
           },
           :docker => {
             'docker_image_commands' => [
@@ -562,8 +547,7 @@ module BeakerHostGenerator
         },
         'debian8-32' => {
           :general => {
-            'platform'           => 'debian-8-i386',
-            'packaging_platform' => 'debian-8-i386'
+            'platform' => 'debian-8-i386'
           },
           :vmpooler => {
             'template' => 'debian-8-i386'
@@ -571,8 +555,7 @@ module BeakerHostGenerator
         },
         'debian8-64' => {
           :general => {
-            'platform'           => 'debian-8-amd64',
-            'packaging_platform' => 'debian-8-amd64'
+            'platform' => 'debian-8-amd64'
           },
           :docker => {
             'docker_image_commands' => [
@@ -590,8 +573,7 @@ module BeakerHostGenerator
         },
         'debian9-32' => {
           :general => {
-            'platform'           => 'debian-9-i386',
-            'packaging_platform' => 'debian-9-i386'
+            'platform' => 'debian-9-i386'
           },
           :vmpooler => {
             'template' => 'debian-9-i386'
@@ -606,8 +588,7 @@ module BeakerHostGenerator
         },
         'debian9-64' => {
           :general => {
-            'platform'           => 'debian-9-amd64',
-            'packaging_platform' => 'debian-9-amd64'
+            'platform' => 'debian-9-amd64'
           },
           :docker => {
             'docker_image_commands' => [
@@ -625,8 +606,7 @@ module BeakerHostGenerator
         },
         'debian10-64' => {
           :general => {
-            'platform'           => 'debian-10-amd64',
-            'packaging_platform' => 'debian-10-amd64'
+            'platform' => 'debian-10-amd64'
           },
           :docker => {
             'docker_image_commands' => [
@@ -644,8 +624,7 @@ module BeakerHostGenerator
         },
         'debian10-32' => {
           :general => {
-            'platform'           => 'debian-10-i386',
-            'packaging_platform' => 'debian-10-i386'
+            'platform' => 'debian-10-i386'
           },
           :docker => {
             'docker_image_commands' => [
@@ -660,8 +639,7 @@ module BeakerHostGenerator
         },
         'debian11-64' => {
           :general => {
-            'platform'           => 'debian-11-amd64',
-            'packaging_platform' => 'debian-11-amd64'
+            'platform' => 'debian-11-amd64'
           },
           :docker => {
             'docker_image_commands' => [
@@ -788,8 +766,7 @@ module BeakerHostGenerator
         },
         'oracle5-32' => {
           :general => {
-            'platform'           => 'el-5-i386',
-            'packaging_platform' => 'el-5-i386'
+            'platform' => 'el-5-i386'
           },
           :vmpooler => {
             'template' => 'oracle-5-i386'
@@ -797,8 +774,7 @@ module BeakerHostGenerator
         },
         'oracle5-64' => {
           :general => {
-            'platform'           => 'el-5-x86_64',
-            'packaging_platform' => 'el-5-x86_64'
+            'platform' => 'el-5-x86_64'
           },
           :vmpooler => {
             'template' => 'oracle-5-x86_64'
@@ -806,8 +782,7 @@ module BeakerHostGenerator
         },
         'oracle6-32' => {
           :general => {
-            'platform'           => 'el-6-i386',
-            'packaging_platform' => 'el-6-i386'
+            'platform' => 'el-6-i386'
           },
           :vmpooler => {
             'template' => 'oracle-6-i386'
@@ -815,8 +790,7 @@ module BeakerHostGenerator
         },
         'oracle6-64' => {
           :general => {
-            'platform'           => 'el-6-x86_64',
-            'packaging_platform' => 'el-6-x86_64'
+            'platform' => 'el-6-x86_64'
           },
           :vmpooler => {
             'template' => 'oracle-6-x86_64'
@@ -824,8 +798,7 @@ module BeakerHostGenerator
         },
         'oracle7-64' => {
           :general => {
-            'platform'           => 'el-7-x86_64',
-            'packaging_platform' => 'el-7-x86_64'
+            'platform' => 'el-7-x86_64'
           },
           :vmpooler => {
             'template' => 'oracle-7-x86_64'
@@ -841,8 +814,7 @@ module BeakerHostGenerator
         },
         'osx1010-64' => {
           :general => {
-            'platform'           => 'osx-10.10-x86_64',
-            'packaging_platform' => 'osx-10.10-x86_64'
+            'platform' => 'osx-10.10-x86_64'
           },
           :vmpooler => {
             'template' => 'osx-1010-x86_64'
@@ -850,8 +822,7 @@ module BeakerHostGenerator
         },
         'osx1011-64' => {
           :general => {
-            'platform'           => 'osx-10.11-x86_64',
-            'packaging_platform' => 'osx-10.11-x86_64'
+            'platform' => 'osx-10.11-x86_64'
           },
           :vmpooler => {
             'template' => 'osx-1011-x86_64'
@@ -859,8 +830,7 @@ module BeakerHostGenerator
         },
         'osx1012-64' => {
           :general => {
-            'platform'           => 'osx-10.12-x86_64',
-            'packaging_platform' => 'osx-10.12-x86_64'
+            'platform' => 'osx-10.12-x86_64'
           },
           :vmpooler => {
             'template' => 'osx-1012-x86_64'
@@ -868,8 +838,7 @@ module BeakerHostGenerator
         },
         'osx1013-64' => {
           :general => {
-            'platform'           => 'osx-10.13-x86_64',
-            'packaging_platform' => 'osx-10.13-x86_64'
+            'platform' => 'osx-10.13-x86_64'
           },
           :vmpooler => {
             'template' => 'osx-1013-x86_64'
@@ -877,8 +846,7 @@ module BeakerHostGenerator
         },
         'osx1014-64' => {
           :general => {
-            'platform'           => 'osx-10.14-x86_64',
-            'packaging_platform' => 'osx-10.14-x86_64'
+            'platform' => 'osx-10.14-x86_64'
           },
           :vmpooler => {
             'template' => 'osx-1014-x86_64'
@@ -886,8 +854,7 @@ module BeakerHostGenerator
         },
         'osx1015-64' => {
           :general => {
-            'platform'           => 'osx-10.15-x86_64',
-            'packaging_platform' => 'osx-10.15-x86_64'
+            'platform' => 'osx-10.15-x86_64'
           },
           :vmpooler => {
             'template' => 'osx-1015-x86_64'
@@ -895,8 +862,7 @@ module BeakerHostGenerator
         },
         'osx11-64' => {
           :general => {
-            'platform'           => 'osx-11-x86_64',
-            'packaging_platform' => 'osx-11-x86_64'
+            'platform' => 'osx-11-x86_64'
           },
           :vmpooler => {
             'template' => 'macos-112-x86_64'
@@ -920,8 +886,7 @@ module BeakerHostGenerator
         },
         'redhat5-32' => {
           :general => {
-            'platform'          => 'el-5-i386',
-            'packaging_platform' => 'el-5-i386'
+            'platform' => 'el-5-i386'
           },
           :vmpooler => {
             'template' => 'redhat-5-i386'
@@ -929,8 +894,7 @@ module BeakerHostGenerator
         },
         'redhat5-64' => {
           :general => {
-            'platform'          => 'el-5-x86_64',
-            'packaging_platform' => 'el-5-x86_64'
+            'platform' => 'el-5-x86_64'
           },
           :vmpooler => {
             'template' => 'redhat-5-x86_64'
@@ -938,8 +902,7 @@ module BeakerHostGenerator
         },
         'redhat6-32' => {
           :general => {
-            'platform'          => 'el-6-i386',
-            'packaging_platform' => 'el-6-i386'
+            'platform' => 'el-6-i386',
           },
           :vmpooler => {
             'template' => 'redhat-6-i386'
@@ -947,8 +910,7 @@ module BeakerHostGenerator
         },
         'redhat6-64' => {
           :general => {
-            'platform'           => 'el-6-x86_64',
-            'packaging_platform' => 'el-6-x86_64'
+            'platform' => 'el-6-x86_64'
           },
           :vmpooler => {
             'template' => 'redhat-6-x86_64'
@@ -956,14 +918,12 @@ module BeakerHostGenerator
         },
         'redhat6-S390X' => {
           :general => {
-            'platform'          => 'el-6-s390x',
-            'packaging_platform' => 'el-6-s390x'
+            'platform' => 'el-6-s390x'
           },
         },
         'redhat7-64' => {
           :general => {
-            'platform'           => 'el-7-x86_64',
-            'packaging_platform' => 'el-7-x86_64'
+            'platform' => 'el-7-x86_64'
           },
           :vmpooler => {
             'template' => 'redhat-7-x86_64'
@@ -980,8 +940,7 @@ module BeakerHostGenerator
         },
         'redhat7-POWER' => {
           :general => {
-            'platform'           => 'el-7-ppc64le',
-            'packaging_platform' => 'el-7-ppc64le'
+            'platform' => 'el-7-ppc64le',
           },
           :abs => {
             'template' => 'redhat-7.3-power8'
@@ -989,14 +948,12 @@ module BeakerHostGenerator
         },
         'redhat7-S390X' => {
           :general => {
-            'platform'           => 'el-7-s390x',
-            'packaging_platform' => 'el-7-s390x'
+            'platform' => 'el-7-s390x'
           },
         },
         'redhat7-AARCH64' => {
           :general => {
-            'platform'           => 'el-7-aarch64',
-            'packaging_platform' => 'el-7-aarch64'
+            'platform' => 'el-7-aarch64'
           },
           :abs => {
             'template' => 'centos-7-arm64'
@@ -1007,8 +964,7 @@ module BeakerHostGenerator
         },
         'redhat8-64' => {
           :general => {
-            'platform'           => 'el-8-x86_64',
-            'packaging_platform' => 'el-8-x86_64'
+            'platform' => 'el-8-x86_64'
           },
           :vmpooler => {
             'template' => 'redhat-8-x86_64'
@@ -1025,8 +981,7 @@ module BeakerHostGenerator
         },
         'redhat8-AARCH64' => {
           :general => {
-            'platform'           => 'el-8-aarch64',
-            'packaging_platform' => 'el-8-aarch64'
+            'platform' => 'el-8-aarch64'
           },
           :abs => {
             'template' => 'redhat-8-arm64'
@@ -1037,8 +992,7 @@ module BeakerHostGenerator
         },
         'redhat8-POWER' => {
           :general => {
-            'platform'           => 'el-8-ppc64le',
-            'packaging_platform' => 'el-8-ppc64le'
+            'platform' => 'el-8-ppc64le'
           },
           :abs => {
             'template' => 'redhat-8-power8'
@@ -1046,8 +1000,7 @@ module BeakerHostGenerator
         },
         'redhat9-64' => {
           :general => {
-            'platform'           => 'el-9-x86_64',
-            'packaging_platform' => 'el-9-x86_64'
+            'platform' => 'el-9-x86_64'
           },
           :vmpooler => {
             'template' => 'redhat-9-x86_64'
@@ -1066,8 +1019,7 @@ module BeakerHostGenerator
         },
         'scientific5-32' => {
           :general => {
-            'platform'           => 'el-5-i386',
-            'packaging_platform' => 'el-5-i386'
+            'platform' => 'el-5-i386'
           },
           :vmpooler => {
             'template' => 'scientific-5-i386'
@@ -1075,8 +1027,7 @@ module BeakerHostGenerator
         },
         'scientific5-64' => {
           :general => {
-            'platform'           => 'el-5-x86_64',
-            'packaging_platform' => 'el-5-x86_64'
+            'platform' => 'el-5-x86_64'
           },
           :vmpooler => {
             'template' => 'scientific-5-x86_64'
@@ -1084,8 +1035,7 @@ module BeakerHostGenerator
         },
         'scientific6-32' => {
           :general => {
-            'platform'          => 'el-6-i386',
-            'packaging_platform' => 'el-6-i386'
+            'platform' => 'el-6-i386'
           },
           :vmpooler => {
             'template' => 'scientific-6-i386'
@@ -1093,8 +1043,7 @@ module BeakerHostGenerator
         },
         'scientific6-64' => {
           :general => {
-            'platform'           => 'el-6-x86_64',
-            'packaging_platform' => 'el-6-x86_64'
+            'platform' => 'el-6-x86_64'
           },
           :vmpooler => {
             'template' => 'scientific-6-x86_64'
@@ -1102,8 +1051,7 @@ module BeakerHostGenerator
         },
         'scientific7-64' => {
           :general => {
-            'platform'          => 'el-7-x86_64',
-            'packaging_platform' => 'el-7-x86_64'
+            'platform' => 'el-7-x86_64'
           },
           :vmpooler => {
             'template' => 'scientific-7-x86_64'
@@ -1127,8 +1075,7 @@ module BeakerHostGenerator
         },
         'sles11-32' => {
           :general => {
-            'platform'           => 'sles-11-i386',
-            'packaging_platform' => 'sles-11-i386'
+            'platform' => 'sles-11-i386'
           },
           :vmpooler => {
             'template' => 'sles-11-i386'
@@ -1136,8 +1083,7 @@ module BeakerHostGenerator
         },
         'sles11-64' => {
           :general => {
-            'platform'           => 'sles-11-x86_64',
-            'packaging_platform' => 'sles-11-x86_64'
+            'platform' => 'sles-11-x86_64'
           },
           :vmpooler => {
             'template' => 'sles-11-x86_64'
@@ -1145,14 +1091,12 @@ module BeakerHostGenerator
         },
         'sles11-S390X' => {
           :general => {
-            'platform'           => 'sles-11-s390x',
-            'packaging_platform' => 'sles-11-s390x'
+            'platform' => 'sles-11-s390x'
           },
         },
         'sles12-64' => {
           :general => {
-            'platform'           => 'sles-12-x86_64',
-            'packaging_platform' => 'sles-12-x86_64'
+            'platform' => 'sles-12-x86_64'
           },
           :vmpooler => {
             'template' => 'sles-12-x86_64'
@@ -1160,14 +1104,12 @@ module BeakerHostGenerator
         },
         'sles12-S390X' => {
           :general => {
-            'platform'           => 'sles-12-s390x',
-            'packaging_platform' => 'sles-12-s390x'
+            'platform' => 'sles-12-s390x'
           }
         },
         'sles12-POWER' => {
           :general => {
-            'platform'           => 'sles-12-ppc64le',
-            'packaging_platform' => 'sles-12-ppc64le'
+            'platform' => 'sles-12-ppc64le'
           },
           :abs => {
             'template' => 'sles-12-power8'
@@ -1175,8 +1117,7 @@ module BeakerHostGenerator
         },
         'sles15-64' => {
           :general => {
-            'platform'           => 'sles-15-x86_64',
-            'packaging_platform' => 'sles-15-x86_64'
+            'platform' => 'sles-15-x86_64'
           },
           :vmpooler => {
             'template' => 'sles-15-x86_64'
@@ -1184,8 +1125,7 @@ module BeakerHostGenerator
         },
         'solaris10-32' => {
           :general => {
-            'platform'           => 'solaris-10-i386',
-            'packaging_platform' => 'solaris-10-i386'
+            'platform' => 'solaris-10-i386'
           },
           :vmpooler => {
             'template' => 'solaris-10-x86_64'
@@ -1193,8 +1133,7 @@ module BeakerHostGenerator
         },
         'solaris10-64' => {
           :general => {
-            'platform'           => 'solaris-10-i386',
-            'packaging_platform' => 'solaris-10-i386'
+            'platform' => 'solaris-10-i386'
           },
           :vmpooler => {
             'template' => 'solaris-10-x86_64'
@@ -1202,8 +1141,7 @@ module BeakerHostGenerator
         },
         'solaris10-SPARC' => {
           :general => {
-            'platform'           => 'solaris-10-sparc',
-            'packaging_platform' => 'solaris-10-sparc'
+            'platform' => 'solaris-10-sparc'
           },
           :abs => {
             'template' => 'solaris-10-sparc'
@@ -1211,8 +1149,7 @@ module BeakerHostGenerator
         },
         'solaris11-32' => {
           :general => {
-            'platform'           => 'solaris-11-i386',
-            'packaging_platform' => 'solaris-11-i386'
+            'platform' => 'solaris-11-i386'
           },
           :vmpooler => {
             'template' => 'solaris-11-x86_64'
@@ -1220,8 +1157,7 @@ module BeakerHostGenerator
         },
         'solaris11-64' => {
           :general => {
-            'platform'           => 'solaris-11-i386',
-            'packaging_platform' => 'solaris-11-i386'
+            'platform' => 'solaris-11-i386'
           },
           :vmpooler => {
             'template' => 'solaris-11-x86_64'
@@ -1229,8 +1165,7 @@ module BeakerHostGenerator
         },
         'solaris11-SPARC' => {
           :general => {
-            'platform'           => 'solaris-11-sparc',
-            'packaging_platform' => 'solaris-11-sparc'
+            'platform' => 'solaris-11-sparc'
           },
           :abs => {
             'template' => 'solaris-11-sparc'
@@ -1274,8 +1209,7 @@ module BeakerHostGenerator
         },
         'vro6-64' => {
           :general => {
-            'platform'           => 'sles-11-x86_64',
-            'packaging_platform' => 'sles-11-x86_64'
+            'platform' => 'sles-11-x86_64'
           },
           :vmpooler => {
             'template' => 'vro-6-x86_64'
@@ -1283,8 +1217,7 @@ module BeakerHostGenerator
         },
         'vro7-64' => {
           :general => {
-            'platform'           => 'sles-11-x86_64',
-            'packaging_platform' => 'sles-11-x86_64'
+            'platform' => 'sles-11-x86_64'
           },
           :vmpooler => {
             'template' => 'vro-7-x86_64'
@@ -1292,8 +1225,7 @@ module BeakerHostGenerator
         },
         'vro71-64' => {
           :general => {
-            'platform'           => 'sles-11-x86_64',
-            'packaging_platform' => 'sles-11-x86_64'
+            'platform' => 'sles-11-x86_64'
           },
           :vmpooler => {
             'template' => 'vro-71-x86_64'
@@ -1301,8 +1233,7 @@ module BeakerHostGenerator
         },
         'vro73-64' => {
           :general => {
-            'platform'           => 'sles-11-x86_64',
-            'packaging_platform' => 'sles-11-x86_64'
+            'platform' => 'sles-11-x86_64'
           },
           :vmpooler => {
             'template' => 'vro-73-x86_64'
@@ -1310,8 +1241,7 @@ module BeakerHostGenerator
         },
         'vro74-64' => {
           :general => {
-            'platform'           => 'sles-11-x86_64',
-            'packaging_platform' => 'sles-11-x86_64'
+            'platform' => 'sles-11-x86_64'
           },
           :vmpooler => {
             'template' => 'vro-74-x86_64'

--- a/test/fixtures/generated/default/aix53-POWERa
+++ b/test/fixtures/generated/default/aix53-POWERa
@@ -4,13 +4,8 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     aix53-POWER-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: aix-5.3-power
-      packaging_platform: aix-5.3-power
       roles:
       - agent
   CONFIG:

--- a/test/fixtures/generated/default/aix61-POWERu
+++ b/test/fixtures/generated/default/aix61-POWERu
@@ -4,13 +4,8 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     aix61-POWER-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: aix-6.1-power
-      packaging_platform: aix-6.1-power
       roles:
       - agent
       - ca

--- a/test/fixtures/generated/default/aix71-POWERl
+++ b/test/fixtures/generated/default/aix71-POWERl
@@ -4,13 +4,8 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     aix71-POWER-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: aix-7.1-power
-      packaging_platform: aix-7.1-power
       roles:
       - agent
       - classifier

--- a/test/fixtures/generated/default/aix72-POWERc
+++ b/test/fixtures/generated/default/aix72-POWERc
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     aix72-POWER-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: aix-7.2-power
       packaging_platform: aix-7.1-power

--- a/test/fixtures/generated/default/almalinux8-64u
+++ b/test/fixtures/generated/default/almalinux8-64u
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     almalinux8-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: el-8-x86_64
       hypervisor: vmpooler
       template: almalinux-8-x86_64

--- a/test/fixtures/generated/default/amazon6-64d
+++ b/test/fixtures/generated/default/amazon6-64d
@@ -4,13 +4,8 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     amazon6-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: el-6-x86_64
-      packaging_platform: el-6-x86_64
       roles:
       - agent
       - database

--- a/test/fixtures/generated/default/amazon7-64f
+++ b/test/fixtures/generated/default/amazon7-64f
@@ -4,13 +4,8 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     amazon7-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: el-7-x86_64
-      packaging_platform: el-7-x86_64
       roles:
       - agent
       - frictionless

--- a/test/fixtures/generated/default/amazon7-ARM64m
+++ b/test/fixtures/generated/default/amazon7-ARM64m
@@ -4,12 +4,7 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     amazon7-ARM64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: el-7-aarch64
-      packaging_platform: el-7-aarch64
       hypervisor: vmpooler
       roles:
       - agent

--- a/test/fixtures/generated/default/archlinuxrolling-64a
+++ b/test/fixtures/generated/default/archlinuxrolling-64a
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     archlinuxrolling-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: archlinux-rolling-x64
       hypervisor: vmpooler
       roles:

--- a/test/fixtures/generated/default/archlinuxrolling-64c
+++ b/test/fixtures/generated/default/archlinuxrolling-64c
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     archlinuxrolling-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: archlinux-rolling-x64
       hypervisor: vmpooler
       roles:

--- a/test/fixtures/generated/default/archlinuxrolling-64l
+++ b/test/fixtures/generated/default/archlinuxrolling-64l
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     archlinuxrolling-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: archlinux-rolling-x64
       hypervisor: vmpooler
       roles:

--- a/test/fixtures/generated/default/archlinuxrolling-64u
+++ b/test/fixtures/generated/default/archlinuxrolling-64u
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     archlinuxrolling-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: archlinux-rolling-x64
       hypervisor: vmpooler
       roles:

--- a/test/fixtures/generated/default/arista4-32d
+++ b/test/fixtures/generated/default/arista4-32d
@@ -4,12 +4,7 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     arista4-32-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: eos-4-i386
-      packaging_platform: eos-4-i386
       template: arista-4-i386
       hypervisor: vmpooler
       roles:

--- a/test/fixtures/generated/default/centos4-32f
+++ b/test/fixtures/generated/default/centos4-32f
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     centos4-32-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: el-4-i386
       hypervisor: vmpooler
       template: centos-4-i386

--- a/test/fixtures/generated/default/centos4-64m
+++ b/test/fixtures/generated/default/centos4-64m
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     centos4-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: el-4-x86_64
       hypervisor: vmpooler
       template: centos-4-x86_64

--- a/test/fixtures/generated/default/centos5-32aulcdfm
+++ b/test/fixtures/generated/default/centos5-32aulcdfm
@@ -4,12 +4,7 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     centos5-32-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: el-5-i386
-      packaging_platform: el-5-i386
       hypervisor: vmpooler
       template: centos-5-i386
       roles:

--- a/test/fixtures/generated/default/centos5-64a
+++ b/test/fixtures/generated/default/centos5-64a
@@ -4,12 +4,7 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     centos5-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: el-5-x86_64
-      packaging_platform: el-5-x86_64
       hypervisor: vmpooler
       template: centos-5-x86_64
       roles:

--- a/test/fixtures/generated/default/centos6-32u
+++ b/test/fixtures/generated/default/centos6-32u
@@ -4,12 +4,7 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     centos6-32-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: el-6-i386
-      packaging_platform: el-6-i386
       hypervisor: vmpooler
       template: centos-6-i386
       roles:

--- a/test/fixtures/generated/default/centos6-64l
+++ b/test/fixtures/generated/default/centos6-64l
@@ -4,12 +4,7 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     centos6-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: el-6-x86_64
-      packaging_platform: el-6-x86_64
       hypervisor: vmpooler
       template: centos-6-x86_64
       roles:

--- a/test/fixtures/generated/default/centos7-64c
+++ b/test/fixtures/generated/default/centos7-64c
@@ -4,12 +4,7 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     centos7-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: el-7-x86_64
-      packaging_platform: el-7-x86_64
       hypervisor: vmpooler
       template: centos-7-x86_64
       roles:

--- a/test/fixtures/generated/default/centos8-64aulcdfm
+++ b/test/fixtures/generated/default/centos8-64aulcdfm
@@ -4,12 +4,7 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     centos8-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: el-8-x86_64
-      packaging_platform: el-8-x86_64
       template: centos-8-x86_64
       hypervisor: vmpooler
       roles:

--- a/test/fixtures/generated/default/cisco_ios_c2960-HWm
+++ b/test/fixtures/generated/default/cisco_ios_c2960-HWm
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     cisco_ios_c2960-HW-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: cisco_ios-12-arm32
       ssh:
         user: admin
@@ -19,4 +15,4 @@ expected_hash:
     nfs_server: none
     consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
-expected_exception: 
+expected_exception:

--- a/test/fixtures/generated/default/cisco_ios_c3560-HWaulcdfm
+++ b/test/fixtures/generated/default/cisco_ios_c3560-HWaulcdfm
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     cisco_ios_c3560-HW-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: cisco_ios-12-arm32
       ssh:
         user: admin
@@ -24,4 +20,4 @@ expected_hash:
     nfs_server: none
     consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
-expected_exception: 
+expected_exception:

--- a/test/fixtures/generated/default/cisco_ios_c3750-HWa
+++ b/test/fixtures/generated/default/cisco_ios_c3750-HWa
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     cisco_ios_c3750-HW-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: cisco_ios-12-arm32
       ssh:
         user: admin
@@ -18,4 +14,4 @@ expected_hash:
     nfs_server: none
     consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
-expected_exception: 
+expected_exception:

--- a/test/fixtures/generated/default/cisco_ios_c4507r-HWu
+++ b/test/fixtures/generated/default/cisco_ios_c4507r-HWu
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     cisco_ios_c4507r-HW-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: cisco_ios-12-arm32
       ssh:
         user: admin
@@ -19,4 +15,4 @@ expected_hash:
     nfs_server: none
     consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
-expected_exception: 
+expected_exception:

--- a/test/fixtures/generated/default/cisco_ios_c4948-HWl
+++ b/test/fixtures/generated/default/cisco_ios_c4948-HWl
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     cisco_ios_c4948-HW-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: cisco_ios-12-arm32
       ssh:
         user: admin
@@ -19,4 +15,4 @@ expected_hash:
     nfs_server: none
     consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
-expected_exception: 
+expected_exception:

--- a/test/fixtures/generated/default/cisco_ios_c6503-HWc
+++ b/test/fixtures/generated/default/cisco_ios_c6503-HWc
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     cisco_ios_c6503-HW-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: cisco_ios-12-arm32
       ssh:
         user: admin
@@ -19,4 +15,4 @@ expected_hash:
     nfs_server: none
     consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
-expected_exception: 
+expected_exception:

--- a/test/fixtures/generated/default/cisco_iosxe_c3650-HWd
+++ b/test/fixtures/generated/default/cisco_iosxe_c3650-HWd
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     cisco_iosxe_c3650-HW-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: cisco_iosxec3650-arm32
       ssh:
         user: admin
@@ -19,4 +15,4 @@ expected_hash:
     nfs_server: none
     consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
-expected_exception: 
+expected_exception:

--- a/test/fixtures/generated/default/cisco_iosxe_c4503-HWf
+++ b/test/fixtures/generated/default/cisco_iosxe_c4503-HWf
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     cisco_iosxe_c4503-HW-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: cisco_iosxe-3-arm32
       ssh:
         user: admin
@@ -19,4 +15,4 @@ expected_hash:
     nfs_server: none
     consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
-expected_exception: 
+expected_exception:

--- a/test/fixtures/generated/default/cisco_n7k-HWc
+++ b/test/fixtures/generated/default/cisco_n7k-HWc
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     cisco_n7k-HW-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: cisco_nexus-7k-x86_64
       packaging_platform: cisco-wrlinux-5-x86_64
       vrf: management
@@ -21,4 +17,4 @@ expected_hash:
     nfs_server: none
     consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
-expected_exception: 
+expected_exception:

--- a/test/fixtures/generated/default/cisco_n7k_vdc-HWd
+++ b/test/fixtures/generated/default/cisco_n7k_vdc-HWd
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     cisco_n7k_vdc-HW-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: cisco_nexus-7k-x86_64
       packaging_platform: cisco-wrlinux-5-x86_64
       vrf: management
@@ -21,4 +17,4 @@ expected_hash:
     nfs_server: none
     consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
-expected_exception: 
+expected_exception:

--- a/test/fixtures/generated/default/cisco_n9k-HWf
+++ b/test/fixtures/generated/default/cisco_n9k-HWf
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     cisco_n9k-HW-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: cisco_nexus-7-x86_64
       packaging_platform: cisco-wrlinux-5-x86_64
       vrf: management
@@ -21,4 +17,4 @@ expected_hash:
     nfs_server: none
     consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
-expected_exception: 
+expected_exception:

--- a/test/fixtures/generated/default/cisco_n9k-VMl
+++ b/test/fixtures/generated/default/cisco_n9k-VMl
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     cisco_n9k-VM-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: cisco_nexus-7-x86_64
       packaging_platform: cisco-wrlinux-5-x86_64
       vrf: management
@@ -22,4 +18,4 @@ expected_hash:
     nfs_server: none
     consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
-expected_exception: 
+expected_exception:

--- a/test/fixtures/generated/default/cisco_xr_9k-VMm
+++ b/test/fixtures/generated/default/cisco_xr_9k-VMm
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     cisco_xr_9k-VM-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: cisco_ios_xr-6-x86_64
       packaging_platform: cisco-wrlinux-7-x86_64
       template: cisco-exr-9k-x86_64
@@ -19,4 +15,4 @@ expected_hash:
     nfs_server: none
     consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
-expected_exception: 
+expected_exception:

--- a/test/fixtures/generated/default/ciscon7k-64a
+++ b/test/fixtures/generated/default/ciscon7k-64a
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     ciscon7k-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: cisco_nexus-7k-x86_64
       packaging_platform: cisco-wrlinux-5-x86_64
       vrf: management
@@ -20,4 +16,4 @@ expected_hash:
     nfs_server: none
     consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
-expected_exception: 
+expected_exception:

--- a/test/fixtures/generated/default/cisconx-64aulcdfm
+++ b/test/fixtures/generated/default/cisconx-64aulcdfm
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     cisconx-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: cisco_nexus-7-x86_64
       packaging_platform: cisco-wrlinux-5-x86_64
       vrf: management
@@ -27,4 +23,4 @@ expected_hash:
     nfs_server: none
     consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
-expected_exception: 
+expected_exception:

--- a/test/fixtures/generated/default/cisconx-64d
+++ b/test/fixtures/generated/default/cisconx-64d
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     cisconx-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: cisco_nexus-7-x86_64
       packaging_platform: cisco-wrlinux-5-x86_64

--- a/test/fixtures/generated/default/cisconxhw-64f
+++ b/test/fixtures/generated/default/cisconxhw-64f
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     cisconxhw-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       hypervisor: vmpooler
       platform: cisco_nexus-7-x86_64
       packaging_platform: cisco-wrlinux-5-x86_64

--- a/test/fixtures/generated/default/cisconxhw-64u
+++ b/test/fixtures/generated/default/cisconxhw-64u
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     cisconxhw-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: cisco_nexus-7-x86_64
       packaging_platform: cisco-wrlinux-5-x86_64
       vrf: management
@@ -21,4 +17,4 @@ expected_hash:
     nfs_server: none
     consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
-expected_exception: 
+expected_exception:

--- a/test/fixtures/generated/default/cumulus25-64m
+++ b/test/fixtures/generated/default/cumulus25-64m
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     cumulus25-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: cumulus-2.5-x86_64
       packaging_platform: cumulus-2.2-amd64
       template: cumulus-vx-25-x86_64

--- a/test/fixtures/generated/default/debian10-32d
+++ b/test/fixtures/generated/default/debian10-32d
@@ -4,12 +4,7 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     debian10-32-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: debian-10-i386
-      packaging_platform: debian-10-i386
       template: debian-10-i386
       hypervisor: vmpooler
       roles:

--- a/test/fixtures/generated/default/debian10-64c
+++ b/test/fixtures/generated/default/debian10-64c
@@ -4,12 +4,7 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     debian10-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: debian-10-amd64
-      packaging_platform: debian-10-amd64
       template: debian-10-x86_64
       hypervisor: vmpooler
       roles:

--- a/test/fixtures/generated/default/debian11-64m
+++ b/test/fixtures/generated/default/debian11-64m
@@ -4,12 +4,7 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     debian11-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: debian-11-amd64
-      packaging_platform: debian-11-amd64
       template: debian-11-x86_64
       hypervisor: vmpooler
       roles:

--- a/test/fixtures/generated/default/debian6-32aulcdfm
+++ b/test/fixtures/generated/default/debian6-32aulcdfm
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     debian6-32-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: debian-6-i386
       template: debian-6-i386
       hypervisor: vmpooler

--- a/test/fixtures/generated/default/debian6-64a
+++ b/test/fixtures/generated/default/debian6-64a
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     debian6-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: debian-6-amd64
       template: debian-6-x86_64
       hypervisor: vmpooler

--- a/test/fixtures/generated/default/debian7-32u
+++ b/test/fixtures/generated/default/debian7-32u
@@ -4,12 +4,7 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     debian7-32-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: debian-7-i386
-      packaging_platform: debian-7-i386
       template: debian-7-i386
       hypervisor: vmpooler
       roles:

--- a/test/fixtures/generated/default/debian7-64l
+++ b/test/fixtures/generated/default/debian7-64l
@@ -4,12 +4,7 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     debian7-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: debian-7-amd64
-      packaging_platform: debian-7-amd64
       template: debian-7-x86_64
       hypervisor: vmpooler
       roles:

--- a/test/fixtures/generated/default/debian8-32c
+++ b/test/fixtures/generated/default/debian8-32c
@@ -4,12 +4,7 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     debian8-32-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: debian-8-i386
-      packaging_platform: debian-8-i386
       template: debian-8-i386
       hypervisor: vmpooler
       roles:

--- a/test/fixtures/generated/default/debian8-64d
+++ b/test/fixtures/generated/default/debian8-64d
@@ -4,12 +4,7 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     debian8-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: debian-8-amd64
-      packaging_platform: debian-8-amd64
       template: debian-8-x86_64
       hypervisor: vmpooler
       roles:

--- a/test/fixtures/generated/default/debian9-32f
+++ b/test/fixtures/generated/default/debian9-32f
@@ -4,12 +4,7 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     debian9-32-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: debian-9-i386
-      packaging_platform: debian-9-i386
       template: debian-9-i386
       hypervisor: vmpooler
       roles:

--- a/test/fixtures/generated/default/debian9-64m
+++ b/test/fixtures/generated/default/debian9-64m
@@ -4,12 +4,7 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     debian9-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: debian-9-amd64
-      packaging_platform: debian-9-amd64
       template: debian-9-x86_64
       hypervisor: vmpooler
       roles:

--- a/test/fixtures/generated/default/fedora14-32aulcdfm
+++ b/test/fixtures/generated/default/fedora14-32aulcdfm
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     fedora14-32-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: fedora-14-i386
       template: fedora-14-i386

--- a/test/fixtures/generated/default/fedora19-32a
+++ b/test/fixtures/generated/default/fedora19-32a
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     fedora19-32-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: fedora-19-i386
       hypervisor: vmpooler
       template: fedora-19-i386

--- a/test/fixtures/generated/default/fedora19-64u
+++ b/test/fixtures/generated/default/fedora19-64u
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     fedora19-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: fedora-19-x86_64
       hypervisor: vmpooler
       template: fedora-19-x86_64

--- a/test/fixtures/generated/default/fedora20-32l
+++ b/test/fixtures/generated/default/fedora20-32l
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     fedora20-32-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: fedora-20-i386
       hypervisor: vmpooler
       template: fedora-20-i386

--- a/test/fixtures/generated/default/fedora20-64c
+++ b/test/fixtures/generated/default/fedora20-64c
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     fedora20-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: fedora-20-x86_64
       hypervisor: vmpooler
       template: fedora-20-x86_64

--- a/test/fixtures/generated/default/fedora21-32d
+++ b/test/fixtures/generated/default/fedora21-32d
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     fedora21-32-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: fedora-21-i386
       hypervisor: vmpooler
       template: fedora-21-i386

--- a/test/fixtures/generated/default/fedora21-64f
+++ b/test/fixtures/generated/default/fedora21-64f
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     fedora21-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: fedora-21-x86_64
       hypervisor: vmpooler
       template: fedora-21-x86_64

--- a/test/fixtures/generated/default/fedora22-32m
+++ b/test/fixtures/generated/default/fedora22-32m
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     fedora22-32-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: fedora-22-i386
       hypervisor: vmpooler
       template: fedora-22-i386

--- a/test/fixtures/generated/default/fedora22-64aulcdfm
+++ b/test/fixtures/generated/default/fedora22-64aulcdfm
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     fedora22-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: fedora-22-x86_64
       hypervisor: vmpooler
       template: fedora-22-x86_64

--- a/test/fixtures/generated/default/fedora23-32a
+++ b/test/fixtures/generated/default/fedora23-32a
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     fedora23-32-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: fedora-23-i386
       hypervisor: vmpooler
       template: fedora-23-i386

--- a/test/fixtures/generated/default/fedora23-64u
+++ b/test/fixtures/generated/default/fedora23-64u
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     fedora23-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: fedora-23-x86_64
       hypervisor: vmpooler
       template: fedora-23-x86_64

--- a/test/fixtures/generated/default/fedora24-32l
+++ b/test/fixtures/generated/default/fedora24-32l
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     fedora24-32-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: fedora-24-i386
       hypervisor: vmpooler
       template: fedora-24-i386

--- a/test/fixtures/generated/default/fedora24-64c
+++ b/test/fixtures/generated/default/fedora24-64c
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     fedora24-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: fedora-24-x86_64
       hypervisor: vmpooler
       template: fedora-24-x86_64

--- a/test/fixtures/generated/default/fedora25-32d
+++ b/test/fixtures/generated/default/fedora25-32d
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     fedora25-32-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: fedora-25-i386
       hypervisor: vmpooler
       template: fedora-25-i386

--- a/test/fixtures/generated/default/fedora25-64f
+++ b/test/fixtures/generated/default/fedora25-64f
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     fedora25-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: fedora-25-x86_64
       hypervisor: vmpooler
       template: fedora-25-x86_64

--- a/test/fixtures/generated/default/fedora26-64m
+++ b/test/fixtures/generated/default/fedora26-64m
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     fedora26-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: fedora-26-x86_64
       template: fedora-26-x86_64

--- a/test/fixtures/generated/default/fedora27-64l
+++ b/test/fixtures/generated/default/fedora27-64l
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     fedora27-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: fedora-27-x86_64
       template: fedora-27-x86_64

--- a/test/fixtures/generated/default/fedora28-64d
+++ b/test/fixtures/generated/default/fedora28-64d
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     fedora28-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: fedora-28-x86_64
       template: fedora-28-x86_64

--- a/test/fixtures/generated/default/fedora29-64d
+++ b/test/fixtures/generated/default/fedora29-64d
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     fedora29-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: fedora-29-x86_64
       template: fedora-29-x86_64

--- a/test/fixtures/generated/default/fedora30-64aulcdfm
+++ b/test/fixtures/generated/default/fedora30-64aulcdfm
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     fedora30-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: fedora-30-x86_64
       hypervisor: vmpooler
       template: fedora-30-x86_64

--- a/test/fixtures/generated/default/fedora31-64aulcdfm
+++ b/test/fixtures/generated/default/fedora31-64aulcdfm
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     fedora31-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: fedora-31-x86_64
       template: fedora-31-x86_64
       hypervisor: vmpooler

--- a/test/fixtures/generated/default/fedora32-64a
+++ b/test/fixtures/generated/default/fedora32-64a
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     fedora32-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: fedora-32-x86_64
       template: fedora-32-x86_64
       hypervisor: vmpooler

--- a/test/fixtures/generated/default/fedora32-64aulcdfm-vagrant
+++ b/test/fixtures/generated/default/fedora32-64aulcdfm-vagrant
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     fedora32-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       box: fedora/32-cloud-base
       synced_folder: disabled
       platform: fedora-32-x86_64

--- a/test/fixtures/generated/default/fedora34-64c
+++ b/test/fixtures/generated/default/fedora34-64c
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     fedora34-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: fedora-34-x86_64
       hypervisor: vmpooler
       template: fedora-34-x86_64

--- a/test/fixtures/generated/default/huaweios6-POWERaulcdfm
+++ b/test/fixtures/generated/default/huaweios6-POWERaulcdfm
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     huaweios6-POWER-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: huaweios-6-powerpc
       roles:

--- a/test/fixtures/generated/default/opensuse11-32a
+++ b/test/fixtures/generated/default/opensuse11-32a
@@ -4,17 +4,13 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     opensuse11-32-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
-      hypervisor: vmpooler
       platform: opensuse-11-i386
       template: opensuse-11-i386
+      hypervisor: vmpooler
       roles:
       - agent
   CONFIG:
     nfs_server: none
     consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
-expected_exception: 
+expected_exception:

--- a/test/fixtures/generated/default/opensuse11-64u
+++ b/test/fixtures/generated/default/opensuse11-64u
@@ -4,13 +4,9 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     opensuse11-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
-      hypervisor: vmpooler
       platform: opensuse-11-x86_64
       template: opensuse-11-x86_64
+      hypervisor: vmpooler
       roles:
       - agent
       - ca
@@ -18,4 +14,4 @@ expected_hash:
     nfs_server: none
     consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
-expected_exception: 
+expected_exception:

--- a/test/fixtures/generated/default/oracle5-32l
+++ b/test/fixtures/generated/default/oracle5-32l
@@ -4,13 +4,8 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     oracle5-32-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: el-5-i386
-      packaging_platform: el-5-i386
       template: oracle-5-i386
       roles:
       - agent

--- a/test/fixtures/generated/default/oracle5-64c
+++ b/test/fixtures/generated/default/oracle5-64c
@@ -4,13 +4,8 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     oracle5-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: el-5-x86_64
-      packaging_platform: el-5-x86_64
       template: oracle-5-x86_64
       roles:
       - agent

--- a/test/fixtures/generated/default/oracle6-32d
+++ b/test/fixtures/generated/default/oracle6-32d
@@ -4,13 +4,8 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     oracle6-32-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: el-6-i386
-      packaging_platform: el-6-i386
       template: oracle-6-i386
       roles:
       - agent

--- a/test/fixtures/generated/default/oracle6-64f
+++ b/test/fixtures/generated/default/oracle6-64f
@@ -4,13 +4,8 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     oracle6-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: el-6-x86_64
-      packaging_platform: el-6-x86_64
       template: oracle-6-x86_64
       roles:
       - agent

--- a/test/fixtures/generated/default/oracle7-64m
+++ b/test/fixtures/generated/default/oracle7-64m
@@ -4,13 +4,8 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     oracle7-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: el-7-x86_64
-      packaging_platform: el-7-x86_64
       template: oracle-7-x86_64
       roles:
       - agent

--- a/test/fixtures/generated/default/osx1010-64a
+++ b/test/fixtures/generated/default/osx1010-64a
@@ -4,13 +4,8 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     osx1010-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: osx-10.10-x86_64
-      packaging_platform: osx-10.10-x86_64
       template: osx-1010-x86_64
       roles:
       - agent

--- a/test/fixtures/generated/default/osx1011-64u
+++ b/test/fixtures/generated/default/osx1011-64u
@@ -4,13 +4,8 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     osx1011-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: osx-10.11-x86_64
-      packaging_platform: osx-10.11-x86_64
       template: osx-1011-x86_64
       roles:
       - agent

--- a/test/fixtures/generated/default/osx1012-64l
+++ b/test/fixtures/generated/default/osx1012-64l
@@ -4,13 +4,8 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     osx1012-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: osx-10.12-x86_64
-      packaging_platform: osx-10.12-x86_64
       template: osx-1012-x86_64
       roles:
       - agent

--- a/test/fixtures/generated/default/osx1013-64f
+++ b/test/fixtures/generated/default/osx1013-64f
@@ -4,12 +4,7 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     osx1013-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: osx-10.13-x86_64
-      packaging_platform: osx-10.13-x86_64
       template: osx-1013-x86_64
       hypervisor: vmpooler
       roles:

--- a/test/fixtures/generated/default/osx1014-64f
+++ b/test/fixtures/generated/default/osx1014-64f
@@ -4,13 +4,8 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     osx1014-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: osx-10.14-x86_64
-      packaging_platform: osx-10.14-x86_64
       template: osx-1014-x86_64
       roles:
       - agent

--- a/test/fixtures/generated/default/osx1015-64u
+++ b/test/fixtures/generated/default/osx1015-64u
@@ -4,12 +4,7 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     osx1015-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: osx-10.15-x86_64
-      packaging_platform: osx-10.15-x86_64
       template: osx-1015-x86_64
       hypervisor: vmpooler
       roles:
@@ -19,4 +14,4 @@ expected_hash:
     nfs_server: none
     consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
-expected_exception: 
+expected_exception:

--- a/test/fixtures/generated/default/osx109-64aulcdfm
+++ b/test/fixtures/generated/default/osx109-64aulcdfm
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     osx109-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: osx-10.9-x86_64
       template: osx-109-x86_64

--- a/test/fixtures/generated/default/osx11-64f
+++ b/test/fixtures/generated/default/osx11-64f
@@ -4,12 +4,7 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     osx11-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: osx-11-x86_64
-      packaging_platform: osx-11-x86_64
       template: macos-112-x86_64
       hypervisor: vmpooler
       roles:

--- a/test/fixtures/generated/default/panos61-64f
+++ b/test/fixtures/generated/default/panos61-64f
@@ -4,13 +4,9 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     panos61-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
-      hypervisor: vmpooler
       platform: palo-alto-6.1.0-x86_64
       template: palo-alto-6.1.0-x86_64
+      hypervisor: vmpooler
       roles:
       - agent
       - frictionless
@@ -18,4 +14,4 @@ expected_hash:
     nfs_server: none
     consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
-expected_exception: 
+expected_exception:

--- a/test/fixtures/generated/default/panos71-64m
+++ b/test/fixtures/generated/default/panos71-64m
@@ -4,13 +4,9 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     panos71-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
-      hypervisor: vmpooler
       platform: palo-alto-7.1.0-x86_64
       template: palo-alto-7.1.0-x86_64
+      hypervisor: vmpooler
       roles:
       - agent
       - master
@@ -18,4 +14,4 @@ expected_hash:
     nfs_server: none
     consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
-expected_exception: 
+expected_exception:

--- a/test/fixtures/generated/default/panos81-64aulcdfm
+++ b/test/fixtures/generated/default/panos81-64aulcdfm
@@ -4,13 +4,9 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     panos81-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
-      hypervisor: vmpooler
       platform: palo-alto-8.1.0-x86_64
       template: palo-alto-8.1.0-x86_64
+      hypervisor: vmpooler
       roles:
       - agent
       - ca
@@ -23,4 +19,4 @@ expected_hash:
     nfs_server: none
     consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
-expected_exception: 
+expected_exception:

--- a/test/fixtures/generated/default/redhat4-32c
+++ b/test/fixtures/generated/default/redhat4-32c
@@ -4,13 +4,9 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     redhat4-32-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
-      hypervisor: vmpooler
       platform: el-4-i386
       template: redhat-4-i386
+      hypervisor: vmpooler
       roles:
       - agent
       - dashboard
@@ -18,4 +14,4 @@ expected_hash:
     nfs_server: none
     consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
-expected_exception: 
+expected_exception:

--- a/test/fixtures/generated/default/redhat4-64d
+++ b/test/fixtures/generated/default/redhat4-64d
@@ -4,13 +4,9 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     redhat4-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
-      hypervisor: vmpooler
       platform: el-4-x86_64
       template: redhat-4-x86_64
+      hypervisor: vmpooler
       roles:
       - agent
       - database
@@ -18,4 +14,4 @@ expected_hash:
     nfs_server: none
     consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
-expected_exception: 
+expected_exception:

--- a/test/fixtures/generated/default/redhat5-32f
+++ b/test/fixtures/generated/default/redhat5-32f
@@ -4,14 +4,9 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     redhat5-32-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
-      hypervisor: vmpooler
       platform: el-5-i386
-      packaging_platform: el-5-i386
       template: redhat-5-i386
+      hypervisor: vmpooler
       roles:
       - agent
       - frictionless
@@ -19,4 +14,4 @@ expected_hash:
     nfs_server: none
     consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
-expected_exception: 
+expected_exception:

--- a/test/fixtures/generated/default/redhat5-64m
+++ b/test/fixtures/generated/default/redhat5-64m
@@ -4,14 +4,9 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     redhat5-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
-      hypervisor: vmpooler
       platform: el-5-x86_64
-      packaging_platform: el-5-x86_64
       template: redhat-5-x86_64
+      hypervisor: vmpooler
       roles:
       - agent
       - master
@@ -19,4 +14,4 @@ expected_hash:
     nfs_server: none
     consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
-expected_exception: 
+expected_exception:

--- a/test/fixtures/generated/default/redhat6-32aulcdfm
+++ b/test/fixtures/generated/default/redhat6-32aulcdfm
@@ -4,14 +4,9 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     redhat6-32-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
-      hypervisor: vmpooler
       platform: el-6-i386
-      packaging_platform: el-6-i386
       template: redhat-6-i386
+      hypervisor: vmpooler
       roles:
       - agent
       - ca
@@ -24,4 +19,4 @@ expected_hash:
     nfs_server: none
     consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
-expected_exception: 
+expected_exception:

--- a/test/fixtures/generated/default/redhat6-64a
+++ b/test/fixtures/generated/default/redhat6-64a
@@ -4,18 +4,13 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     redhat6-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
-      hypervisor: vmpooler
       platform: el-6-x86_64
-      packaging_platform: el-6-x86_64
       template: redhat-6-x86_64
+      hypervisor: vmpooler
       roles:
       - agent
   CONFIG:
     nfs_server: none
     consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
-expected_exception: 
+expected_exception:

--- a/test/fixtures/generated/default/redhat7-64l
+++ b/test/fixtures/generated/default/redhat7-64l
@@ -4,14 +4,9 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     redhat7-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
-      hypervisor: vmpooler
       platform: el-7-x86_64
-      packaging_platform: el-7-x86_64
       template: redhat-7-x86_64
+      hypervisor: vmpooler
       roles:
       - agent
       - classifier
@@ -19,4 +14,4 @@ expected_hash:
     nfs_server: none
     consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
-expected_exception: 
+expected_exception:

--- a/test/fixtures/generated/default/redhat7-AARCH64a
+++ b/test/fixtures/generated/default/redhat7-AARCH64a
@@ -4,13 +4,8 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     redhat7-AARCH64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: el-7-aarch64
-      packaging_platform: el-7-aarch64
       template: redhat-7-x86_64
       roles:
       - agent

--- a/test/fixtures/generated/default/redhat7-AARCH64aulcdfm
+++ b/test/fixtures/generated/default/redhat7-AARCH64aulcdfm
@@ -4,13 +4,8 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     redhat7-AARCH64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: el-7-aarch64
-      packaging_platform: el-7-aarch64
       template: redhat-7-x86_64
       roles:
       - agent

--- a/test/fixtures/generated/default/redhat7-POWERc
+++ b/test/fixtures/generated/default/redhat7-POWERc
@@ -4,12 +4,7 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     redhat7-POWER-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: el-7-ppc64le
-      packaging_platform: el-7-ppc64le
       hypervisor: vmpooler
       template: redhat-7-ppc64le
       roles:

--- a/test/fixtures/generated/default/redhat7-S390Xd
+++ b/test/fixtures/generated/default/redhat7-S390Xd
@@ -4,12 +4,7 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     redhat7-S390X-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: el-7-s390x
-      packaging_platform: el-7-s390x
       hypervisor: vmpooler
       template: redhat-7-s390x
       roles:

--- a/test/fixtures/generated/default/redhat8-64u
+++ b/test/fixtures/generated/default/redhat8-64u
@@ -4,13 +4,8 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     redhat8-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: el-8-x86_64
-      packaging_platform: el-8-x86_64
       template: redhat-8-x86_64
       roles:
       - agent

--- a/test/fixtures/generated/default/redhat8-AARCH64a
+++ b/test/fixtures/generated/default/redhat8-AARCH64a
@@ -4,12 +4,7 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     redhat8-AARCH64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: el-8-aarch64
-      packaging_platform: el-8-aarch64
       template: redhat-8-x86_64
       hypervisor: vmpooler
       roles:

--- a/test/fixtures/generated/default/redhat9-64l
+++ b/test/fixtures/generated/default/redhat9-64l
@@ -4,12 +4,7 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     redhat9-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: el-9-x86_64
-      packaging_platform: el-9-x86_64
       template: redhat-9-x86_64
       hypervisor: vmpooler
       roles:

--- a/test/fixtures/generated/default/redhatfips7-64aulcdfm
+++ b/test/fixtures/generated/default/redhatfips7-64aulcdfm
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     redhatfips7-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: el-7-x86_64
       packaging_platform: redhatfips-7-x86_64

--- a/test/fixtures/generated/default/redhatfips8-64m
+++ b/test/fixtures/generated/default/redhatfips8-64m
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     redhatfips8-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: el-8-x86_64
       packaging_platform: redhatfips-8-x86_64
       template: redhat-fips-8-x86_64

--- a/test/fixtures/generated/default/rocky8-64l
+++ b/test/fixtures/generated/default/rocky8-64l
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     rocky8-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: el-8-x86_64
       hypervisor: vmpooler
       template: rocky-8-x86_64

--- a/test/fixtures/generated/default/scientific5-32f
+++ b/test/fixtures/generated/default/scientific5-32f
@@ -4,14 +4,9 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     scientific5-32-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
-      hypervisor: vmpooler
       platform: el-5-i386
-      packaging_platform: el-5-i386
       template: scientific-5-i386
+      hypervisor: vmpooler
       roles:
       - agent
       - frictionless
@@ -19,4 +14,4 @@ expected_hash:
     nfs_server: none
     consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
-expected_exception: 
+expected_exception:

--- a/test/fixtures/generated/default/scientific5-64m
+++ b/test/fixtures/generated/default/scientific5-64m
@@ -4,14 +4,9 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     scientific5-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
-      hypervisor: vmpooler
       platform: el-5-x86_64
-      packaging_platform: el-5-x86_64
       template: scientific-5-x86_64
+      hypervisor: vmpooler
       roles:
       - agent
       - master
@@ -19,4 +14,4 @@ expected_hash:
     nfs_server: none
     consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
-expected_exception: 
+expected_exception:

--- a/test/fixtures/generated/default/scientific6-32aulcdfm
+++ b/test/fixtures/generated/default/scientific6-32aulcdfm
@@ -4,14 +4,9 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     scientific6-32-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
-      hypervisor: vmpooler
       platform: el-6-i386
-      packaging_platform: el-6-i386
       template: scientific-6-i386
+      hypervisor: vmpooler
       roles:
       - agent
       - ca
@@ -24,4 +19,4 @@ expected_hash:
     nfs_server: none
     consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
-expected_exception: 
+expected_exception:

--- a/test/fixtures/generated/default/scientific6-64a
+++ b/test/fixtures/generated/default/scientific6-64a
@@ -4,18 +4,13 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     scientific6-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
-      hypervisor: vmpooler
       platform: el-6-x86_64
-      packaging_platform: el-6-x86_64
       template: scientific-6-x86_64
+      hypervisor: vmpooler
       roles:
       - agent
   CONFIG:
     nfs_server: none
     consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
-expected_exception: 
+expected_exception:

--- a/test/fixtures/generated/default/scientific7-64u
+++ b/test/fixtures/generated/default/scientific7-64u
@@ -4,14 +4,9 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     scientific7-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
-      hypervisor: vmpooler
       platform: el-7-x86_64
-      packaging_platform: el-7-x86_64
       template: scientific-7-x86_64
+      hypervisor: vmpooler
       roles:
       - agent
       - ca
@@ -19,4 +14,4 @@ expected_hash:
     nfs_server: none
     consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
-expected_exception: 
+expected_exception:

--- a/test/fixtures/generated/default/sles10-32l
+++ b/test/fixtures/generated/default/sles10-32l
@@ -4,13 +4,9 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     sles10-32-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
-      hypervisor: vmpooler
       platform: sles-10-i386
       template: sles-10-i386
+      hypervisor: vmpooler
       roles:
       - agent
       - classifier
@@ -18,4 +14,4 @@ expected_hash:
     nfs_server: none
     consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
-expected_exception: 
+expected_exception:

--- a/test/fixtures/generated/default/sles10-64c
+++ b/test/fixtures/generated/default/sles10-64c
@@ -4,13 +4,9 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     sles10-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
-      hypervisor: vmpooler
       platform: sles-10-x86_64
       template: sles-10-x86_64
+      hypervisor: vmpooler
       roles:
       - agent
       - dashboard
@@ -18,4 +14,4 @@ expected_hash:
     nfs_server: none
     consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
-expected_exception: 
+expected_exception:

--- a/test/fixtures/generated/default/sles11-32d
+++ b/test/fixtures/generated/default/sles11-32d
@@ -4,14 +4,9 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     sles11-32-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
-      hypervisor: vmpooler
       platform: sles-11-i386
-      packaging_platform: sles-11-i386
       template: sles-11-i386
+      hypervisor: vmpooler
       roles:
       - agent
       - database
@@ -19,4 +14,4 @@ expected_hash:
     nfs_server: none
     consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
-expected_exception: 
+expected_exception:

--- a/test/fixtures/generated/default/sles11-64f
+++ b/test/fixtures/generated/default/sles11-64f
@@ -4,14 +4,9 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     sles11-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
-      hypervisor: vmpooler
       platform: sles-11-x86_64
-      packaging_platform: sles-11-x86_64
       template: sles-11-x86_64
+      hypervisor: vmpooler
       roles:
       - agent
       - frictionless
@@ -19,4 +14,4 @@ expected_hash:
     nfs_server: none
     consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
-expected_exception: 
+expected_exception:

--- a/test/fixtures/generated/default/sles11-S390Xm
+++ b/test/fixtures/generated/default/sles11-S390Xm
@@ -4,13 +4,8 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     sles11-S390X-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
-      hypervisor: vmpooler
       platform: sles-11-s390x
-      packaging_platform: sles-11-s390x
+      hypervisor: vmpooler
       roles:
       - agent
       - master
@@ -18,4 +13,4 @@ expected_hash:
     nfs_server: none
     consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
-expected_exception: 
+expected_exception:

--- a/test/fixtures/generated/default/sles12-64aulcdfm
+++ b/test/fixtures/generated/default/sles12-64aulcdfm
@@ -4,14 +4,9 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     sles12-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
-      hypervisor: vmpooler
       platform: sles-12-x86_64
-      packaging_platform: sles-12-x86_64
       template: sles-12-x86_64
+      hypervisor: vmpooler
       roles:
       - agent
       - ca
@@ -24,4 +19,4 @@ expected_hash:
     nfs_server: none
     consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
-expected_exception: 
+expected_exception:

--- a/test/fixtures/generated/default/sles12-POWERu
+++ b/test/fixtures/generated/default/sles12-POWERu
@@ -4,13 +4,8 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     sles12-POWER-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
-      hypervisor: vmpooler
       platform: sles-12-ppc64le
-      packaging_platform: sles-12-ppc64le
+      hypervisor: vmpooler
       roles:
       - agent
       - ca
@@ -18,4 +13,4 @@ expected_hash:
     nfs_server: none
     consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
-expected_exception: 
+expected_exception:

--- a/test/fixtures/generated/default/sles12-S390Xa
+++ b/test/fixtures/generated/default/sles12-S390Xa
@@ -4,17 +4,12 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     sles12-S390X-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
-      hypervisor: vmpooler
       platform: sles-12-s390x
-      packaging_platform: sles-12-s390x
+      hypervisor: vmpooler
       roles:
       - agent
   CONFIG:
     nfs_server: none
     consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
-expected_exception: 
+expected_exception:

--- a/test/fixtures/generated/default/sles15-64l
+++ b/test/fixtures/generated/default/sles15-64l
@@ -4,14 +4,9 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     sles15-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
-      hypervisor: vmpooler
       platform: sles-15-x86_64
-      packaging_platform: sles-15-x86_64
       template: sles-15-x86_64
+      hypervisor: vmpooler
       roles:
       - agent
       - classifier
@@ -19,4 +14,4 @@ expected_hash:
     nfs_server: none
     consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
-expected_exception: 
+expected_exception:

--- a/test/fixtures/generated/default/solaris10-32l
+++ b/test/fixtures/generated/default/solaris10-32l
@@ -4,13 +4,8 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     solaris10-32-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: solaris-10-i386
-      packaging_platform: solaris-10-i386
       template: solaris-10-x86_64
       roles:
       - agent

--- a/test/fixtures/generated/default/solaris10-64c
+++ b/test/fixtures/generated/default/solaris10-64c
@@ -4,13 +4,8 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     solaris10-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: solaris-10-i386
-      packaging_platform: solaris-10-i386
       template: solaris-10-x86_64
       roles:
       - agent

--- a/test/fixtures/generated/default/solaris10-SPARCd
+++ b/test/fixtures/generated/default/solaris10-SPARCd
@@ -4,13 +4,8 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     solaris10-SPARC-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: solaris-10-sparc
-      packaging_platform: solaris-10-sparc
       roles:
       - agent
       - database

--- a/test/fixtures/generated/default/solaris11-32f
+++ b/test/fixtures/generated/default/solaris11-32f
@@ -4,13 +4,8 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     solaris11-32-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: solaris-11-i386
-      packaging_platform: solaris-11-i386
       template: solaris-11-x86_64
       roles:
       - agent

--- a/test/fixtures/generated/default/solaris11-64m
+++ b/test/fixtures/generated/default/solaris11-64m
@@ -4,13 +4,8 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     solaris11-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: solaris-11-i386
-      packaging_platform: solaris-11-i386
       template: solaris-11-x86_64
       roles:
       - agent

--- a/test/fixtures/generated/default/solaris11-SPARCaulcdfm
+++ b/test/fixtures/generated/default/solaris11-SPARCaulcdfm
@@ -4,13 +4,8 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     solaris11-SPARC-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: solaris-11-sparc
-      packaging_platform: solaris-11-sparc
       roles:
       - agent
       - ca

--- a/test/fixtures/generated/default/solaris112-32a
+++ b/test/fixtures/generated/default/solaris112-32a
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     solaris112-32-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: solaris-11.2-i386
       packaging_platform: solaris-11-i386

--- a/test/fixtures/generated/default/solaris112-64u
+++ b/test/fixtures/generated/default/solaris112-64u
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     solaris112-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: solaris-11.2-i386
       packaging_platform: solaris-11-i386

--- a/test/fixtures/generated/default/ubuntu1404-32d
+++ b/test/fixtures/generated/default/ubuntu1404-32d
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     ubuntu1404-32-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: ubuntu-14.04-i386
       hypervisor: vmpooler
       template: ubuntu-1404-i386

--- a/test/fixtures/generated/default/ubuntu1404-32m
+++ b/test/fixtures/generated/default/ubuntu1404-32m
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     ubuntu1404-32-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: ubuntu-14.04-i386
       template: ubuntu-1404-i386

--- a/test/fixtures/generated/default/ubuntu1404-64aulcdfm
+++ b/test/fixtures/generated/default/ubuntu1404-64aulcdfm
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     ubuntu1404-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: ubuntu-14.04-amd64
       template: ubuntu-1404-x86_64

--- a/test/fixtures/generated/default/ubuntu1404-64f
+++ b/test/fixtures/generated/default/ubuntu1404-64f
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     ubuntu1404-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: ubuntu-14.04-amd64
       hypervisor: vmpooler
       template: ubuntu-1404-x86_64

--- a/test/fixtures/generated/default/ubuntu1404-AARCH64aulcdfm
+++ b/test/fixtures/generated/default/ubuntu1404-AARCH64aulcdfm
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     ubuntu1404-AARCH64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: ubuntu-14.04-aarch64
       hypervisor: vmpooler
       roles:

--- a/test/fixtures/generated/default/ubuntu1404-POWERm
+++ b/test/fixtures/generated/default/ubuntu1404-POWERm
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     ubuntu1404-POWER-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: ubuntu-14.04-ppc64el
       hypervisor: vmpooler
       roles:

--- a/test/fixtures/generated/default/ubuntu1604-32a
+++ b/test/fixtures/generated/default/ubuntu1604-32a
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     ubuntu1604-32-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: ubuntu-16.04-i386
       hypervisor: vmpooler
       template: ubuntu-1604-i386

--- a/test/fixtures/generated/default/ubuntu1604-32d
+++ b/test/fixtures/generated/default/ubuntu1604-32d
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     ubuntu1604-32-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: ubuntu-16.04-i386
       template: ubuntu-1604-i386

--- a/test/fixtures/generated/default/ubuntu1604-64f
+++ b/test/fixtures/generated/default/ubuntu1604-64f
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     ubuntu1604-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: ubuntu-16.04-amd64
       template: ubuntu-1604-x86_64

--- a/test/fixtures/generated/default/ubuntu1604-64u
+++ b/test/fixtures/generated/default/ubuntu1604-64u
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     ubuntu1604-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: ubuntu-16.04-amd64
       hypervisor: vmpooler
       template: ubuntu-1604-x86_64

--- a/test/fixtures/generated/default/ubuntu1604-AARCH64c
+++ b/test/fixtures/generated/default/ubuntu1604-AARCH64c
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     ubuntu1604-AARCH64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: ubuntu-16.04-aarch64
       hypervisor: vmpooler
       roles:

--- a/test/fixtures/generated/default/ubuntu1604-POWERl
+++ b/test/fixtures/generated/default/ubuntu1604-POWERl
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     ubuntu1604-POWER-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: ubuntu-16.04-ppc64el
       hypervisor: vmpooler
       roles:

--- a/test/fixtures/generated/default/ubuntu1604-POWERm
+++ b/test/fixtures/generated/default/ubuntu1604-POWERm
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     ubuntu1604-POWER-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: ubuntu-16.04-ppc64el
       roles:

--- a/test/fixtures/generated/default/ubuntu1804-64a
+++ b/test/fixtures/generated/default/ubuntu1804-64a
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     ubuntu1804-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: ubuntu-18.04-amd64
       template: ubuntu-1804-x86_64

--- a/test/fixtures/generated/default/ubuntu1804-64d
+++ b/test/fixtures/generated/default/ubuntu1804-64d
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     ubuntu1804-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: ubuntu-18.04-amd64
       hypervisor: vmpooler
       template: ubuntu-1804-x86_64

--- a/test/fixtures/generated/default/ubuntu1804-AARCH64m
+++ b/test/fixtures/generated/default/ubuntu1804-AARCH64m
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     ubuntu1804-AARCH64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: ubuntu-18.04-aarch64
       hypervisor: vmpooler
       roles:

--- a/test/fixtures/generated/default/ubuntu1804-POWERf
+++ b/test/fixtures/generated/default/ubuntu1804-POWERf
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     ubuntu1804-POWER-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: ubuntu-18.04-ppc64el
       hypervisor: vmpooler
       roles:

--- a/test/fixtures/generated/default/ubuntu2004-64a
+++ b/test/fixtures/generated/default/ubuntu2004-64a
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     ubuntu2004-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: ubuntu-20.04-amd64
       template: ubuntu-2004-x86_64
       hypervisor: vmpooler

--- a/test/fixtures/generated/default/ubuntu2004-64aulcdfm
+++ b/test/fixtures/generated/default/ubuntu2004-64aulcdfm
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     ubuntu2004-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: ubuntu-20.04-amd64
       hypervisor: vmpooler
       template: ubuntu-2004-x86_64

--- a/test/fixtures/generated/default/ubuntu2004-AARCH64c
+++ b/test/fixtures/generated/default/ubuntu2004-AARCH64c
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     ubuntu2004-AARCH64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: ubuntu-20.04-aarch64
       hypervisor: vmpooler
       roles:

--- a/test/fixtures/generated/default/ubuntu2004-AARCH64u
+++ b/test/fixtures/generated/default/ubuntu2004-AARCH64u
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     ubuntu2004-AARCH64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: ubuntu-20.04-aarch64
       hypervisor: vmpooler
       roles:

--- a/test/fixtures/generated/default/ubuntu2004-POWERa
+++ b/test/fixtures/generated/default/ubuntu2004-POWERa
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     ubuntu2004-POWER-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: ubuntu-20.04-ppc64el
       hypervisor: vmpooler
       roles:

--- a/test/fixtures/generated/default/ubuntu2010-64l
+++ b/test/fixtures/generated/default/ubuntu2010-64l
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     ubuntu2010-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: ubuntu-20.10-amd64
       hypervisor: vmpooler
       template: ubuntu-2010-x86_64

--- a/test/fixtures/generated/default/ubuntu2104-64c
+++ b/test/fixtures/generated/default/ubuntu2104-64c
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     ubuntu2104-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: ubuntu-21.04-amd64
       hypervisor: vmpooler
       template: ubuntu-2104-x86_64

--- a/test/fixtures/generated/default/ubuntu2110-64d
+++ b/test/fixtures/generated/default/ubuntu2110-64d
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     ubuntu2110-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: ubuntu-21.10-amd64
       hypervisor: vmpooler
       template: ubuntu-2110-x86_64

--- a/test/fixtures/generated/default/vro6-64u
+++ b/test/fixtures/generated/default/vro6-64u
@@ -4,12 +4,7 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     vro6-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: sles-11-x86_64
-      packaging_platform: sles-11-x86_64
       template: vro-6-x86_64
       hypervisor: vmpooler
       roles:

--- a/test/fixtures/generated/default/vro7-64l
+++ b/test/fixtures/generated/default/vro7-64l
@@ -4,12 +4,7 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     vro7-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: sles-11-x86_64
-      packaging_platform: sles-11-x86_64
       template: vro-7-x86_64
       hypervisor: vmpooler
       roles:

--- a/test/fixtures/generated/default/vro71-64d
+++ b/test/fixtures/generated/default/vro71-64d
@@ -4,13 +4,8 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     vro71-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: sles-11-x86_64
-      packaging_platform: sles-11-x86_64
       template: vro-71-x86_64
       roles:
       - agent

--- a/test/fixtures/generated/default/vro73-64l
+++ b/test/fixtures/generated/default/vro73-64l
@@ -4,13 +4,8 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     vro73-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: sles-11-x86_64
-      packaging_platform: sles-11-x86_64
       template: vro-73-x86_64
       roles:
       - agent

--- a/test/fixtures/generated/default/vro74-64m
+++ b/test/fixtures/generated/default/vro74-64m
@@ -4,13 +4,8 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     vro74-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: sles-11-x86_64
-      packaging_platform: sles-11-x86_64
       template: vro-74-x86_64
       roles:
       - agent

--- a/test/fixtures/generated/default/windows10_1511-64a
+++ b/test/fixtures/generated/default/windows10_1511-64a
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     windows10_1511-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-10ent-64
       packaging_platform: windows-2012-x64

--- a/test/fixtures/generated/default/windows10_1607-64a
+++ b/test/fixtures/generated/default/windows10_1607-64a
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     windows10_1607-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: windows-10ent-64
       packaging_platform: windows-2012-x64
       ruby_arch: x64

--- a/test/fixtures/generated/default/windows10_1809-64a
+++ b/test/fixtures/generated/default/windows10_1809-64a
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     windows10_1809-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: windows-10ent-64
       packaging_platform: windows-2012-x64
       ruby_arch: x64

--- a/test/fixtures/generated/default/windows10ent-32u
+++ b/test/fixtures/generated/default/windows10ent-32u
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     windows10ent-32-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: windows-10ent-32
       packaging_platform: windows-2012-x86
       ruby_arch: x86

--- a/test/fixtures/generated/default/windows10ent-64l
+++ b/test/fixtures/generated/default/windows10ent-64l
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     windows10ent-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: windows-10ent-64
       packaging_platform: windows-2012-x64
       ruby_arch: x64

--- a/test/fixtures/generated/default/windows10next-32a
+++ b/test/fixtures/generated/default/windows10next-32a
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     windows10next-32-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-10ent-32
       packaging_platform: windows-2012-x86

--- a/test/fixtures/generated/default/windows10next-64a
+++ b/test/fixtures/generated/default/windows10next-64a
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     windows10next-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-10ent-64
       packaging_platform: windows-2012-x64

--- a/test/fixtures/generated/default/windows10pro-64c
+++ b/test/fixtures/generated/default/windows10pro-64c
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     windows10pro-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: windows-10pro-64
       packaging_platform: windows-2012-x64
       ruby_arch: x64

--- a/test/fixtures/generated/default/windows2008-6432u
+++ b/test/fixtures/generated/default/windows2008-6432u
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     windows2008-6432-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: windows-2008-64
       packaging_platform: windows-2012-x64
       ruby_arch: x86

--- a/test/fixtures/generated/default/windows2008-64a
+++ b/test/fixtures/generated/default/windows2008-64a
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     windows2008-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: windows-2008-64
       packaging_platform: windows-2012-x64
       ruby_arch: x64

--- a/test/fixtures/generated/default/windows2008r2-6432c
+++ b/test/fixtures/generated/default/windows2008r2-6432c
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     windows2008r2-6432-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: windows-2008r2-64
       packaging_platform: windows-2012-x64
       ruby_arch: x86

--- a/test/fixtures/generated/default/windows2008r2-64l
+++ b/test/fixtures/generated/default/windows2008r2-64l
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     windows2008r2-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: windows-2008r2-64
       packaging_platform: windows-2012-x64
       ruby_arch: x64

--- a/test/fixtures/generated/default/windows2012-6432f
+++ b/test/fixtures/generated/default/windows2012-6432f
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     windows2012-6432-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: windows-2012-64
       packaging_platform: windows-2012-x64
       ruby_arch: x86

--- a/test/fixtures/generated/default/windows2012-64d
+++ b/test/fixtures/generated/default/windows2012-64d
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     windows2012-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: windows-2012-64
       packaging_platform: windows-2012-x64
       ruby_arch: x64

--- a/test/fixtures/generated/default/windows2012r2-6432aulcdfm
+++ b/test/fixtures/generated/default/windows2012r2-6432aulcdfm
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     windows2012r2-6432-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: windows-2012r2-64
       packaging_platform: windows-2012-x64
       ruby_arch: x86

--- a/test/fixtures/generated/default/windows2012r2-64m
+++ b/test/fixtures/generated/default/windows2012r2-64m
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     windows2012r2-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: windows-2012r2-64
       packaging_platform: windows-2012-x64
       ruby_arch: x64

--- a/test/fixtures/generated/default/windows2012r2_ja-6432l
+++ b/test/fixtures/generated/default/windows2012r2_ja-6432l
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     windows2012r2_ja-6432-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: windows-2012r2-64
       packaging_platform: windows-2012-x64
       ruby_arch: x86

--- a/test/fixtures/generated/default/windows2012r2_ja-64u
+++ b/test/fixtures/generated/default/windows2012r2_ja-64u
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     windows2012r2_ja-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: windows-2012r2-64
       packaging_platform: windows-2012-x64
       ruby_arch: x64

--- a/test/fixtures/generated/default/windows2012r2_wmf5-64a
+++ b/test/fixtures/generated/default/windows2012r2_wmf5-64a
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     windows2012r2_wmf5-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: windows-2012r2-64
       packaging_platform: windows-2012-x64
       ruby_arch: x64

--- a/test/fixtures/generated/default/windows2016-6432d
+++ b/test/fixtures/generated/default/windows2016-6432d
@@ -4,15 +4,11 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     windows2016-6432-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
-      hypervisor: vmpooler
       platform: windows-2016-64
       packaging_platform: windows-2012-x64
       ruby_arch: x86
       template: win-2016-x86_64
+      hypervisor: vmpooler
       roles:
       - agent
       - database
@@ -20,4 +16,4 @@ expected_hash:
     nfs_server: none
     consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
-expected_exception: 
+expected_exception:

--- a/test/fixtures/generated/default/windows2016-64c
+++ b/test/fixtures/generated/default/windows2016-64c
@@ -4,15 +4,11 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     windows2016-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
-      hypervisor: vmpooler
       platform: windows-2016-64
       packaging_platform: windows-2012-x64
       ruby_arch: x64
       template: win-2016-x86_64
+      hypervisor: vmpooler
       roles:
       - agent
       - dashboard
@@ -20,4 +16,4 @@ expected_hash:
     nfs_server: none
     consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
-expected_exception: 
+expected_exception:

--- a/test/fixtures/generated/default/windows2016_fr-6432f
+++ b/test/fixtures/generated/default/windows2016_fr-6432f
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     windows2016_fr-6432-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: windows-2016-64
       packaging_platform: windows-2012-x64
       ruby_arch: x86

--- a/test/fixtures/generated/default/windows2016_fr-64d
+++ b/test/fixtures/generated/default/windows2016_fr-64d
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     windows2016_fr-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: windows-2016-64
       packaging_platform: windows-2012-x64
       ruby_arch: x64

--- a/test/fixtures/generated/default/windows2019_fr-6432f
+++ b/test/fixtures/generated/default/windows2019_fr-6432f
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     windows2019_fr-6432-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       hypervisor: vmpooler
       platform: windows-2019-64
       packaging_platform: windows-2012-x64

--- a/test/fixtures/generated/default/windows2019_fr-64c
+++ b/test/fixtures/generated/default/windows2019_fr-64c
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     windows2019_fr-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: windows-2019-64
       packaging_platform: windows-2012-x64
       ruby_arch: x64

--- a/test/fixtures/generated/default/windows2019_ja-6432f
+++ b/test/fixtures/generated/default/windows2019_ja-6432f
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     windows2019_ja-6432-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-2019-64
       packaging_platform: windows-2012-x64

--- a/test/fixtures/generated/default/windows2019_ja-64c
+++ b/test/fixtures/generated/default/windows2019_ja-64c
@@ -4,16 +4,12 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     windows2019_ja-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
-      hypervisor: vmpooler
       platform: windows-2019-64
       packaging_platform: windows-2012-x64
       ruby_arch: x64
       template: win-2019-ja-x86_64
       locale: ja
+      hypervisor: vmpooler
       roles:
       - agent
       - dashboard
@@ -21,4 +17,4 @@ expected_hash:
     nfs_server: none
     consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
-expected_exception: 
+expected_exception:

--- a/test/fixtures/generated/default/windows2022-64aulcdfm
+++ b/test/fixtures/generated/default/windows2022-64aulcdfm
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     windows2022-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: windows-2022-64
       packaging_platform: windows-2012-x64
       ruby_arch: x64

--- a/test/fixtures/generated/default/windows7-64f
+++ b/test/fixtures/generated/default/windows7-64f
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     windows7-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: windows-7-64
       packaging_platform: windows-2012-x64
       ruby_arch: x64

--- a/test/fixtures/generated/default/windows81-64aulcdfm
+++ b/test/fixtures/generated/default/windows81-64aulcdfm
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     windows81-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-8.1-64
       packaging_platform: windows-2012-x64

--- a/test/fixtures/generated/default/windows81-64m
+++ b/test/fixtures/generated/default/windows81-64m
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     windows81-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: windows-8.1-64
       packaging_platform: windows-2012-x64
       ruby_arch: x64

--- a/test/fixtures/generated/default/windowsfips2012r2-6432f
+++ b/test/fixtures/generated/default/windowsfips2012r2-6432f
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     windowsfips2012r2-6432-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: windows-2012r2-64
       packaging_platform: windowsfips-2012-x64
       ruby_arch: x64

--- a/test/fixtures/generated/default/windowsfips2012r2-64d
+++ b/test/fixtures/generated/default/windowsfips2012r2-64d
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     windowsfips2012r2-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: windows-2012r2-64
       packaging_platform: windowsfips-2012-x64
       ruby_arch: x64

--- a/test/fixtures/generated/environment_variable_tests/pe_version_and_pe_family/centos6-32a
+++ b/test/fixtures/generated/environment_variable_tests/pe_version_and_pe_family/centos6-32a
@@ -13,7 +13,6 @@ expected_hash:
       pe_upgrade_dir: https://artifactory.delivery.puppetlabs.net/artifactory/generic_enterprise__local/archives/releases/6.6.6/
       pe_upgrade_ver: 6.6.6
       platform: el-6-i386
-      packaging_platform: el-6-i386
       hypervisor: vmpooler
       template: centos-6-i386
       roles:

--- a/test/fixtures/generated/environment_variable_tests/pe_version_and_pe_family_no_upgrade/centos6-32a
+++ b/test/fixtures/generated/environment_variable_tests/pe_version_and_pe_family_no_upgrade/centos6-32a
@@ -8,10 +8,7 @@ expected_hash:
     centos6-32-1:
       pe_dir: https://artifactory.delivery.puppetlabs.net/artifactory/generic_enterprise__local/archives/releases/6.6.6/
       pe_ver: 6.6.6
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: el-6-i386
-      packaging_platform: el-6-i386
       hypervisor: vmpooler
       template: centos-6-i386
       roles:

--- a/test/fixtures/generated/environment_variable_tests/pe_version_and_pe_family_upgrade_only/centos6-32a
+++ b/test/fixtures/generated/environment_variable_tests/pe_version_and_pe_family_upgrade_only/centos6-32a
@@ -6,12 +6,9 @@ environment_variables:
 expected_hash:
   HOSTS:
     centos6-32-1:
-      pe_dir:
-      pe_ver:
       pe_upgrade_dir: https://artifactory.delivery.puppetlabs.net/artifactory/generic_enterprise__local/archives/releases/6.6.6/
       pe_upgrade_ver: 6.6.6
       platform: el-6-i386
-      packaging_platform: el-6-i386
       hypervisor: vmpooler
       template: centos-6-i386
       roles:

--- a/test/fixtures/generated/multiplatform/aix53-POWERa-windows10pro-64-aix53-POWERaulcdfm
+++ b/test/fixtures/generated/multiplatform/aix53-POWERa-windows10pro-64-aix53-POWERaulcdfm
@@ -4,20 +4,11 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     aix53-POWER-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: aix-5.3-power
-      packaging_platform: aix-5.3-power
       roles:
       - agent
     windows10pro-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-10pro-64
       packaging_platform: windows-2012-x64
@@ -26,13 +17,8 @@ expected_hash:
       roles:
       - agent
     aix53-POWER-2:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: aix-5.3-power
-      packaging_platform: aix-5.3-power
       roles:
       - agent
       - ca

--- a/test/fixtures/generated/multiplatform/aix61-POWERu-windows10ent-64-aix61-POWERm
+++ b/test/fixtures/generated/multiplatform/aix61-POWERu-windows10ent-64-aix61-POWERm
@@ -4,21 +4,12 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     aix61-POWER-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: aix-6.1-power
-      packaging_platform: aix-6.1-power
       roles:
       - agent
       - ca
     windows10ent-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-10ent-64
       packaging_platform: windows-2012-x64
@@ -27,13 +18,8 @@ expected_hash:
       roles:
       - agent
     aix61-POWER-2:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: aix-6.1-power
-      packaging_platform: aix-6.1-power
       roles:
       - agent
       - master

--- a/test/fixtures/generated/multiplatform/aix71-POWERl-windows10ent-32-aix71-POWERf
+++ b/test/fixtures/generated/multiplatform/aix71-POWERl-windows10ent-32-aix71-POWERf
@@ -4,21 +4,12 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     aix71-POWER-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: aix-7.1-power
-      packaging_platform: aix-7.1-power
       roles:
       - agent
       - classifier
     windows10ent-32-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-10ent-32
       packaging_platform: windows-2012-x86
@@ -27,13 +18,8 @@ expected_hash:
       roles:
       - agent
     aix71-POWER-2:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: aix-7.1-power
-      packaging_platform: aix-7.1-power
       roles:
       - agent
       - frictionless

--- a/test/fixtures/generated/multiplatform/almalinux8-64u-solaris112-32-almalinux8-64m
+++ b/test/fixtures/generated/multiplatform/almalinux8-64u-solaris112-32-almalinux8-64m
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     almalinux8-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: el-8-x86_64
       hypervisor: vmpooler
       template: almalinux-8-x86_64
@@ -15,10 +11,6 @@ expected_hash:
       - agent
       - ca
     solaris112-32-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: solaris-11.2-i386
       packaging_platform: solaris-11-i386
       template: solaris-112-x86_64
@@ -26,10 +18,6 @@ expected_hash:
       roles:
       - agent
     almalinux8-64-2:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: el-8-x86_64
       hypervisor: vmpooler
       template: almalinux-8-x86_64

--- a/test/fixtures/generated/multiplatform/amazon6-64d-windows81-64-amazon6-64c
+++ b/test/fixtures/generated/multiplatform/amazon6-64d-windows81-64-amazon6-64c
@@ -4,21 +4,12 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     amazon6-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: el-6-x86_64
-      packaging_platform: el-6-x86_64
       roles:
       - agent
       - database
     windows81-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-8.1-64
       packaging_platform: windows-2012-x64
@@ -27,13 +18,8 @@ expected_hash:
       roles:
       - agent
     amazon6-64-2:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: el-6-x86_64
-      packaging_platform: el-6-x86_64
       roles:
       - agent
       - dashboard

--- a/test/fixtures/generated/multiplatform/amazon7-ARM64m-windows7-64-amazon7-ARM64u
+++ b/test/fixtures/generated/multiplatform/amazon7-ARM64m-windows7-64-amazon7-ARM64u
@@ -4,21 +4,12 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     amazon7-ARM64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: el-7-aarch64
-      packaging_platform: el-7-aarch64
       hypervisor: vmpooler
       roles:
       - agent
       - master
     windows7-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: windows-7-64
       packaging_platform: windows-2012-x64
       ruby_arch: x64
@@ -27,12 +18,7 @@ expected_hash:
       roles:
       - agent
     amazon7-ARM64-2:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: el-7-aarch64
-      packaging_platform: el-7-aarch64
       hypervisor: vmpooler
       roles:
       - agent

--- a/test/fixtures/generated/multiplatform/arista4-32d-windows81-64-arista4-32c
+++ b/test/fixtures/generated/multiplatform/arista4-32d-windows81-64-arista4-32c
@@ -4,22 +4,13 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     arista4-32-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: eos-4-i386
-      packaging_platform: eos-4-i386
       template: arista-4-i386
       roles:
       - agent
       - database
     windows81-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-8.1-64
       packaging_platform: windows-2012-x64
@@ -28,13 +19,8 @@ expected_hash:
       roles:
       - agent
     arista4-32-2:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: eos-4-i386
-      packaging_platform: eos-4-i386
       template: arista-4-i386
       roles:
       - agent

--- a/test/fixtures/generated/multiplatform/centos4-64m-windows7-64-centos4-64u
+++ b/test/fixtures/generated/multiplatform/centos4-64m-windows7-64-centos4-64u
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     centos4-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: el-4-x86_64
       template: centos-4-x86_64
@@ -15,10 +11,6 @@ expected_hash:
       - agent
       - master
     windows7-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-7-64
       packaging_platform: windows-2012-x64
@@ -27,10 +19,6 @@ expected_hash:
       roles:
       - agent
     centos4-64-2:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: el-4-x86_64
       template: centos-4-x86_64

--- a/test/fixtures/generated/multiplatform/centos5-32aulcdfm-windows2016-6432-centos5-32a
+++ b/test/fixtures/generated/multiplatform/centos5-32aulcdfm-windows2016-6432-centos5-32a
@@ -4,13 +4,8 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     centos5-32-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: el-5-i386
-      packaging_platform: el-5-i386
       template: centos-5-i386
       roles:
       - agent
@@ -21,10 +16,6 @@ expected_hash:
       - frictionless
       - master
     windows2016-6432-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-2016-64
       packaging_platform: windows-2012-x64
@@ -33,13 +24,8 @@ expected_hash:
       roles:
       - agent
     centos5-32-2:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: el-5-i386
-      packaging_platform: el-5-i386
       template: centos-5-i386
       roles:
       - agent

--- a/test/fixtures/generated/multiplatform/centos5-64a-windows2016-64-centos5-64aulcdfm
+++ b/test/fixtures/generated/multiplatform/centos5-64a-windows2016-64-centos5-64aulcdfm
@@ -4,21 +4,12 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     centos5-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: el-5-x86_64
-      packaging_platform: el-5-x86_64
       template: centos-5-x86_64
       roles:
       - agent
     windows2016-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-2016-64
       packaging_platform: windows-2012-x64
@@ -27,13 +18,8 @@ expected_hash:
       roles:
       - agent
     centos5-64-2:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: el-5-x86_64
-      packaging_platform: el-5-x86_64
       template: centos-5-x86_64
       roles:
       - agent

--- a/test/fixtures/generated/multiplatform/centos5-64c-windows2016_fr-6432-centos5-64d
+++ b/test/fixtures/generated/multiplatform/centos5-64c-windows2016_fr-6432-centos5-64d
@@ -4,22 +4,13 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     centos5-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: el-5-x86_64
-      packaging_platform: el-5-x86_64
       template: centos-5-x86_64
       hypervisor: vmpooler
       roles:
       - agent
       - dashboard
     windows2016_fr-6432-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: windows-2016-64
       packaging_platform: windows-2012-x64
       ruby_arch: x86
@@ -30,12 +21,7 @@ expected_hash:
       roles:
       - agent
     centos5-64-2:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: el-5-x86_64
-      packaging_platform: el-5-x86_64
       template: centos-5-x86_64
       hypervisor: vmpooler
       roles:

--- a/test/fixtures/generated/multiplatform/centos6-32d-windows2016_fr-64-centos6-32c
+++ b/test/fixtures/generated/multiplatform/centos6-32d-windows2016_fr-64-centos6-32c
@@ -4,22 +4,13 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     centos6-32-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: el-6-i386
-      packaging_platform: el-6-i386
       template: centos-6-i386
       hypervisor: vmpooler
       roles:
       - agent
       - database
     windows2016_fr-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: windows-2016-64
       packaging_platform: windows-2012-x64
       ruby_arch: x64
@@ -30,12 +21,7 @@ expected_hash:
       roles:
       - agent
     centos6-32-2:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: el-6-i386
-      packaging_platform: el-6-i386
       template: centos-6-i386
       hypervisor: vmpooler
       roles:

--- a/test/fixtures/generated/multiplatform/centos6-32u-windows2012r2_ja-6432-centos6-32m
+++ b/test/fixtures/generated/multiplatform/centos6-32u-windows2012r2_ja-6432-centos6-32m
@@ -4,22 +4,13 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     centos6-32-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: el-6-i386
-      packaging_platform: el-6-i386
       template: centos-6-i386
       roles:
       - agent
       - ca
     windows2012r2_ja-6432-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-2012r2-64
       packaging_platform: windows-2012-x64
@@ -29,13 +20,8 @@ expected_hash:
       roles:
       - agent
     centos6-32-2:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: el-6-i386
-      packaging_platform: el-6-i386
       template: centos-6-i386
       roles:
       - agent

--- a/test/fixtures/generated/multiplatform/centos6-64l-windows2012r2_ja-64-centos6-64f
+++ b/test/fixtures/generated/multiplatform/centos6-64l-windows2012r2_ja-64-centos6-64f
@@ -4,22 +4,13 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     centos6-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: el-6-x86_64
-      packaging_platform: el-6-x86_64
       template: centos-6-x86_64
       roles:
       - agent
       - classifier
     windows2012r2_ja-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-2012r2-64
       packaging_platform: windows-2012-x64
@@ -29,13 +20,8 @@ expected_hash:
       roles:
       - agent
     centos6-64-2:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: el-6-x86_64
-      packaging_platform: el-6-x86_64
       template: centos-6-x86_64
       roles:
       - agent

--- a/test/fixtures/generated/multiplatform/centos7-64c-windows2012r2_wmf5-64-centos7-64d
+++ b/test/fixtures/generated/multiplatform/centos7-64c-windows2012r2_wmf5-64-centos7-64d
@@ -4,22 +4,13 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     centos7-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: el-7-x86_64
-      packaging_platform: el-7-x86_64
       template: centos-7-x86_64
       roles:
       - agent
       - dashboard
     windows2012r2_wmf5-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-2012r2-64
       packaging_platform: windows-2012-x64
@@ -28,13 +19,8 @@ expected_hash:
       roles:
       - agent
     centos7-64-2:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: el-7-x86_64
-      packaging_platform: el-7-x86_64
       template: centos-7-x86_64
       roles:
       - agent

--- a/test/fixtures/generated/multiplatform/centos8-64aulcdfm-windows2019_ja-64-centos8-64a
+++ b/test/fixtures/generated/multiplatform/centos8-64aulcdfm-windows2019_ja-64-centos8-64a
@@ -4,12 +4,7 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     centos8-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: el-8-x86_64
-      packaging_platform: el-8-x86_64
       template: centos-8-x86_64
       hypervisor: vmpooler
       roles:
@@ -21,10 +16,6 @@ expected_hash:
       - frictionless
       - master
     windows2019_ja-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: windows-2019-64
       packaging_platform: windows-2012-x64
       ruby_arch: x64
@@ -34,12 +25,7 @@ expected_hash:
       roles:
       - agent
     centos8-64-2:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: el-8-x86_64
-      packaging_platform: el-8-x86_64
       template: centos-8-x86_64
       hypervisor: vmpooler
       roles:

--- a/test/fixtures/generated/multiplatform/cisco_ios_c2960-HWm-windows2016-6432-cisco_ios_c2960-HWu
+++ b/test/fixtures/generated/multiplatform/cisco_ios_c2960-HWm-windows2016-6432-cisco_ios_c2960-HWu
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     cisco_ios_c2960-HW-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: cisco_ios-12-arm32
       ssh:
         user: admin
@@ -16,10 +12,6 @@ expected_hash:
       - agent
       - master
     windows2016-6432-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: windows-2016-64
       packaging_platform: windows-2012-x64
       ruby_arch: x86
@@ -28,10 +20,6 @@ expected_hash:
       roles:
       - agent
     cisco_ios_c2960-HW-2:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: cisco_ios-12-arm32
       ssh:
         user: admin

--- a/test/fixtures/generated/multiplatform/cisco_ios_c3560-HWaulcdfm-windows2016-64-cisco_ios_c3560-HWa
+++ b/test/fixtures/generated/multiplatform/cisco_ios_c3560-HWaulcdfm-windows2016-64-cisco_ios_c3560-HWa
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     cisco_ios_c3560-HW-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: cisco_ios-12-arm32
       ssh:
         user: admin
@@ -21,10 +17,6 @@ expected_hash:
       - frictionless
       - master
     windows2016-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: windows-2016-64
       packaging_platform: windows-2012-x64
       ruby_arch: x64
@@ -33,10 +25,6 @@ expected_hash:
       roles:
       - agent
     cisco_ios_c3560-HW-2:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: cisco_ios-12-arm32
       ssh:
         user: admin

--- a/test/fixtures/generated/multiplatform/cisco_ios_c3560-HWm-rocky8-64-cisco_ios_c3560-HWu
+++ b/test/fixtures/generated/multiplatform/cisco_ios_c3560-HWm-rocky8-64-cisco_ios_c3560-HWu
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     cisco_ios_c3560-HW-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: cisco_ios-12-arm32
       ssh:
         user: admin
@@ -16,20 +12,12 @@ expected_hash:
       - agent
       - master
     rocky8-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: el-8-x86_64
       hypervisor: vmpooler
       template: rocky-8-x86_64
       roles:
       - agent
     cisco_ios_c3560-HW-2:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: cisco_ios-12-arm32
       ssh:
         user: admin

--- a/test/fixtures/generated/multiplatform/cisco_ios_c3750-HWa-windows2012r2_core-6432-cisco_ios_c3750-HWaulcdfm
+++ b/test/fixtures/generated/multiplatform/cisco_ios_c3750-HWa-windows2012r2_core-6432-cisco_ios_c3750-HWaulcdfm
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     cisco_ios_c3750-HW-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: cisco_ios-12-arm32
       ssh:
         user: admin
@@ -15,10 +11,6 @@ expected_hash:
       roles:
       - agent
     windows2012r2_core-6432-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: windows-2012r2-64
       packaging_platform: windows-2012-x64
       ruby_arch: x86
@@ -27,10 +19,6 @@ expected_hash:
       roles:
       - agent
     cisco_ios_c3750-HW-2:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: cisco_ios-12-arm32
       ssh:
         user: admin

--- a/test/fixtures/generated/multiplatform/cisco_ios_c4507r-HWa-redhat9-64-cisco_ios_c4507r-HWaulcdfm
+++ b/test/fixtures/generated/multiplatform/cisco_ios_c4507r-HWa-redhat9-64-cisco_ios_c4507r-HWaulcdfm
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     cisco_ios_c4507r-HW-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: cisco_ios-12-arm32
       ssh:
         user: admin
@@ -15,21 +11,12 @@ expected_hash:
       roles:
       - agent
     redhat9-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: el-9-x86_64
-      packaging_platform: el-9-x86_64
       template: redhat-9-x86_64
       hypervisor: vmpooler
       roles:
       - agent
     cisco_ios_c4507r-HW-2:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: cisco_ios-12-arm32
       ssh:
         user: admin

--- a/test/fixtures/generated/multiplatform/cisco_ios_c4507r-HWu-windows2012r2_core-64-cisco_ios_c4507r-HWm
+++ b/test/fixtures/generated/multiplatform/cisco_ios_c4507r-HWu-windows2012r2_core-64-cisco_ios_c4507r-HWm
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     cisco_ios_c4507r-HW-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: cisco_ios-12-arm32
       ssh:
         user: admin
@@ -16,10 +12,6 @@ expected_hash:
       - agent
       - ca
     windows2012r2_core-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: windows-2012r2-64
       packaging_platform: windows-2012-x64
       ruby_arch: x64
@@ -28,10 +20,6 @@ expected_hash:
       roles:
       - agent
     cisco_ios_c4507r-HW-2:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: cisco_ios-12-arm32
       ssh:
         user: admin

--- a/test/fixtures/generated/multiplatform/cisco_ios_c4948-HWa-redhatfips8-64-cisco_ios_c4948-HWaulcdfm
+++ b/test/fixtures/generated/multiplatform/cisco_ios_c4948-HWa-redhatfips8-64-cisco_ios_c4948-HWaulcdfm
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     cisco_ios_c4948-HW-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: cisco_ios-12-arm32
       ssh:
         user: admin
@@ -15,10 +11,6 @@ expected_hash:
       roles:
       - agent
     redhatfips8-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: el-8-x86_64
       packaging_platform: redhatfips-8-x86_64
       template: redhat-fips-8-x86_64
@@ -26,10 +18,6 @@ expected_hash:
       roles:
       - agent
     cisco_ios_c4948-HW-2:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: cisco_ios-12-arm32
       ssh:
         user: admin

--- a/test/fixtures/generated/multiplatform/cisco_ios_c4948-HWl-windows2012r2_fr-6432-cisco_ios_c4948-HWf
+++ b/test/fixtures/generated/multiplatform/cisco_ios_c4948-HWl-windows2012r2_fr-6432-cisco_ios_c4948-HWf
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     cisco_ios_c4948-HW-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: cisco_ios-12-arm32
       ssh:
         user: admin
@@ -16,10 +12,6 @@ expected_hash:
       - agent
       - classifier
     windows2012r2_fr-6432-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: windows-2012r2-64
       packaging_platform: windows-2012-x64
       ruby_arch: x86
@@ -30,10 +22,6 @@ expected_hash:
       roles:
       - agent
     cisco_ios_c4948-HW-2:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: cisco_ios-12-arm32
       ssh:
         user: admin

--- a/test/fixtures/generated/multiplatform/cisco_ios_c6503-HWc-windows2012r2_fr-64-cisco_ios_c6503-HWd
+++ b/test/fixtures/generated/multiplatform/cisco_ios_c6503-HWc-windows2012r2_fr-64-cisco_ios_c6503-HWd
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     cisco_ios_c6503-HW-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: cisco_ios-12-arm32
       ssh:
         user: admin
@@ -16,10 +12,6 @@ expected_hash:
       - agent
       - dashboard
     windows2012r2_fr-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: windows-2012r2-64
       packaging_platform: windows-2012-x64
       ruby_arch: x64
@@ -30,10 +22,6 @@ expected_hash:
       roles:
       - agent
     cisco_ios_c6503-HW-2:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: cisco_ios-12-arm32
       ssh:
         user: admin

--- a/test/fixtures/generated/multiplatform/cisco_iosxe_c3650-HWd-windows2012r2_ja-6432-cisco_iosxe_c3650-HWc
+++ b/test/fixtures/generated/multiplatform/cisco_iosxe_c3650-HWd-windows2012r2_ja-6432-cisco_iosxe_c3650-HWc
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     cisco_iosxe_c3650-HW-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: cisco_iosxec3650-arm32
       ssh:
         user: admin
@@ -16,10 +12,6 @@ expected_hash:
       - agent
       - database
     windows2012r2_ja-6432-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: windows-2012r2-64
       packaging_platform: windows-2012-x64
       ruby_arch: x86
@@ -29,10 +21,6 @@ expected_hash:
       roles:
       - agent
     cisco_iosxe_c3650-HW-2:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: cisco_iosxec3650-arm32
       ssh:
         user: admin

--- a/test/fixtures/generated/multiplatform/cisco_iosxe_c4503-HWf-windows2012r2_ja-64-cisco_iosxe_c4503-HWl
+++ b/test/fixtures/generated/multiplatform/cisco_iosxe_c4503-HWf-windows2012r2_ja-64-cisco_iosxe_c4503-HWl
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     cisco_iosxe_c4503-HW-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: cisco_iosxe-3-arm32
       ssh:
         user: admin
@@ -16,10 +12,6 @@ expected_hash:
       - agent
       - frictionless
     windows2012r2_ja-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: windows-2012r2-64
       packaging_platform: windows-2012-x64
       ruby_arch: x64
@@ -29,10 +21,6 @@ expected_hash:
       roles:
       - agent
     cisco_iosxe_c4503-HW-2:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: cisco_iosxe-3-arm32
       ssh:
         user: admin

--- a/test/fixtures/generated/multiplatform/cisco_n7k-HWc-windows2016_fr-64-cisco_n7k-HWd
+++ b/test/fixtures/generated/multiplatform/cisco_n7k-HWc-windows2016_fr-64-cisco_n7k-HWd
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     cisco_n7k-HW-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: cisco_nexus-7k-x86_64
       packaging_platform: cisco-wrlinux-5-x86_64
       vrf: management
@@ -18,10 +14,6 @@ expected_hash:
       - agent
       - dashboard
     windows2016_fr-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: windows-2016-64
       packaging_platform: windows-2012-x64
       ruby_arch: x64
@@ -32,10 +24,6 @@ expected_hash:
       roles:
       - agent
     cisco_n7k-HW-2:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: cisco_nexus-7k-x86_64
       packaging_platform: cisco-wrlinux-5-x86_64
       vrf: management

--- a/test/fixtures/generated/multiplatform/cisco_n7k_vdc-HWd-windows2016_core-6432-cisco_n7k_vdc-HWc
+++ b/test/fixtures/generated/multiplatform/cisco_n7k_vdc-HWd-windows2016_core-6432-cisco_n7k_vdc-HWc
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     cisco_n7k_vdc-HW-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: cisco_nexus-7k-x86_64
       packaging_platform: cisco-wrlinux-5-x86_64
       vrf: management
@@ -18,10 +14,6 @@ expected_hash:
       - agent
       - database
     windows2016_core-6432-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: windows-2016-64
       packaging_platform: windows-2012-x64
       ruby_arch: x86
@@ -30,10 +22,6 @@ expected_hash:
       roles:
       - agent
     cisco_n7k_vdc-HW-2:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: cisco_nexus-7k-x86_64
       packaging_platform: cisco-wrlinux-5-x86_64
       vrf: management

--- a/test/fixtures/generated/multiplatform/cisco_n9k-HWf-windows2016_core-64-cisco_n9k-HWl
+++ b/test/fixtures/generated/multiplatform/cisco_n9k-HWf-windows2016_core-64-cisco_n9k-HWl
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     cisco_n9k-HW-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: cisco_nexus-7-x86_64
       packaging_platform: cisco-wrlinux-5-x86_64
       vrf: management
@@ -18,10 +14,6 @@ expected_hash:
       - agent
       - frictionless
     windows2016_core-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: windows-2016-64
       packaging_platform: windows-2012-x64
       ruby_arch: x64
@@ -30,10 +22,6 @@ expected_hash:
       roles:
       - agent
     cisco_n9k-HW-2:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: cisco_nexus-7-x86_64
       packaging_platform: cisco-wrlinux-5-x86_64
       vrf: management

--- a/test/fixtures/generated/multiplatform/cisco_n9k-VMl-windows2016_fr-6432-cisco_n9k-VMf
+++ b/test/fixtures/generated/multiplatform/cisco_n9k-VMl-windows2016_fr-6432-cisco_n9k-VMf
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     cisco_n9k-VM-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: cisco_nexus-7-x86_64
       packaging_platform: cisco-wrlinux-5-x86_64
       vrf: management
@@ -19,10 +15,6 @@ expected_hash:
       - agent
       - classifier
     windows2016_fr-6432-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: windows-2016-64
       packaging_platform: windows-2012-x64
       ruby_arch: x86
@@ -33,10 +25,6 @@ expected_hash:
       roles:
       - agent
     cisco_n9k-VM-2:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: cisco_nexus-7-x86_64
       packaging_platform: cisco-wrlinux-5-x86_64
       vrf: management

--- a/test/fixtures/generated/multiplatform/cisco_xr_9k-VMm-windows2012r2_wmf5-64-cisco_xr_9k-VMu
+++ b/test/fixtures/generated/multiplatform/cisco_xr_9k-VMm-windows2012r2_wmf5-64-cisco_xr_9k-VMu
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     cisco_xr_9k-VM-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: cisco_ios_xr-6-x86_64
       packaging_platform: cisco-wrlinux-7-x86_64
       template: cisco-exr-9k-x86_64
@@ -16,10 +12,6 @@ expected_hash:
       - agent
       - master
     windows2012r2_wmf5-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: windows-2012r2-64
       packaging_platform: windows-2012-x64
       ruby_arch: x64
@@ -28,10 +20,6 @@ expected_hash:
       roles:
       - agent
     cisco_xr_9k-VM-2:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: cisco_ios_xr-6-x86_64
       packaging_platform: cisco-wrlinux-7-x86_64
       template: cisco-exr-9k-x86_64

--- a/test/fixtures/generated/multiplatform/ciscon7k-64a-windows2019-6432-ciscon7k-64aulcdfm
+++ b/test/fixtures/generated/multiplatform/ciscon7k-64a-windows2019-6432-ciscon7k-64aulcdfm
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     ciscon7k-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: cisco_nexus-7k-x86_64
       packaging_platform: cisco-wrlinux-5-x86_64
       vrf: management
@@ -17,10 +13,6 @@ expected_hash:
       roles:
       - agent
     windows2019-6432-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: windows-2019-64
       packaging_platform: windows-2012-x64
       ruby_arch: x86
@@ -29,10 +21,6 @@ expected_hash:
       roles:
       - agent
     ciscon7k-64-2:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: cisco_nexus-7k-x86_64
       packaging_platform: cisco-wrlinux-5-x86_64
       vrf: management

--- a/test/fixtures/generated/multiplatform/cisconx-64aulcdfm-windows2019_ja-64-cisconx-64a
+++ b/test/fixtures/generated/multiplatform/cisconx-64aulcdfm-windows2019_ja-64-cisconx-64a
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     cisconx-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: cisco_nexus-7-x86_64
       packaging_platform: cisco-wrlinux-5-x86_64
       vrf: management
@@ -24,10 +20,6 @@ expected_hash:
       - frictionless
       - master
     windows2019_ja-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: windows-2019-64
       packaging_platform: windows-2012-x64
       ruby_arch: x64
@@ -37,10 +29,6 @@ expected_hash:
       roles:
       - agent
     cisconx-64-2:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: cisco_nexus-7-x86_64
       packaging_platform: cisco-wrlinux-5-x86_64
       vrf: management

--- a/test/fixtures/generated/multiplatform/cisconx-64d-windows2012r2-6432-cisconx-64c
+++ b/test/fixtures/generated/multiplatform/cisconx-64d-windows2012r2-6432-cisconx-64c
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     cisconx-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: cisco_nexus-7-x86_64
       packaging_platform: cisco-wrlinux-5-x86_64
@@ -19,10 +15,6 @@ expected_hash:
       - agent
       - database
     windows2012r2-6432-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-2012r2-64
       packaging_platform: windows-2012-x64
@@ -31,10 +23,6 @@ expected_hash:
       roles:
       - agent
     cisconx-64-2:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: cisco_nexus-7-x86_64
       packaging_platform: cisco-wrlinux-5-x86_64

--- a/test/fixtures/generated/multiplatform/cisconxhw-64f-windows2012r2-64-cisconxhw-64l
+++ b/test/fixtures/generated/multiplatform/cisconxhw-64f-windows2012r2-64-cisconxhw-64l
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     cisconxhw-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       hypervisor: vmpooler
       platform: cisco_nexus-7-x86_64
       packaging_platform: cisco-wrlinux-5-x86_64
@@ -18,10 +14,6 @@ expected_hash:
       - agent
       - frictionless
     windows2012r2-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       hypervisor: vmpooler
       platform: windows-2012r2-64
       packaging_platform: windows-2012-x64
@@ -30,10 +22,6 @@ expected_hash:
       roles:
       - agent
     cisconxhw-64-2:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       hypervisor: vmpooler
       platform: cisco_nexus-7-x86_64
       packaging_platform: cisco-wrlinux-5-x86_64

--- a/test/fixtures/generated/multiplatform/cisconxhw-64u-windows2019-64-cisconxhw-64m
+++ b/test/fixtures/generated/multiplatform/cisconxhw-64u-windows2019-64-cisconxhw-64m
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     cisconxhw-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: cisco_nexus-7-x86_64
       packaging_platform: cisco-wrlinux-5-x86_64
       vrf: management
@@ -18,10 +14,6 @@ expected_hash:
       - agent
       - ca
     windows2019-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: windows-2019-64
       packaging_platform: windows-2012-x64
       ruby_arch: x64
@@ -30,10 +22,6 @@ expected_hash:
       roles:
       - agent
     cisconxhw-64-2:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: cisco_nexus-7-x86_64
       packaging_platform: cisco-wrlinux-5-x86_64
       vrf: management

--- a/test/fixtures/generated/multiplatform/cumulus25-64m-windows2012-6432-cumulus25-64u
+++ b/test/fixtures/generated/multiplatform/cumulus25-64m-windows2012-6432-cumulus25-64u
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     cumulus25-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: cumulus-2.5-x86_64
       packaging_platform: cumulus-2.2-amd64
@@ -16,10 +12,6 @@ expected_hash:
       - agent
       - master
     windows2012-6432-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-2012-64
       packaging_platform: windows-2012-x64
@@ -28,10 +20,6 @@ expected_hash:
       roles:
       - agent
     cumulus25-64-2:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: cumulus-2.5-x86_64
       packaging_platform: cumulus-2.2-amd64

--- a/test/fixtures/generated/multiplatform/debian10-32d-windows2008-6432-debian10-32c
+++ b/test/fixtures/generated/multiplatform/debian10-32d-windows2008-6432-debian10-32c
@@ -4,22 +4,13 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     debian10-32-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: debian-10-i386
-      packaging_platform: debian-10-i386
       template: debian-10-i386
       hypervisor: vmpooler
       roles:
       - agent
       - database
     windows2008-6432-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: windows-2008-64
       packaging_platform: windows-2012-x64
       ruby_arch: x86
@@ -28,12 +19,7 @@ expected_hash:
       roles:
       - agent
     debian10-32-2:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: debian-10-i386
-      packaging_platform: debian-10-i386
       template: debian-10-i386
       hypervisor: vmpooler
       roles:

--- a/test/fixtures/generated/multiplatform/debian10-64c-windows2008r2-64-debian10-64d
+++ b/test/fixtures/generated/multiplatform/debian10-64c-windows2008r2-64-debian10-64d
@@ -4,22 +4,13 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     debian10-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: debian-10-amd64
-      packaging_platform: debian-10-amd64
       template: debian-10-x86_64
       hypervisor: vmpooler
       roles:
       - agent
       - dashboard
     windows2008r2-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: windows-2008r2-64
       packaging_platform: windows-2012-x64
       ruby_arch: x64
@@ -28,12 +19,7 @@ expected_hash:
       roles:
       - agent
     debian10-64-2:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: debian-10-amd64
-      packaging_platform: debian-10-amd64
       template: debian-10-x86_64
       hypervisor: vmpooler
       roles:

--- a/test/fixtures/generated/multiplatform/debian11-64m-solaris11-64-debian11-64u
+++ b/test/fixtures/generated/multiplatform/debian11-64m-solaris11-64-debian11-64u
@@ -4,35 +4,20 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     debian11-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: debian-11-amd64
-      packaging_platform: debian-11-amd64
       template: debian-11-x86_64
       hypervisor: vmpooler
       roles:
       - agent
       - master
     solaris11-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: solaris-11-i386
-      packaging_platform: solaris-11-i386
       template: solaris-11-x86_64
       hypervisor: vmpooler
       roles:
       - agent
     debian11-64-2:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: debian-11-amd64
-      packaging_platform: debian-11-amd64
       template: debian-11-x86_64
       hypervisor: vmpooler
       roles:

--- a/test/fixtures/generated/multiplatform/debian6-32aulcdfm-windows2012-64-debian6-32a
+++ b/test/fixtures/generated/multiplatform/debian6-32aulcdfm-windows2012-64-debian6-32a
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     debian6-32-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: debian-6-i386
       template: debian-6-i386
@@ -20,10 +16,6 @@ expected_hash:
       - frictionless
       - master
     windows2012-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-2012-64
       packaging_platform: windows-2012-x64
@@ -32,10 +24,6 @@ expected_hash:
       roles:
       - agent
     debian6-32-2:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: debian-6-i386
       template: debian-6-i386

--- a/test/fixtures/generated/multiplatform/debian6-64a-windows2008r2-6432-debian6-64aulcdfm
+++ b/test/fixtures/generated/multiplatform/debian6-64a-windows2008r2-6432-debian6-64aulcdfm
@@ -4,20 +4,12 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     debian6-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: debian-6-amd64
       template: debian-6-x86_64
       roles:
       - agent
     windows2008r2-6432-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-2008r2-64
       packaging_platform: windows-2012-x64
@@ -26,10 +18,6 @@ expected_hash:
       roles:
       - agent
     debian6-64-2:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: debian-6-amd64
       template: debian-6-x86_64

--- a/test/fixtures/generated/multiplatform/debian7-32u-windows2008r2-64-debian7-32m
+++ b/test/fixtures/generated/multiplatform/debian7-32u-windows2008r2-64-debian7-32m
@@ -4,22 +4,13 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     debian7-32-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: debian-7-i386
-      packaging_platform: debian-7-i386
       template: debian-7-i386
       roles:
       - agent
       - ca
     windows2008r2-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-2008r2-64
       packaging_platform: windows-2012-x64
@@ -28,13 +19,8 @@ expected_hash:
       roles:
       - agent
     debian7-32-2:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: debian-7-i386
-      packaging_platform: debian-7-i386
       template: debian-7-i386
       roles:
       - agent

--- a/test/fixtures/generated/multiplatform/debian7-64l-windows2008-6432-debian7-64f
+++ b/test/fixtures/generated/multiplatform/debian7-64l-windows2008-6432-debian7-64f
@@ -4,22 +4,13 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     debian7-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: debian-7-amd64
-      packaging_platform: debian-7-amd64
       template: debian-7-x86_64
       roles:
       - agent
       - classifier
     windows2008-6432-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-2008-64
       packaging_platform: windows-2012-x64
@@ -28,13 +19,8 @@ expected_hash:
       roles:
       - agent
     debian7-64-2:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: debian-7-amd64
-      packaging_platform: debian-7-amd64
       template: debian-7-x86_64
       roles:
       - agent

--- a/test/fixtures/generated/multiplatform/debian8-32c-windows2008-64-debian8-32d
+++ b/test/fixtures/generated/multiplatform/debian8-32c-windows2008-64-debian8-32d
@@ -4,22 +4,13 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     debian8-32-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: debian-8-i386
-      packaging_platform: debian-8-i386
       template: debian-8-i386
       roles:
       - agent
       - dashboard
     windows2008-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-2008-64
       packaging_platform: windows-2012-x64
@@ -28,13 +19,8 @@ expected_hash:
       roles:
       - agent
     debian8-32-2:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: debian-8-i386
-      packaging_platform: debian-8-i386
       template: debian-8-i386
       roles:
       - agent

--- a/test/fixtures/generated/multiplatform/debian8-64a-windowsfips2012r2-6432-debian8-64aulcdfm
+++ b/test/fixtures/generated/multiplatform/debian8-64a-windowsfips2012r2-6432-debian8-64aulcdfm
@@ -4,21 +4,12 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     debian8-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: debian-8-amd64
-      packaging_platform: debian-8-amd64
       template: debian-8-x86_64
       hypervisor: vmpooler
       roles:
       - agent
     windowsfips2012r2-6432-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: windows-2012r2-64
       packaging_platform: windowsfips-2012-x64
       ruby_arch: x64
@@ -27,12 +18,7 @@ expected_hash:
       roles:
       - agent
     debian8-64-2:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: debian-8-amd64
-      packaging_platform: debian-8-amd64
       template: debian-8-x86_64
       hypervisor: vmpooler
       roles:

--- a/test/fixtures/generated/multiplatform/debian9-32u-windowsfips2012r2-64-debian9-32m
+++ b/test/fixtures/generated/multiplatform/debian9-32u-windowsfips2012r2-64-debian9-32m
@@ -4,22 +4,13 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     debian9-32-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: debian-9-i386
-      packaging_platform: debian-9-i386
       template: debian-9-i386
       hypervisor: vmpooler
       roles:
       - agent
       - ca
     windowsfips2012r2-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: windows-2012r2-64
       packaging_platform: windowsfips-2012-x64
       ruby_arch: x64
@@ -28,12 +19,7 @@ expected_hash:
       roles:
       - agent
     debian9-32-2:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: debian-9-i386
-      packaging_platform: debian-9-i386
       template: debian-9-i386
       hypervisor: vmpooler
       roles:

--- a/test/fixtures/generated/multiplatform/fedora19-64u-vro7-64-fedora19-64m
+++ b/test/fixtures/generated/multiplatform/fedora19-64u-vro7-64-fedora19-64m
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     fedora19-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: fedora-19-x86_64
       template: fedora-19-x86_64
@@ -15,21 +11,12 @@ expected_hash:
       - agent
       - ca
     vro7-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: sles-11-x86_64
-      packaging_platform: sles-11-x86_64
       template: vro-7-x86_64
       roles:
       - agent
     fedora19-64-2:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: fedora-19-x86_64
       template: fedora-19-x86_64

--- a/test/fixtures/generated/multiplatform/fedora19-64u-vro73-64-fedora19-64m
+++ b/test/fixtures/generated/multiplatform/fedora19-64u-vro73-64-fedora19-64m
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     fedora19-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: fedora-19-x86_64
       template: fedora-19-x86_64
@@ -15,21 +11,12 @@ expected_hash:
       - agent
       - ca
     vro73-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: sles-11-x86_64
-      packaging_platform: sles-11-x86_64
       template: vro-73-x86_64
       roles:
       - agent
     fedora19-64-2:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: fedora-19-x86_64
       template: fedora-19-x86_64

--- a/test/fixtures/generated/multiplatform/fedora20-32l-vro6-64-fedora20-32f
+++ b/test/fixtures/generated/multiplatform/fedora20-32l-vro6-64-fedora20-32f
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     fedora20-32-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: fedora-20-i386
       template: fedora-20-i386
@@ -15,21 +11,12 @@ expected_hash:
       - agent
       - classifier
     vro6-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: sles-11-x86_64
-      packaging_platform: sles-11-x86_64
       template: vro-6-x86_64
       roles:
       - agent
     fedora20-32-2:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: fedora-20-i386
       template: fedora-20-i386

--- a/test/fixtures/generated/multiplatform/fedora20-32m-ubuntu2004-64-fedora20-32u
+++ b/test/fixtures/generated/multiplatform/fedora20-32m-ubuntu2004-64-fedora20-32u
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     fedora20-32-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: fedora-20-i386
       template: fedora-20-i386
       hypervisor: vmpooler
@@ -15,20 +11,12 @@ expected_hash:
       - agent
       - master
     ubuntu2004-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: ubuntu-20.04-amd64
       template: ubuntu-2004-x86_64
       hypervisor: vmpooler
       roles:
       - agent
     fedora20-32-2:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: fedora-20-i386
       template: fedora-20-i386
       hypervisor: vmpooler

--- a/test/fixtures/generated/multiplatform/fedora20-32m-ubuntu2004-AARCH64-fedora20-32u
+++ b/test/fixtures/generated/multiplatform/fedora20-32m-ubuntu2004-AARCH64-fedora20-32u
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     fedora20-32-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: fedora-20-i386
       template: fedora-20-i386
       hypervisor: vmpooler
@@ -15,19 +11,11 @@ expected_hash:
       - agent
       - master
     ubuntu2004-AARCH64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: ubuntu-20.04-aarch64
       hypervisor: vmpooler
       roles:
       - agent
     fedora20-32-2:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: fedora-20-i386
       template: fedora-20-i386
       hypervisor: vmpooler

--- a/test/fixtures/generated/multiplatform/fedora21-32aulcdfm-vro74-64-fedora21-32a
+++ b/test/fixtures/generated/multiplatform/fedora21-32aulcdfm-vro74-64-fedora21-32a
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     fedora21-32-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: fedora-21-i386
       template: fedora-21-i386
@@ -20,21 +16,12 @@ expected_hash:
       - frictionless
       - master
     vro74-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: sles-11-x86_64
-      packaging_platform: sles-11-x86_64
       template: vro-74-x86_64
       roles:
       - agent
     fedora21-32-2:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: fedora-21-i386
       template: fedora-21-i386

--- a/test/fixtures/generated/multiplatform/fedora21-64f-ubuntu1604-POWER-fedora21-64l
+++ b/test/fixtures/generated/multiplatform/fedora21-64f-ubuntu1604-POWER-fedora21-64l
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     fedora21-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: fedora-21-x86_64
       template: fedora-21-x86_64
@@ -15,19 +11,11 @@ expected_hash:
       - agent
       - frictionless
     ubuntu1604-POWER-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: ubuntu-16.04-ppc64el
       roles:
       - agent
     fedora21-64-2:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: fedora-21-x86_64
       template: fedora-21-x86_64

--- a/test/fixtures/generated/multiplatform/fedora22-32m-ubuntu1604-64-fedora22-32u
+++ b/test/fixtures/generated/multiplatform/fedora22-32m-ubuntu1604-64-fedora22-32u
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     fedora22-32-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: fedora-22-i386
       template: fedora-22-i386
@@ -15,20 +11,12 @@ expected_hash:
       - agent
       - master
     ubuntu1604-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: ubuntu-16.04-amd64
       template: ubuntu-1604-x86_64
       roles:
       - agent
     fedora22-32-2:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: fedora-22-i386
       template: fedora-22-i386

--- a/test/fixtures/generated/multiplatform/fedora22-32u-ubuntu1804-64-fedora22-32m
+++ b/test/fixtures/generated/multiplatform/fedora22-32u-ubuntu1804-64-fedora22-32m
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     fedora22-32-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: fedora-22-i386
       template: fedora-22-i386
@@ -15,20 +11,12 @@ expected_hash:
       - agent
       - ca
     ubuntu1804-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: ubuntu-18.04-amd64
       template: ubuntu-1804-x86_64
       roles:
       - agent
     fedora22-32-2:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: fedora-22-i386
       template: fedora-22-i386

--- a/test/fixtures/generated/multiplatform/fedora22-32u-vro71-64-fedora22-32m
+++ b/test/fixtures/generated/multiplatform/fedora22-32u-vro71-64-fedora22-32m
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     fedora22-32-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: fedora-22-i386
       template: fedora-22-i386
@@ -15,21 +11,12 @@ expected_hash:
       - agent
       - ca
     vro71-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: sles-11-x86_64
-      packaging_platform: sles-11-x86_64
       template: vro-71-x86_64
       roles:
       - agent
     fedora22-32-2:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: fedora-22-i386
       template: fedora-22-i386

--- a/test/fixtures/generated/multiplatform/fedora22-64aulcdfm-ubuntu1604-32-fedora22-64a
+++ b/test/fixtures/generated/multiplatform/fedora22-64aulcdfm-ubuntu1604-32-fedora22-64a
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     fedora22-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: fedora-22-x86_64
       template: fedora-22-x86_64
@@ -20,20 +16,12 @@ expected_hash:
       - frictionless
       - master
     ubuntu1604-32-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: ubuntu-16.04-i386
       template: ubuntu-1604-i386
       roles:
       - agent
     fedora22-64-2:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: fedora-22-x86_64
       template: fedora-22-x86_64

--- a/test/fixtures/generated/multiplatform/fedora24-32l-windows2022-64-fedora24-32f
+++ b/test/fixtures/generated/multiplatform/fedora24-32l-windows2022-64-fedora24-32f
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     fedora24-32-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: fedora-24-i386
       hypervisor: vmpooler
       template: fedora-24-i386
@@ -15,10 +11,6 @@ expected_hash:
       - agent
       - classifier
     windows2022-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: windows-2022-64
       packaging_platform: windows-2012-x64
       ruby_arch: x64
@@ -27,10 +19,6 @@ expected_hash:
       roles:
       - agent
     fedora24-32-2:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: fedora-24-i386
       hypervisor: vmpooler
       template: fedora-24-i386

--- a/test/fixtures/generated/multiplatform/fedora25-32d-ubuntu1404-64-fedora25-32c
+++ b/test/fixtures/generated/multiplatform/fedora25-32d-ubuntu1404-64-fedora25-32c
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     fedora25-32-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: fedora-25-i386
       template: fedora-25-i386
@@ -15,20 +11,12 @@ expected_hash:
       - agent
       - database
     ubuntu1404-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: ubuntu-14.04-amd64
       template: ubuntu-1404-x86_64
       roles:
       - agent
     fedora25-32-2:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: fedora-25-i386
       template: fedora-25-i386

--- a/test/fixtures/generated/multiplatform/fedora25-64f-ubuntu1404-32-fedora25-64l
+++ b/test/fixtures/generated/multiplatform/fedora25-64f-ubuntu1404-32-fedora25-64l
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     fedora25-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: fedora-25-x86_64
       template: fedora-25-x86_64
@@ -15,20 +11,12 @@ expected_hash:
       - agent
       - frictionless
     ubuntu1404-32-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: ubuntu-14.04-i386
       template: ubuntu-1404-i386
       roles:
       - agent
     fedora25-64-2:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: fedora-25-x86_64
       template: fedora-25-x86_64

--- a/test/fixtures/generated/multiplatform/fedora27-64l-ubuntu1404-64-fedora27-64f
+++ b/test/fixtures/generated/multiplatform/fedora27-64l-ubuntu1404-64-fedora27-64f
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     fedora27-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: fedora-27-x86_64
       template: fedora-27-x86_64
@@ -15,20 +11,12 @@ expected_hash:
       - agent
       - classifier
     ubuntu1404-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: ubuntu-14.04-amd64
       template: ubuntu-1404-x86_64
       roles:
       - agent
     fedora27-64-2:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: fedora-27-x86_64
       template: fedora-27-x86_64

--- a/test/fixtures/generated/multiplatform/fedora28-64d-ubuntu1404-64-fedora28-64c
+++ b/test/fixtures/generated/multiplatform/fedora28-64d-ubuntu1404-64-fedora28-64c
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     fedora28-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: fedora-28-x86_64
       template: fedora-28-x86_64
@@ -15,20 +11,12 @@ expected_hash:
       - agent
       - database
     ubuntu1404-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: ubuntu-14.04-amd64
       template: ubuntu-1404-x86_64
       roles:
       - agent
     fedora28-64-2:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: fedora-28-x86_64
       template: fedora-28-x86_64

--- a/test/fixtures/generated/multiplatform/fedora29-64d-ubuntu1604-POWER-fedora29-64c
+++ b/test/fixtures/generated/multiplatform/fedora29-64d-ubuntu1604-POWER-fedora29-64c
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     fedora29-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: fedora-29-x86_64
       template: fedora-29-x86_64
@@ -15,19 +11,11 @@ expected_hash:
       - agent
       - database
     ubuntu1604-POWER-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: ubuntu-16.04-ppc64el
       roles:
       - agent
     fedora29-64-2:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: fedora-29-x86_64
       template: fedora-29-x86_64

--- a/test/fixtures/generated/multiplatform/fedora31-64aulcdfm-solaris114-64-fedora31-64a
+++ b/test/fixtures/generated/multiplatform/fedora31-64aulcdfm-solaris114-64-fedora31-64a
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     fedora31-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: fedora-31-x86_64
       template: fedora-31-x86_64
       hypervisor: vmpooler
@@ -20,10 +16,6 @@ expected_hash:
       - frictionless
       - master
     solaris114-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: solaris-11.4-i386
       packaging_platform: solaris-11-i386
       template: solaris-114-x86_64
@@ -31,10 +23,6 @@ expected_hash:
       roles:
       - agent
     fedora31-64-2:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: fedora-31-x86_64
       template: fedora-31-x86_64
       hypervisor: vmpooler

--- a/test/fixtures/generated/multiplatform/fedora32-64a-solaris114-64-fedora32-64aulcdfm
+++ b/test/fixtures/generated/multiplatform/fedora32-64a-solaris114-64-fedora32-64aulcdfm
@@ -4,20 +4,12 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     fedora32-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: fedora-32-x86_64
       template: fedora-32-x86_64
       hypervisor: vmpooler
       roles:
       - agent
     solaris114-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: solaris-11.4-i386
       packaging_platform: solaris-11-i386
       template: solaris-114-x86_64
@@ -25,10 +17,6 @@ expected_hash:
       roles:
       - agent
     fedora32-64-2:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: fedora-32-x86_64
       template: fedora-32-x86_64
       hypervisor: vmpooler

--- a/test/fixtures/generated/multiplatform/fedora34-64c-windows2012r2_fr-64-fedora34-64d
+++ b/test/fixtures/generated/multiplatform/fedora34-64c-windows2012r2_fr-64-fedora34-64d
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     fedora34-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: fedora-34-x86_64
       hypervisor: vmpooler
       template: fedora-34-x86_64
@@ -15,10 +11,6 @@ expected_hash:
       - agent
       - dashboard
     windows2012r2_fr-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: windows-2012r2-64
       packaging_platform: windows-2012-x64
       ruby_arch: x64
@@ -29,10 +21,6 @@ expected_hash:
       roles:
       - agent
     fedora34-64-2:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: fedora-34-x86_64
       hypervisor: vmpooler
       template: fedora-34-x86_64

--- a/test/fixtures/generated/multiplatform/oracle5-32l-solaris112-64-oracle5-32f
+++ b/test/fixtures/generated/multiplatform/oracle5-32l-solaris112-64-oracle5-32f
@@ -4,22 +4,13 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     oracle5-32-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: el-5-i386
-      packaging_platform: el-5-i386
       template: oracle-5-i386
       roles:
       - agent
       - classifier
     solaris112-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: solaris-11.2-i386
       packaging_platform: solaris-11-i386
@@ -27,13 +18,8 @@ expected_hash:
       roles:
       - agent
     oracle5-32-2:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: el-5-i386
-      packaging_platform: el-5-i386
       template: oracle-5-i386
       roles:
       - agent

--- a/test/fixtures/generated/multiplatform/oracle5-64c-solaris112-32-oracle5-64d
+++ b/test/fixtures/generated/multiplatform/oracle5-64c-solaris112-32-oracle5-64d
@@ -4,22 +4,13 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     oracle5-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: el-5-x86_64
-      packaging_platform: el-5-x86_64
       template: oracle-5-x86_64
       roles:
       - agent
       - dashboard
     solaris112-32-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: solaris-11.2-i386
       packaging_platform: solaris-11-i386
@@ -27,13 +18,8 @@ expected_hash:
       roles:
       - agent
     oracle5-64-2:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: el-5-x86_64
-      packaging_platform: el-5-x86_64
       template: oracle-5-x86_64
       roles:
       - agent

--- a/test/fixtures/generated/multiplatform/oracle6-32d-solaris11-SPARC-oracle6-32c
+++ b/test/fixtures/generated/multiplatform/oracle6-32d-solaris11-SPARC-oracle6-32c
@@ -4,35 +4,20 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     oracle6-32-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: el-6-i386
-      packaging_platform: el-6-i386
       template: oracle-6-i386
       roles:
       - agent
       - database
     solaris11-SPARC-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: solaris-11-sparc
-      packaging_platform: solaris-11-sparc
       roles:
       - agent
     oracle6-32-2:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: el-6-i386
-      packaging_platform: el-6-i386
       template: oracle-6-i386
       roles:
       - agent

--- a/test/fixtures/generated/multiplatform/oracle6-64f-solaris11-64-oracle6-64l
+++ b/test/fixtures/generated/multiplatform/oracle6-64f-solaris11-64-oracle6-64l
@@ -4,36 +4,21 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     oracle6-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: el-6-x86_64
-      packaging_platform: el-6-x86_64
       template: oracle-6-x86_64
       roles:
       - agent
       - frictionless
     solaris11-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: solaris-11-i386
-      packaging_platform: solaris-11-i386
       template: solaris-11-x86_64
       roles:
       - agent
     oracle6-64-2:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: el-6-x86_64
-      packaging_platform: el-6-x86_64
       template: oracle-6-x86_64
       roles:
       - agent

--- a/test/fixtures/generated/multiplatform/oracle7-64m-solaris11-32-oracle7-64u
+++ b/test/fixtures/generated/multiplatform/oracle7-64m-solaris11-32-oracle7-64u
@@ -4,36 +4,21 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     oracle7-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: el-7-x86_64
-      packaging_platform: el-7-x86_64
       template: oracle-7-x86_64
       roles:
       - agent
       - master
     solaris11-32-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: solaris-11-i386
-      packaging_platform: solaris-11-i386
       template: solaris-11-x86_64
       roles:
       - agent
     oracle7-64-2:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: el-7-x86_64
-      packaging_platform: el-7-x86_64
       template: oracle-7-x86_64
       roles:
       - agent

--- a/test/fixtures/generated/multiplatform/osx1010-64a-solaris10-64-osx1010-64aulcdfm
+++ b/test/fixtures/generated/multiplatform/osx1010-64a-solaris10-64-osx1010-64aulcdfm
@@ -4,35 +4,20 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     osx1010-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: osx-10.10-x86_64
-      packaging_platform: osx-10.10-x86_64
       template: osx-1010-x86_64
       roles:
       - agent
     solaris10-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: solaris-10-i386
-      packaging_platform: solaris-10-i386
       template: solaris-10-x86_64
       roles:
       - agent
     osx1010-64-2:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: osx-10.10-x86_64
-      packaging_platform: osx-10.10-x86_64
       template: osx-1010-x86_64
       roles:
       - agent

--- a/test/fixtures/generated/multiplatform/osx1011-64u-solaris10-32-osx1011-64m
+++ b/test/fixtures/generated/multiplatform/osx1011-64u-solaris10-32-osx1011-64m
@@ -4,36 +4,21 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     osx1011-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: osx-10.11-x86_64
-      packaging_platform: osx-10.11-x86_64
       template: osx-1011-x86_64
       roles:
       - agent
       - ca
     solaris10-32-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: solaris-10-i386
-      packaging_platform: solaris-10-i386
       template: solaris-10-x86_64
       roles:
       - agent
     osx1011-64-2:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: osx-10.11-x86_64
-      packaging_platform: osx-10.11-x86_64
       template: osx-1011-x86_64
       roles:
       - agent

--- a/test/fixtures/generated/multiplatform/osx1012-64l-sles12-POWER-osx1012-64f
+++ b/test/fixtures/generated/multiplatform/osx1012-64l-sles12-POWER-osx1012-64f
@@ -4,35 +4,20 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     osx1012-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: osx-10.12-x86_64
-      packaging_platform: osx-10.12-x86_64
       template: osx-1012-x86_64
       roles:
       - agent
       - classifier
     sles12-POWER-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: sles-12-ppc64le
-      packaging_platform: sles-12-ppc64le
       roles:
       - agent
     osx1012-64-2:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: osx-10.12-x86_64
-      packaging_platform: osx-10.12-x86_64
       template: osx-1012-x86_64
       roles:
       - agent

--- a/test/fixtures/generated/multiplatform/osx1013-64f-sles11-S390X-osx1013-64l
+++ b/test/fixtures/generated/multiplatform/osx1013-64f-sles11-S390X-osx1013-64l
@@ -4,35 +4,20 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     osx1013-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: osx-10.13-x86_64
-      packaging_platform: osx-10.13-x86_64
       template: osx-1013-x86_64
       roles:
       - agent
       - frictionless
     sles11-S390X-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: sles-11-s390x
-      packaging_platform: sles-11-s390x
       roles:
       - agent
     osx1013-64-2:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: osx-10.13-x86_64
-      packaging_platform: osx-10.13-x86_64
       template: osx-1013-x86_64
       roles:
       - agent

--- a/test/fixtures/generated/multiplatform/osx1014-64f-solaris11-SPARC-osx1014-64l
+++ b/test/fixtures/generated/multiplatform/osx1014-64f-solaris11-SPARC-osx1014-64l
@@ -4,35 +4,20 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     osx1014-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: osx-10.14-x86_64
-      packaging_platform: osx-10.14-x86_64
       template: osx-1014-x86_64
       roles:
       - agent
       - frictionless
     solaris11-SPARC-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: solaris-11-sparc
-      packaging_platform: solaris-11-sparc
       roles:
       - agent
     osx1014-64-2:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: osx-10.14-x86_64
-      packaging_platform: osx-10.14-x86_64
       template: osx-1014-x86_64
       roles:
       - agent

--- a/test/fixtures/generated/multiplatform/osx1015-64u-sles10-32-osx1015-64m
+++ b/test/fixtures/generated/multiplatform/osx1015-64u-sles10-32-osx1015-64m
@@ -4,34 +4,20 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     osx1015-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: osx-10.15-x86_64
-      packaging_platform: osx-10.15-x86_64
       template: osx-1015-x86_64
       hypervisor: vmpooler
       roles:
       - agent
       - ca
     sles10-32-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: sles-10-i386
       template: sles-10-i386
       hypervisor: vmpooler
       roles:
       - agent
     osx1015-64-2:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: osx-10.15-x86_64
-      packaging_platform: osx-10.15-x86_64
       template: osx-1015-x86_64
       hypervisor: vmpooler
       roles:

--- a/test/fixtures/generated/multiplatform/osx109-64aulcdfm-solaris10-SPARC-osx109-64a
+++ b/test/fixtures/generated/multiplatform/osx109-64aulcdfm-solaris10-SPARC-osx109-64a
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     osx109-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: osx-10.9-x86_64
       template: osx-109-x86_64
@@ -20,20 +16,11 @@ expected_hash:
       - frictionless
       - master
     solaris10-SPARC-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: solaris-10-sparc
-      packaging_platform: solaris-10-sparc
       roles:
       - agent
     osx109-64-2:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: osx-10.9-x86_64
       template: osx-109-x86_64

--- a/test/fixtures/generated/multiplatform/osx11-64f-redhat7-POWER-osx11-64l
+++ b/test/fixtures/generated/multiplatform/osx11-64f-redhat7-POWER-osx11-64l
@@ -4,35 +4,20 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     osx11-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: osx-11-x86_64
-      packaging_platform: osx-11-x86_64
       template: macos-112-x86_64
       hypervisor: vmpooler
       roles:
       - agent
       - frictionless
     redhat7-POWER-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: el-7-ppc64le
-      packaging_platform: el-7-ppc64le
       template: redhat-7-ppc64le
       hypervisor: vmpooler
       roles:
       - agent
     osx11-64-2:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: osx-11-x86_64
-      packaging_platform: osx-11-x86_64
       template: macos-112-x86_64
       hypervisor: vmpooler
       roles:

--- a/test/fixtures/generated/multiplatform/redhat4-32c-sles12-S390X-redhat4-32d
+++ b/test/fixtures/generated/multiplatform/redhat4-32c-sles12-S390X-redhat4-32d
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     redhat4-32-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: el-4-i386
       template: redhat-4-i386
@@ -15,20 +11,11 @@ expected_hash:
       - agent
       - dashboard
     sles12-S390X-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: sles-12-s390x
-      packaging_platform: sles-12-s390x
       roles:
       - agent
     redhat4-32-2:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: el-4-i386
       template: redhat-4-i386

--- a/test/fixtures/generated/multiplatform/redhat4-64d-sles12-64-redhat4-64c
+++ b/test/fixtures/generated/multiplatform/redhat4-64d-sles12-64-redhat4-64c
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     redhat4-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: el-4-x86_64
       template: redhat-4-x86_64
@@ -15,21 +11,12 @@ expected_hash:
       - agent
       - database
     sles12-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: sles-12-x86_64
-      packaging_platform: sles-12-x86_64
       template: sles-12-x86_64
       roles:
       - agent
     redhat4-64-2:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: el-4-x86_64
       template: redhat-4-x86_64

--- a/test/fixtures/generated/multiplatform/redhat5-32f-sles11-S390X-redhat5-32l
+++ b/test/fixtures/generated/multiplatform/redhat5-32f-sles11-S390X-redhat5-32l
@@ -4,35 +4,20 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     redhat5-32-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: el-5-i386
-      packaging_platform: el-5-i386
       template: redhat-5-i386
       roles:
       - agent
       - frictionless
     sles11-S390X-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: sles-11-s390x
-      packaging_platform: sles-11-s390x
       roles:
       - agent
     redhat5-32-2:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: el-5-i386
-      packaging_platform: el-5-i386
       template: redhat-5-i386
       roles:
       - agent

--- a/test/fixtures/generated/multiplatform/redhat5-64m-sles11-64-redhat5-64u
+++ b/test/fixtures/generated/multiplatform/redhat5-64m-sles11-64-redhat5-64u
@@ -4,36 +4,21 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     redhat5-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: el-5-x86_64
-      packaging_platform: el-5-x86_64
       template: redhat-5-x86_64
       roles:
       - agent
       - master
     sles11-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: sles-11-x86_64
-      packaging_platform: sles-11-x86_64
       template: sles-11-x86_64
       roles:
       - agent
     redhat5-64-2:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: el-5-x86_64
-      packaging_platform: el-5-x86_64
       template: redhat-5-x86_64
       roles:
       - agent

--- a/test/fixtures/generated/multiplatform/redhat6-32aulcdfm-sles11-32-redhat6-32a
+++ b/test/fixtures/generated/multiplatform/redhat6-32aulcdfm-sles11-32-redhat6-32a
@@ -4,13 +4,8 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     redhat6-32-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: el-6-i386
-      packaging_platform: el-6-i386
       template: redhat-6-i386
       roles:
       - agent
@@ -21,24 +16,14 @@ expected_hash:
       - frictionless
       - master
     sles11-32-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: sles-11-i386
-      packaging_platform: sles-11-i386
       template: sles-11-i386
       roles:
       - agent
     redhat6-32-2:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: el-6-i386
-      packaging_platform: el-6-i386
       template: redhat-6-i386
       roles:
       - agent

--- a/test/fixtures/generated/multiplatform/redhat6-64a-redhat8-AARCH64-redhat6-64aulcdfm
+++ b/test/fixtures/generated/multiplatform/redhat6-64a-redhat8-AARCH64-redhat6-64aulcdfm
@@ -4,34 +4,19 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     redhat6-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: el-6-x86_64
-      packaging_platform: el-6-x86_64
       template: redhat-6-x86_64
       hypervisor: vmpooler
       roles:
       - agent
     redhat8-AARCH64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: el-8-aarch64
-      packaging_platform: el-8-aarch64
       template: redhat-8-x86_64
       hypervisor: vmpooler
       roles:
       - agent
     redhat6-64-2:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: el-6-x86_64
-      packaging_platform: el-6-x86_64
       template: redhat-6-x86_64
       hypervisor: vmpooler
       roles:

--- a/test/fixtures/generated/multiplatform/redhat6-64a-sles10-64-redhat6-64aulcdfm
+++ b/test/fixtures/generated/multiplatform/redhat6-64a-sles10-64-redhat6-64aulcdfm
@@ -4,34 +4,20 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     redhat6-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: el-6-x86_64
-      packaging_platform: el-6-x86_64
       template: redhat-6-x86_64
       roles:
       - agent
     sles10-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: sles-10-x86_64
       template: sles-10-x86_64
       roles:
       - agent
     redhat6-64-2:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: el-6-x86_64
-      packaging_platform: el-6-x86_64
       template: redhat-6-x86_64
       roles:
       - agent

--- a/test/fixtures/generated/multiplatform/redhat6-64m-sles15-64-redhat6-64u
+++ b/test/fixtures/generated/multiplatform/redhat6-64m-sles15-64-redhat6-64u
@@ -4,36 +4,21 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     redhat6-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: el-6-x86_64
-      packaging_platform: el-6-x86_64
       template: redhat-6-x86_64
       roles:
       - agent
       - master
     sles15-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: sles-15-x86_64
-      packaging_platform: sles-15-x86_64
       template: sles-15-x86_64
       roles:
       - agent
     redhat6-64-2:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: el-6-x86_64
-      packaging_platform: el-6-x86_64
       template: redhat-6-x86_64
       roles:
       - agent

--- a/test/fixtures/generated/multiplatform/redhat7-64l-scientific7-64-redhat7-64f
+++ b/test/fixtures/generated/multiplatform/redhat7-64l-scientific7-64-redhat7-64f
@@ -4,36 +4,21 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     redhat7-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: el-7-x86_64
-      packaging_platform: el-7-x86_64
       template: redhat-7-x86_64
       roles:
       - agent
       - classifier
     scientific7-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: el-7-x86_64
-      packaging_platform: el-7-x86_64
       template: scientific-7-x86_64
       roles:
       - agent
     redhat7-64-2:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: el-7-x86_64
-      packaging_platform: el-7-x86_64
       template: redhat-7-x86_64
       roles:
       - agent

--- a/test/fixtures/generated/multiplatform/redhat7-AARCH64aulcdfm-redhat7-AARCH64-redhat7-AARCH64a
+++ b/test/fixtures/generated/multiplatform/redhat7-AARCH64aulcdfm-redhat7-AARCH64-redhat7-AARCH64a
@@ -4,13 +4,8 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     redhat7-AARCH64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: el-7-aarch64
-      packaging_platform: el-7-aarch64
       template: redhat-7-x86_64
       roles:
       - agent
@@ -21,24 +16,14 @@ expected_hash:
       - frictionless
       - master
     redhat7-AARCH64-2:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: el-7-aarch64
-      packaging_platform: el-7-aarch64
       template: redhat-7-x86_64
       roles:
       - agent
     redhat7-AARCH64-3:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: el-7-aarch64
-      packaging_platform: el-7-aarch64
       template: redhat-7-x86_64
       roles:
       - agent

--- a/test/fixtures/generated/multiplatform/redhat7-POWERaulcdfm-osx11-64-redhat7-POWERa
+++ b/test/fixtures/generated/multiplatform/redhat7-POWERaulcdfm-osx11-64-redhat7-POWERa
@@ -4,12 +4,7 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     redhat7-POWER-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: el-7-ppc64le
-      packaging_platform: el-7-ppc64le
       template: redhat-7-ppc64le
       hypervisor: vmpooler
       roles:
@@ -21,23 +16,13 @@ expected_hash:
       - frictionless
       - master
     osx11-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: osx-11-x86_64
-      packaging_platform: osx-11-x86_64
       template: macos-112-x86_64
       hypervisor: vmpooler
       roles:
       - agent
     redhat7-POWER-2:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: el-7-ppc64le
-      packaging_platform: el-7-ppc64le
       template: redhat-7-ppc64le
       hypervisor: vmpooler
       roles:

--- a/test/fixtures/generated/multiplatform/redhat7-POWERc-scientific6-64-redhat7-POWERd
+++ b/test/fixtures/generated/multiplatform/redhat7-POWERc-scientific6-64-redhat7-POWERd
@@ -4,36 +4,21 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     redhat7-POWER-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: el-7-ppc64le
-      packaging_platform: el-7-ppc64le
       template: redhat-7-ppc64le
       roles:
       - agent
       - dashboard
     scientific6-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: el-6-x86_64
-      packaging_platform: el-6-x86_64
       template: scientific-6-x86_64
       roles:
       - agent
     redhat7-POWER-2:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: el-7-ppc64le
-      packaging_platform: el-7-ppc64le
       template: redhat-7-ppc64le
       roles:
       - agent

--- a/test/fixtures/generated/multiplatform/redhat8-64u-sles11-32-redhat8-64m
+++ b/test/fixtures/generated/multiplatform/redhat8-64u-sles11-32-redhat8-64m
@@ -4,36 +4,21 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     redhat8-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: el-8-x86_64
-      packaging_platform: el-8-x86_64
       template: redhat-8-x86_64
       roles:
       - agent
       - ca
     sles11-32-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: sles-11-i386
-      packaging_platform: sles-11-i386
       template: sles-11-i386
       roles:
       - agent
     redhat8-64-2:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: el-8-x86_64
-      packaging_platform: el-8-x86_64
       template: redhat-8-x86_64
       roles:
       - agent

--- a/test/fixtures/generated/multiplatform/redhat8-AARCH64a-redhat6-64-redhat8-AARCH64aulcdfm
+++ b/test/fixtures/generated/multiplatform/redhat8-AARCH64a-redhat6-64-redhat8-AARCH64aulcdfm
@@ -4,34 +4,19 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     redhat8-AARCH64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: el-8-aarch64
-      packaging_platform: el-8-aarch64
       template: redhat-8-x86_64
       hypervisor: vmpooler
       roles:
       - agent
     redhat6-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: el-6-x86_64
-      packaging_platform: el-6-x86_64
       template: redhat-6-x86_64
       hypervisor: vmpooler
       roles:
       - agent
     redhat8-AARCH64-2:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: el-8-aarch64
-      packaging_platform: el-8-aarch64
       template: redhat-8-x86_64
       hypervisor: vmpooler
       roles:

--- a/test/fixtures/generated/multiplatform/redhat9-64l-cisco_ios_c4507r-HW-redhat9-64f
+++ b/test/fixtures/generated/multiplatform/redhat9-64l-cisco_ios_c4507r-HW-redhat9-64f
@@ -4,22 +4,13 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     redhat9-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: el-9-x86_64
-      packaging_platform: el-9-x86_64
       template: redhat-9-x86_64
       hypervisor: vmpooler
       roles:
       - agent
       - classifier
     cisco_ios_c4507r-HW-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: cisco_ios-12-arm32
       ssh:
         user: admin
@@ -27,12 +18,7 @@ expected_hash:
       roles:
       - agent
     redhat9-64-2:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: el-9-x86_64
-      packaging_platform: el-9-x86_64
       template: redhat-9-x86_64
       hypervisor: vmpooler
       roles:

--- a/test/fixtures/generated/multiplatform/redhatfips7-64aulcdfm-sles10-32-redhatfips7-64a
+++ b/test/fixtures/generated/multiplatform/redhatfips7-64aulcdfm-sles10-32-redhatfips7-64a
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     redhatfips7-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: el-7-x86_64
       packaging_platform: redhatfips-7-x86_64
@@ -21,20 +17,12 @@ expected_hash:
       - frictionless
       - master
     sles10-32-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: sles-10-i386
       template: sles-10-i386
       roles:
       - agent
     redhatfips7-64-2:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: el-7-x86_64
       packaging_platform: redhatfips-7-x86_64

--- a/test/fixtures/generated/multiplatform/redhatfips8-64m-cisco_ios_c4948-HW-redhatfips8-64u
+++ b/test/fixtures/generated/multiplatform/redhatfips8-64m-cisco_ios_c4948-HW-redhatfips8-64u
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     redhatfips8-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: el-8-x86_64
       packaging_platform: redhatfips-8-x86_64
       template: redhat-fips-8-x86_64
@@ -16,10 +12,6 @@ expected_hash:
       - agent
       - master
     cisco_ios_c4948-HW-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: cisco_ios-12-arm32
       ssh:
         user: admin
@@ -27,10 +19,6 @@ expected_hash:
       roles:
       - agent
     redhatfips8-64-2:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: el-8-x86_64
       packaging_platform: redhatfips-8-x86_64
       template: redhat-fips-8-x86_64

--- a/test/fixtures/generated/multiplatform/rocky8-64l-cisco_ios_c3560-HW-rocky8-64f
+++ b/test/fixtures/generated/multiplatform/rocky8-64l-cisco_ios_c3560-HW-rocky8-64f
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     rocky8-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: el-8-x86_64
       hypervisor: vmpooler
       template: rocky-8-x86_64
@@ -15,10 +11,6 @@ expected_hash:
       - agent
       - classifier
     cisco_ios_c3560-HW-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: cisco_ios-12-arm32
       ssh:
         user: admin
@@ -26,10 +18,6 @@ expected_hash:
       roles:
       - agent
     rocky8-64-2:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: el-8-x86_64
       hypervisor: vmpooler
       template: rocky-8-x86_64

--- a/test/fixtures/generated/multiplatform/scientific5-32f-scientific5-64-scientific5-32l
+++ b/test/fixtures/generated/multiplatform/scientific5-32f-scientific5-64-scientific5-32l
@@ -4,36 +4,21 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     scientific5-32-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: el-5-i386
-      packaging_platform: el-5-i386
       template: scientific-5-i386
       roles:
       - agent
       - frictionless
     scientific5-64-2:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: el-5-x86_64
-      packaging_platform: el-5-x86_64
       template: scientific-5-x86_64
       roles:
       - agent
     scientific5-32-3:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: el-5-i386
-      packaging_platform: el-5-i386
       template: scientific-5-i386
       roles:
       - agent

--- a/test/fixtures/generated/multiplatform/scientific5-64m-scientific5-32-scientific5-64u
+++ b/test/fixtures/generated/multiplatform/scientific5-64m-scientific5-32-scientific5-64u
@@ -4,36 +4,21 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     scientific5-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: el-5-x86_64
-      packaging_platform: el-5-x86_64
       template: scientific-5-x86_64
       roles:
       - agent
       - master
     scientific5-32-2:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: el-5-i386
-      packaging_platform: el-5-i386
       template: scientific-5-i386
       roles:
       - agent
     scientific5-64-3:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: el-5-x86_64
-      packaging_platform: el-5-x86_64
       template: scientific-5-x86_64
       roles:
       - agent

--- a/test/fixtures/generated/multiplatform/scientific6-64a-redhat7-POWER-scientific6-64aulcdfm
+++ b/test/fixtures/generated/multiplatform/scientific6-64a-redhat7-POWER-scientific6-64aulcdfm
@@ -4,35 +4,20 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     scientific6-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: el-6-x86_64
-      packaging_platform: el-6-x86_64
       template: scientific-6-x86_64
       roles:
       - agent
     redhat7-POWER-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: el-7-ppc64le
-      packaging_platform: el-7-ppc64le
       template: redhat-7-ppc64le
       roles:
       - agent
     scientific6-64-2:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: el-6-x86_64
-      packaging_platform: el-6-x86_64
       template: scientific-6-x86_64
       roles:
       - agent

--- a/test/fixtures/generated/multiplatform/scientific7-64u-redhat7-64-scientific7-64m
+++ b/test/fixtures/generated/multiplatform/scientific7-64u-redhat7-64-scientific7-64m
@@ -4,36 +4,21 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     scientific7-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: el-7-x86_64
-      packaging_platform: el-7-x86_64
       template: scientific-7-x86_64
       roles:
       - agent
       - ca
     redhat7-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: el-7-x86_64
-      packaging_platform: el-7-x86_64
       template: redhat-7-x86_64
       roles:
       - agent
     scientific7-64-2:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: el-7-x86_64
-      packaging_platform: el-7-x86_64
       template: scientific-7-x86_64
       roles:
       - agent

--- a/test/fixtures/generated/multiplatform/sles10-32a-redhatfips7-64-sles10-32aulcdfm
+++ b/test/fixtures/generated/multiplatform/sles10-32a-redhatfips7-64-sles10-32aulcdfm
@@ -4,20 +4,12 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     sles10-32-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: sles-10-i386
       template: sles-10-i386
       roles:
       - agent
     redhatfips7-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: el-7-x86_64
       packaging_platform: redhatfips-7-x86_64
@@ -25,10 +17,6 @@ expected_hash:
       roles:
       - agent
     sles10-32-2:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: sles-10-i386
       template: sles-10-i386

--- a/test/fixtures/generated/multiplatform/sles10-32d-osx1015-64-sles10-32c
+++ b/test/fixtures/generated/multiplatform/sles10-32d-osx1015-64-sles10-32c
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     sles10-32-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: sles-10-i386
       template: sles-10-i386
       hypervisor: vmpooler
@@ -15,21 +11,12 @@ expected_hash:
       - agent
       - database
     osx1015-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: osx-10.15-x86_64
-      packaging_platform: osx-10.15-x86_64
       template: osx-1015-x86_64
       hypervisor: vmpooler
       roles:
       - agent
     sles10-32-2:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: sles-10-i386
       template: sles-10-i386
       hypervisor: vmpooler

--- a/test/fixtures/generated/multiplatform/sles10-64c-redhat6-64-sles10-64d
+++ b/test/fixtures/generated/multiplatform/sles10-64c-redhat6-64-sles10-64d
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     sles10-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: sles-10-x86_64
       template: sles-10-x86_64
@@ -15,21 +11,12 @@ expected_hash:
       - agent
       - dashboard
     redhat6-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: el-6-x86_64
-      packaging_platform: el-6-x86_64
       template: redhat-6-x86_64
       roles:
       - agent
     sles10-64-2:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: sles-10-x86_64
       template: sles-10-x86_64

--- a/test/fixtures/generated/multiplatform/sles11-32d-redhat6-32-sles11-32c
+++ b/test/fixtures/generated/multiplatform/sles11-32d-redhat6-32-sles11-32c
@@ -4,36 +4,21 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     sles11-32-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: sles-11-i386
-      packaging_platform: sles-11-i386
       template: sles-11-i386
       roles:
       - agent
       - database
     redhat6-32-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: el-6-i386
-      packaging_platform: el-6-i386
       template: redhat-6-i386
       roles:
       - agent
     sles11-32-2:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: sles-11-i386
-      packaging_platform: sles-11-i386
       template: sles-11-i386
       roles:
       - agent

--- a/test/fixtures/generated/multiplatform/sles11-32u-redhat8-64-sles11-32m
+++ b/test/fixtures/generated/multiplatform/sles11-32u-redhat8-64-sles11-32m
@@ -4,36 +4,21 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     sles11-32-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: sles-11-i386
-      packaging_platform: sles-11-i386
       template: sles-11-i386
       roles:
       - agent
       - ca
     redhat8-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: el-8-x86_64
-      packaging_platform: el-8-x86_64
       template: redhat-8-x86_64
       roles:
       - agent
     sles11-32-2:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: sles-11-i386
-      packaging_platform: sles-11-i386
       template: sles-11-i386
       roles:
       - agent

--- a/test/fixtures/generated/multiplatform/sles11-64f-redhat5-64-sles11-64l
+++ b/test/fixtures/generated/multiplatform/sles11-64f-redhat5-64-sles11-64l
@@ -4,36 +4,21 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     sles11-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: sles-11-x86_64
-      packaging_platform: sles-11-x86_64
       template: sles-11-x86_64
       roles:
       - agent
       - frictionless
     redhat5-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: el-5-x86_64
-      packaging_platform: el-5-x86_64
       template: redhat-5-x86_64
       roles:
       - agent
     sles11-64-2:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: sles-11-x86_64
-      packaging_platform: sles-11-x86_64
       template: sles-11-x86_64
       roles:
       - agent

--- a/test/fixtures/generated/multiplatform/sles11-S390Xm-redhat5-32-sles11-S390Xu
+++ b/test/fixtures/generated/multiplatform/sles11-S390Xm-redhat5-32-sles11-S390Xu
@@ -4,35 +4,20 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     sles11-S390X-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: sles-11-s390x
-      packaging_platform: sles-11-s390x
       roles:
       - agent
       - master
     redhat5-32-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: el-5-i386
-      packaging_platform: el-5-i386
       template: redhat-5-i386
       roles:
       - agent
     sles11-S390X-2:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: sles-11-s390x
-      packaging_platform: sles-11-s390x
       roles:
       - agent
       - ca

--- a/test/fixtures/generated/multiplatform/sles11-S390Xu-osx1013-64-sles11-S390Xm
+++ b/test/fixtures/generated/multiplatform/sles11-S390Xu-osx1013-64-sles11-S390Xm
@@ -4,35 +4,20 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     sles11-S390X-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: sles-11-s390x
-      packaging_platform: sles-11-s390x
       roles:
       - agent
       - ca
     osx1013-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: osx-10.13-x86_64
-      packaging_platform: osx-10.13-x86_64
       template: osx-1013-x86_64
       roles:
       - agent
     sles11-S390X-2:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: sles-11-s390x
-      packaging_platform: sles-11-s390x
       roles:
       - agent
       - master

--- a/test/fixtures/generated/multiplatform/sles12-64aulcdfm-redhat4-64-sles12-64a
+++ b/test/fixtures/generated/multiplatform/sles12-64aulcdfm-redhat4-64-sles12-64a
@@ -4,13 +4,8 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     sles12-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: sles-12-x86_64
-      packaging_platform: sles-12-x86_64
       template: sles-12-x86_64
       roles:
       - agent
@@ -21,23 +16,14 @@ expected_hash:
       - frictionless
       - master
     redhat4-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: el-4-x86_64
       template: redhat-4-x86_64
       roles:
       - agent
     sles12-64-2:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: sles-12-x86_64
-      packaging_platform: sles-12-x86_64
       template: sles-12-x86_64
       roles:
       - agent

--- a/test/fixtures/generated/multiplatform/sles12-POWERu-osx1012-64-sles12-POWERm
+++ b/test/fixtures/generated/multiplatform/sles12-POWERu-osx1012-64-sles12-POWERm
@@ -4,35 +4,20 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     sles12-POWER-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: sles-12-ppc64le
-      packaging_platform: sles-12-ppc64le
       roles:
       - agent
       - ca
     osx1012-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: osx-10.12-x86_64
-      packaging_platform: osx-10.12-x86_64
       template: osx-1012-x86_64
       roles:
       - agent
     sles12-POWER-2:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: sles-12-ppc64le
-      packaging_platform: sles-12-ppc64le
       roles:
       - agent
       - master

--- a/test/fixtures/generated/multiplatform/sles12-S390Xa-redhat4-32-sles12-S390Xaulcdfm
+++ b/test/fixtures/generated/multiplatform/sles12-S390Xa-redhat4-32-sles12-S390Xaulcdfm
@@ -4,33 +4,19 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     sles12-S390X-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: sles-12-s390x
-      packaging_platform: sles-12-s390x
       roles:
       - agent
     redhat4-32-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: el-4-i386
       template: redhat-4-i386
       roles:
       - agent
     sles12-S390X-2:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: sles-12-s390x
-      packaging_platform: sles-12-s390x
       roles:
       - agent
       - ca

--- a/test/fixtures/generated/multiplatform/sles15-64l-redhat6-64-sles15-64f
+++ b/test/fixtures/generated/multiplatform/sles15-64l-redhat6-64-sles15-64f
@@ -4,36 +4,21 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     sles15-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: sles-15-x86_64
-      packaging_platform: sles-15-x86_64
       template: sles-15-x86_64
       roles:
       - agent
       - classifier
     redhat6-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: el-6-x86_64
-      packaging_platform: el-6-x86_64
       template: redhat-6-x86_64
       roles:
       - agent
     sles15-64-2:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: sles-15-x86_64
-      packaging_platform: sles-15-x86_64
       template: sles-15-x86_64
       roles:
       - agent

--- a/test/fixtures/generated/multiplatform/solaris10-32l-osx1011-64-solaris10-32f
+++ b/test/fixtures/generated/multiplatform/solaris10-32l-osx1011-64-solaris10-32f
@@ -4,36 +4,21 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     solaris10-32-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: solaris-10-i386
-      packaging_platform: solaris-10-i386
       template: solaris-10-x86_64
       roles:
       - agent
       - classifier
     osx1011-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: osx-10.11-x86_64
-      packaging_platform: osx-10.11-x86_64
       template: osx-1011-x86_64
       roles:
       - agent
     solaris10-32-2:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: solaris-10-i386
-      packaging_platform: solaris-10-i386
       template: solaris-10-x86_64
       roles:
       - agent

--- a/test/fixtures/generated/multiplatform/solaris10-64c-osx1010-64-solaris10-64d
+++ b/test/fixtures/generated/multiplatform/solaris10-64c-osx1010-64-solaris10-64d
@@ -4,36 +4,21 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     solaris10-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: solaris-10-i386
-      packaging_platform: solaris-10-i386
       template: solaris-10-x86_64
       roles:
       - agent
       - dashboard
     osx1010-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: osx-10.10-x86_64
-      packaging_platform: osx-10.10-x86_64
       template: osx-1010-x86_64
       roles:
       - agent
     solaris10-64-2:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: solaris-10-i386
-      packaging_platform: solaris-10-i386
       template: solaris-10-x86_64
       roles:
       - agent

--- a/test/fixtures/generated/multiplatform/solaris10-SPARCd-osx109-64-solaris10-SPARCc
+++ b/test/fixtures/generated/multiplatform/solaris10-SPARCd-osx109-64-solaris10-SPARCc
@@ -4,34 +4,20 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     solaris10-SPARC-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: solaris-10-sparc
-      packaging_platform: solaris-10-sparc
       roles:
       - agent
       - database
     osx109-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: osx-10.9-x86_64
       template: osx-109-x86_64
       roles:
       - agent
     solaris10-SPARC-2:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: solaris-10-sparc
-      packaging_platform: solaris-10-sparc
       roles:
       - agent
       - dashboard

--- a/test/fixtures/generated/multiplatform/solaris11-32f-oracle7-64-solaris11-32l
+++ b/test/fixtures/generated/multiplatform/solaris11-32f-oracle7-64-solaris11-32l
@@ -4,36 +4,21 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     solaris11-32-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: solaris-11-i386
-      packaging_platform: solaris-11-i386
       template: solaris-11-x86_64
       roles:
       - agent
       - frictionless
     oracle7-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: el-7-x86_64
-      packaging_platform: el-7-x86_64
       template: oracle-7-x86_64
       roles:
       - agent
     solaris11-32-2:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: solaris-11-i386
-      packaging_platform: solaris-11-i386
       template: solaris-11-x86_64
       roles:
       - agent

--- a/test/fixtures/generated/multiplatform/solaris11-64a-debian11-64-solaris11-64aulcdfm
+++ b/test/fixtures/generated/multiplatform/solaris11-64a-debian11-64-solaris11-64aulcdfm
@@ -4,34 +4,19 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     solaris11-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: solaris-11-i386
-      packaging_platform: solaris-11-i386
       template: solaris-11-x86_64
       hypervisor: vmpooler
       roles:
       - agent
     debian11-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: debian-11-amd64
-      packaging_platform: debian-11-amd64
       template: debian-11-x86_64
       hypervisor: vmpooler
       roles:
       - agent
     solaris11-64-2:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: solaris-11-i386
-      packaging_platform: solaris-11-i386
       template: solaris-11-x86_64
       hypervisor: vmpooler
       roles:

--- a/test/fixtures/generated/multiplatform/solaris11-64m-oracle6-64-solaris11-64u
+++ b/test/fixtures/generated/multiplatform/solaris11-64m-oracle6-64-solaris11-64u
@@ -4,36 +4,21 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     solaris11-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: solaris-11-i386
-      packaging_platform: solaris-11-i386
       template: solaris-11-x86_64
       roles:
       - agent
       - master
     oracle6-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: el-6-x86_64
-      packaging_platform: el-6-x86_64
       template: oracle-6-x86_64
       roles:
       - agent
     solaris11-64-2:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: solaris-11-i386
-      packaging_platform: solaris-11-i386
       template: solaris-11-x86_64
       roles:
       - agent

--- a/test/fixtures/generated/multiplatform/solaris11-SPARCaulcdfm-oracle6-32-solaris11-SPARCa
+++ b/test/fixtures/generated/multiplatform/solaris11-SPARCaulcdfm-oracle6-32-solaris11-SPARCa
@@ -4,13 +4,8 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     solaris11-SPARC-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: solaris-11-sparc
-      packaging_platform: solaris-11-sparc
       roles:
       - agent
       - ca
@@ -20,24 +15,14 @@ expected_hash:
       - frictionless
       - master
     oracle6-32-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: el-6-i386
-      packaging_platform: el-6-i386
       template: oracle-6-i386
       roles:
       - agent
     solaris11-SPARC-2:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: solaris-11-sparc
-      packaging_platform: solaris-11-sparc
       roles:
       - agent
   CONFIG:

--- a/test/fixtures/generated/multiplatform/solaris112-32a-oracle5-64-solaris112-32aulcdfm
+++ b/test/fixtures/generated/multiplatform/solaris112-32a-oracle5-64-solaris112-32aulcdfm
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     solaris112-32-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: solaris-11.2-i386
       packaging_platform: solaris-11-i386
@@ -15,21 +11,12 @@ expected_hash:
       roles:
       - agent
     oracle5-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: el-5-x86_64
-      packaging_platform: el-5-x86_64
       template: oracle-5-x86_64
       roles:
       - agent
     solaris112-32-2:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: solaris-11.2-i386
       packaging_platform: solaris-11-i386

--- a/test/fixtures/generated/multiplatform/solaris112-32aulcdfm-almalinux8-64-solaris112-32a
+++ b/test/fixtures/generated/multiplatform/solaris112-32aulcdfm-almalinux8-64-solaris112-32a
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     solaris112-32-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: solaris-11.2-i386
       packaging_platform: solaris-11-i386
       template: solaris-112-x86_64
@@ -21,20 +17,12 @@ expected_hash:
       - frictionless
       - master
     almalinux8-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: el-8-x86_64
       hypervisor: vmpooler
       template: almalinux-8-x86_64
       roles:
       - agent
     solaris112-32-2:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: solaris-11.2-i386
       packaging_platform: solaris-11-i386
       template: solaris-112-x86_64

--- a/test/fixtures/generated/multiplatform/solaris112-64u-oracle5-32-solaris112-64m
+++ b/test/fixtures/generated/multiplatform/solaris112-64u-oracle5-32-solaris112-64m
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     solaris112-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: solaris-11.2-i386
       packaging_platform: solaris-11-i386
@@ -16,21 +12,12 @@ expected_hash:
       - agent
       - ca
     oracle5-32-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: el-5-i386
-      packaging_platform: el-5-i386
       template: oracle-5-i386
       roles:
       - agent
     solaris112-64-2:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: solaris-11.2-i386
       packaging_platform: solaris-11-i386

--- a/test/fixtures/generated/multiplatform/solaris114-64aulcdfm-fedora32-64-solaris114-64a
+++ b/test/fixtures/generated/multiplatform/solaris114-64aulcdfm-fedora32-64-solaris114-64a
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     solaris114-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: solaris-11.4-i386
       packaging_platform: solaris-11-i386
       template: solaris-114-x86_64
@@ -21,20 +17,12 @@ expected_hash:
       - frictionless
       - master
     fedora32-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: fedora-32-x86_64
       template: fedora-32-x86_64
       hypervisor: vmpooler
       roles:
       - agent
     solaris114-64-2:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: solaris-11.4-i386
       packaging_platform: solaris-11-i386
       template: solaris-114-x86_64

--- a/test/fixtures/generated/multiplatform/solaris114-64f-fedora31-64-solaris114-64l
+++ b/test/fixtures/generated/multiplatform/solaris114-64f-fedora31-64-solaris114-64l
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     solaris114-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: solaris-11.4-i386
       packaging_platform: solaris-11-i386
       template: solaris-114-x86_64
@@ -16,20 +12,12 @@ expected_hash:
       - agent
       - frictionless
     fedora31-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: fedora-31-x86_64
       template: fedora-31-x86_64
       hypervisor: vmpooler
       roles:
       - agent
     solaris114-64-2:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: solaris-11.4-i386
       packaging_platform: solaris-11-i386
       template: solaris-114-x86_64

--- a/test/fixtures/generated/multiplatform/ubuntu1404-32d-windows2012r2_ja-6432-ubuntu1404-32c
+++ b/test/fixtures/generated/multiplatform/ubuntu1404-32d-windows2012r2_ja-6432-ubuntu1404-32c
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     ubuntu1404-32-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: ubuntu-14.04-i386
       hypervisor: vmpooler
       template: ubuntu-1404-i386
@@ -15,10 +11,6 @@ expected_hash:
       - agent
       - database
     windows2012r2_ja-6432-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: windows-2012r2-64
       packaging_platform: windows-2012-x64
       ruby_arch: x86
@@ -28,10 +20,6 @@ expected_hash:
       roles:
       - agent
     ubuntu1404-32-2:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: ubuntu-14.04-i386
       hypervisor: vmpooler
       template: ubuntu-1404-i386

--- a/test/fixtures/generated/multiplatform/ubuntu1404-32m-fedora25-64-ubuntu1404-32u
+++ b/test/fixtures/generated/multiplatform/ubuntu1404-32m-fedora25-64-ubuntu1404-32u
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     ubuntu1404-32-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: ubuntu-14.04-i386
       template: ubuntu-1404-i386
@@ -15,20 +11,12 @@ expected_hash:
       - agent
       - master
     fedora25-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: fedora-25-x86_64
       template: fedora-25-x86_64
       roles:
       - agent
     ubuntu1404-32-2:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: ubuntu-14.04-i386
       template: ubuntu-1404-i386

--- a/test/fixtures/generated/multiplatform/ubuntu1404-64a-fedora28-64-ubuntu1404-64aulcdfm
+++ b/test/fixtures/generated/multiplatform/ubuntu1404-64a-fedora28-64-ubuntu1404-64aulcdfm
@@ -4,30 +4,18 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     ubuntu1404-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: ubuntu-14.04-amd64
       template: ubuntu-1404-x86_64
       roles:
       - agent
     fedora28-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: fedora-28-x86_64
       template: fedora-28-x86_64
       roles:
       - agent
     ubuntu1404-64-2:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: ubuntu-14.04-amd64
       template: ubuntu-1404-x86_64

--- a/test/fixtures/generated/multiplatform/ubuntu1404-64aulcdfm-fedora25-32-ubuntu1404-64a
+++ b/test/fixtures/generated/multiplatform/ubuntu1404-64aulcdfm-fedora25-32-ubuntu1404-64a
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     ubuntu1404-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: ubuntu-14.04-amd64
       template: ubuntu-1404-x86_64
@@ -20,20 +16,12 @@ expected_hash:
       - frictionless
       - master
     fedora25-32-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: fedora-25-i386
       template: fedora-25-i386
       roles:
       - agent
     ubuntu1404-64-2:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: ubuntu-14.04-amd64
       template: ubuntu-1404-x86_64

--- a/test/fixtures/generated/multiplatform/ubuntu1404-64f-windows2012r2_ja-64-ubuntu1404-64l
+++ b/test/fixtures/generated/multiplatform/ubuntu1404-64f-windows2012r2_ja-64-ubuntu1404-64l
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     ubuntu1404-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: ubuntu-14.04-amd64
       hypervisor: vmpooler
       template: ubuntu-1404-x86_64
@@ -15,10 +11,6 @@ expected_hash:
       - agent
       - frictionless
     windows2012r2_ja-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: windows-2012r2-64
       packaging_platform: windows-2012-x64
       ruby_arch: x64
@@ -28,10 +20,6 @@ expected_hash:
       roles:
       - agent
     ubuntu1404-64-2:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: ubuntu-14.04-amd64
       hypervisor: vmpooler
       template: ubuntu-1404-x86_64

--- a/test/fixtures/generated/multiplatform/ubuntu1404-64m-fedora27-64-ubuntu1404-64u
+++ b/test/fixtures/generated/multiplatform/ubuntu1404-64m-fedora27-64-ubuntu1404-64u
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     ubuntu1404-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: ubuntu-14.04-amd64
       template: ubuntu-1404-x86_64
@@ -15,20 +11,12 @@ expected_hash:
       - agent
       - master
     fedora27-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: fedora-27-x86_64
       template: fedora-27-x86_64
       roles:
       - agent
     ubuntu1404-64-2:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: ubuntu-14.04-amd64
       template: ubuntu-1404-x86_64

--- a/test/fixtures/generated/multiplatform/ubuntu1404-AARCH64aulcdfm-windows2012r2-6432-ubuntu1404-AARCH64a
+++ b/test/fixtures/generated/multiplatform/ubuntu1404-AARCH64aulcdfm-windows2012r2-6432-ubuntu1404-AARCH64a
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     ubuntu1404-AARCH64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: ubuntu-14.04-aarch64
       hypervisor: vmpooler
       roles:
@@ -19,10 +15,6 @@ expected_hash:
       - frictionless
       - master
     windows2012r2-6432-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: windows-2012r2-64
       packaging_platform: windows-2012-x64
       ruby_arch: x86
@@ -31,10 +23,6 @@ expected_hash:
       roles:
       - agent
     ubuntu1404-AARCH64-2:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: ubuntu-14.04-aarch64
       hypervisor: vmpooler
       roles:

--- a/test/fixtures/generated/multiplatform/ubuntu1404-POWERm-windows2012r2_wmf5-64-ubuntu1404-POWERu
+++ b/test/fixtures/generated/multiplatform/ubuntu1404-POWERm-windows2012r2_wmf5-64-ubuntu1404-POWERu
@@ -4,20 +4,12 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     ubuntu1404-POWER-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: ubuntu-14.04-ppc64el
       hypervisor: vmpooler
       roles:
       - agent
       - master
     windows2012r2_wmf5-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: windows-2012r2-64
       packaging_platform: windows-2012-x64
       ruby_arch: x64
@@ -26,10 +18,6 @@ expected_hash:
       roles:
       - agent
     ubuntu1404-POWER-2:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: ubuntu-14.04-ppc64el
       hypervisor: vmpooler
       roles:

--- a/test/fixtures/generated/multiplatform/ubuntu1604-32a-windowsfips2012r2-6432-ubuntu1604-32aulcdfm
+++ b/test/fixtures/generated/multiplatform/ubuntu1604-32a-windowsfips2012r2-6432-ubuntu1604-32aulcdfm
@@ -4,20 +4,12 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     ubuntu1604-32-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: ubuntu-16.04-i386
       hypervisor: vmpooler
       template: ubuntu-1604-i386
       roles:
       - agent
     windowsfips2012r2-6432-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: windows-2012r2-64
       packaging_platform: windowsfips-2012-x64
       ruby_arch: x64
@@ -26,10 +18,6 @@ expected_hash:
       roles:
       - agent
     ubuntu1604-32-2:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: ubuntu-16.04-i386
       hypervisor: vmpooler
       template: ubuntu-1604-i386

--- a/test/fixtures/generated/multiplatform/ubuntu1604-32d-fedora22-64-ubuntu1604-32c
+++ b/test/fixtures/generated/multiplatform/ubuntu1604-32d-fedora22-64-ubuntu1604-32c
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     ubuntu1604-32-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: ubuntu-16.04-i386
       template: ubuntu-1604-i386
@@ -15,20 +11,12 @@ expected_hash:
       - agent
       - database
     fedora22-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: fedora-22-x86_64
       template: fedora-22-x86_64
       roles:
       - agent
     ubuntu1604-32-2:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: ubuntu-16.04-i386
       template: ubuntu-1604-i386

--- a/test/fixtures/generated/multiplatform/ubuntu1604-64f-fedora22-32-ubuntu1604-64l
+++ b/test/fixtures/generated/multiplatform/ubuntu1604-64f-fedora22-32-ubuntu1604-64l
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     ubuntu1604-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: ubuntu-16.04-amd64
       template: ubuntu-1604-x86_64
@@ -15,20 +11,12 @@ expected_hash:
       - agent
       - frictionless
     fedora22-32-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: fedora-22-i386
       template: fedora-22-i386
       roles:
       - agent
     ubuntu1604-64-2:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: ubuntu-16.04-amd64
       template: ubuntu-1604-x86_64

--- a/test/fixtures/generated/multiplatform/ubuntu1604-64u-windowsfips2012r2-64-ubuntu1604-64m
+++ b/test/fixtures/generated/multiplatform/ubuntu1604-64u-windowsfips2012r2-64-ubuntu1604-64m
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     ubuntu1604-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: ubuntu-16.04-amd64
       hypervisor: vmpooler
       template: ubuntu-1604-x86_64
@@ -15,10 +11,6 @@ expected_hash:
       - agent
       - ca
     windowsfips2012r2-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: windows-2012r2-64
       packaging_platform: windowsfips-2012-x64
       ruby_arch: x64
@@ -27,10 +19,6 @@ expected_hash:
       roles:
       - agent
     ubuntu1604-64-2:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: ubuntu-16.04-amd64
       hypervisor: vmpooler
       template: ubuntu-1604-x86_64

--- a/test/fixtures/generated/multiplatform/ubuntu1604-AARCH64c-windows2012-6432-ubuntu1604-AARCH64d
+++ b/test/fixtures/generated/multiplatform/ubuntu1604-AARCH64c-windows2012-6432-ubuntu1604-AARCH64d
@@ -4,20 +4,12 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     ubuntu1604-AARCH64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: ubuntu-16.04-aarch64
       hypervisor: vmpooler
       roles:
       - agent
       - dashboard
     windows2012-6432-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: windows-2012-64
       packaging_platform: windows-2012-x64
       ruby_arch: x86
@@ -26,10 +18,6 @@ expected_hash:
       roles:
       - agent
     ubuntu1604-AARCH64-2:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: ubuntu-16.04-aarch64
       hypervisor: vmpooler
       roles:

--- a/test/fixtures/generated/multiplatform/ubuntu1604-POWERf-fedora29-64-ubuntu1604-POWERl
+++ b/test/fixtures/generated/multiplatform/ubuntu1604-POWERf-fedora29-64-ubuntu1604-POWERl
@@ -4,30 +4,18 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     ubuntu1604-POWER-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: ubuntu-16.04-ppc64el
       roles:
       - agent
       - frictionless
     fedora29-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: fedora-29-x86_64
       template: fedora-29-x86_64
       roles:
       - agent
     ubuntu1604-POWER-2:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: ubuntu-16.04-ppc64el
       roles:

--- a/test/fixtures/generated/multiplatform/ubuntu1604-POWERl-windows2012r2-64-ubuntu1604-POWERf
+++ b/test/fixtures/generated/multiplatform/ubuntu1604-POWERl-windows2012r2-64-ubuntu1604-POWERf
@@ -4,20 +4,12 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     ubuntu1604-POWER-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: ubuntu-16.04-ppc64el
       hypervisor: vmpooler
       roles:
       - agent
       - classifier
     windows2012r2-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: windows-2012r2-64
       packaging_platform: windows-2012-x64
       ruby_arch: x64
@@ -26,10 +18,6 @@ expected_hash:
       roles:
       - agent
     ubuntu1604-POWER-2:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: ubuntu-16.04-ppc64el
       hypervisor: vmpooler
       roles:

--- a/test/fixtures/generated/multiplatform/ubuntu1604-POWERm-fedora21-64-ubuntu1604-POWERu
+++ b/test/fixtures/generated/multiplatform/ubuntu1604-POWERm-fedora21-64-ubuntu1604-POWERu
@@ -4,30 +4,18 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     ubuntu1604-POWER-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: ubuntu-16.04-ppc64el
       roles:
       - agent
       - master
     fedora21-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: fedora-21-x86_64
       template: fedora-21-x86_64
       roles:
       - agent
     ubuntu1604-POWER-2:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: ubuntu-16.04-ppc64el
       roles:

--- a/test/fixtures/generated/multiplatform/ubuntu1804-64a-fedora22-32-ubuntu1804-64aulcdfm
+++ b/test/fixtures/generated/multiplatform/ubuntu1804-64a-fedora22-32-ubuntu1804-64aulcdfm
@@ -4,30 +4,18 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     ubuntu1804-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: ubuntu-18.04-amd64
       template: ubuntu-1804-x86_64
       roles:
       - agent
     fedora22-32-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: fedora-22-i386
       template: fedora-22-i386
       roles:
       - agent
     ubuntu1804-64-2:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: ubuntu-18.04-amd64
       template: ubuntu-1804-x86_64

--- a/test/fixtures/generated/multiplatform/ubuntu1804-64d-windows2012-64-ubuntu1804-64c
+++ b/test/fixtures/generated/multiplatform/ubuntu1804-64d-windows2012-64-ubuntu1804-64c
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     ubuntu1804-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: ubuntu-18.04-amd64
       hypervisor: vmpooler
       template: ubuntu-1804-x86_64
@@ -15,10 +11,6 @@ expected_hash:
       - agent
       - database
     windows2012-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: windows-2012-64
       packaging_platform: windows-2012-x64
       ruby_arch: x64
@@ -27,10 +19,6 @@ expected_hash:
       roles:
       - agent
     ubuntu1804-64-2:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: ubuntu-18.04-amd64
       hypervisor: vmpooler
       template: ubuntu-1804-x86_64

--- a/test/fixtures/generated/multiplatform/ubuntu1804-AARCH64m-windows2008r2-64-ubuntu1804-AARCH64u
+++ b/test/fixtures/generated/multiplatform/ubuntu1804-AARCH64m-windows2008r2-64-ubuntu1804-AARCH64u
@@ -4,20 +4,12 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     ubuntu1804-AARCH64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: ubuntu-18.04-aarch64
       hypervisor: vmpooler
       roles:
       - agent
       - master
     windows2008r2-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: windows-2008r2-64
       packaging_platform: windows-2012-x64
       ruby_arch: x64
@@ -26,10 +18,6 @@ expected_hash:
       roles:
       - agent
     ubuntu1804-AARCH64-2:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: ubuntu-18.04-aarch64
       hypervisor: vmpooler
       roles:

--- a/test/fixtures/generated/multiplatform/ubuntu1804-POWERf-windows2008r2-6432-ubuntu1804-POWERl
+++ b/test/fixtures/generated/multiplatform/ubuntu1804-POWERf-windows2008r2-6432-ubuntu1804-POWERl
@@ -4,20 +4,12 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     ubuntu1804-POWER-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: ubuntu-18.04-ppc64el
       hypervisor: vmpooler
       roles:
       - agent
       - frictionless
     windows2008r2-6432-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: windows-2008r2-64
       packaging_platform: windows-2012-x64
       ruby_arch: x86
@@ -26,10 +18,6 @@ expected_hash:
       roles:
       - agent
     ubuntu1804-POWER-2:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: ubuntu-18.04-ppc64el
       hypervisor: vmpooler
       roles:

--- a/test/fixtures/generated/multiplatform/ubuntu2004-64a-fedora20-32-ubuntu2004-64aulcdfm
+++ b/test/fixtures/generated/multiplatform/ubuntu2004-64a-fedora20-32-ubuntu2004-64aulcdfm
@@ -4,30 +4,18 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     ubuntu2004-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: ubuntu-20.04-amd64
       template: ubuntu-2004-x86_64
       hypervisor: vmpooler
       roles:
       - agent
     fedora20-32-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: fedora-20-i386
       template: fedora-20-i386
       hypervisor: vmpooler
       roles:
       - agent
     ubuntu2004-64-2:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: ubuntu-20.04-amd64
       template: ubuntu-2004-x86_64
       hypervisor: vmpooler

--- a/test/fixtures/generated/multiplatform/ubuntu2004-64aulcdfm-windows2008-6432-ubuntu2004-64a
+++ b/test/fixtures/generated/multiplatform/ubuntu2004-64aulcdfm-windows2008-6432-ubuntu2004-64a
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     ubuntu2004-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: ubuntu-20.04-amd64
       hypervisor: vmpooler
       template: ubuntu-2004-x86_64
@@ -20,10 +16,6 @@ expected_hash:
       - frictionless
       - master
     windows2008-6432-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: windows-2008-64
       packaging_platform: windows-2012-x64
       ruby_arch: x86
@@ -32,10 +24,6 @@ expected_hash:
       roles:
       - agent
     ubuntu2004-64-2:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: ubuntu-20.04-amd64
       hypervisor: vmpooler
       template: ubuntu-2004-x86_64

--- a/test/fixtures/generated/multiplatform/ubuntu2004-AARCH64c-fedora20-32-ubuntu2004-AARCH64d
+++ b/test/fixtures/generated/multiplatform/ubuntu2004-AARCH64c-fedora20-32-ubuntu2004-AARCH64d
@@ -4,30 +4,18 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     ubuntu2004-AARCH64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: ubuntu-20.04-aarch64
       hypervisor: vmpooler
       roles:
       - agent
       - dashboard
     fedora20-32-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: fedora-20-i386
       template: fedora-20-i386
       hypervisor: vmpooler
       roles:
       - agent
     ubuntu2004-AARCH64-2:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: ubuntu-20.04-aarch64
       hypervisor: vmpooler
       roles:

--- a/test/fixtures/generated/multiplatform/ubuntu2004-AARCH64u-vro74-64-ubuntu2004-AARCH64m
+++ b/test/fixtures/generated/multiplatform/ubuntu2004-AARCH64u-vro74-64-ubuntu2004-AARCH64m
@@ -4,31 +4,18 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     ubuntu2004-AARCH64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: ubuntu-20.04-aarch64
       hypervisor: vmpooler
       roles:
       - agent
       - ca
     vro74-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: sles-11-x86_64
-      packaging_platform: sles-11-x86_64
       template: vro-74-x86_64
       hypervisor: vmpooler
       roles:
       - agent
     ubuntu2004-AARCH64-2:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: ubuntu-20.04-aarch64
       hypervisor: vmpooler
       roles:

--- a/test/fixtures/generated/multiplatform/ubuntu2004-POWERa-windows2008-64-ubuntu2004-POWERaulcdfm
+++ b/test/fixtures/generated/multiplatform/ubuntu2004-POWERa-windows2008-64-ubuntu2004-POWERaulcdfm
@@ -4,19 +4,11 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     ubuntu2004-POWER-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: ubuntu-20.04-ppc64el
       hypervisor: vmpooler
       roles:
       - agent
     windows2008-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: windows-2008-64
       packaging_platform: windows-2012-x64
       ruby_arch: x64
@@ -25,10 +17,6 @@ expected_hash:
       roles:
       - agent
     ubuntu2004-POWER-2:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: ubuntu-20.04-ppc64el
       hypervisor: vmpooler
       roles:

--- a/test/fixtures/generated/multiplatform/ubuntu2010-64l-vro73-64-ubuntu2010-64f
+++ b/test/fixtures/generated/multiplatform/ubuntu2010-64l-vro73-64-ubuntu2010-64f
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     ubuntu2010-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: ubuntu-20.10-amd64
       hypervisor: vmpooler
       template: ubuntu-2010-x86_64
@@ -15,21 +11,12 @@ expected_hash:
       - agent
       - classifier
     vro73-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: sles-11-x86_64
-      packaging_platform: sles-11-x86_64
       template: vro-73-x86_64
       hypervisor: vmpooler
       roles:
       - agent
     ubuntu2010-64-2:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: ubuntu-20.10-amd64
       hypervisor: vmpooler
       template: ubuntu-2010-x86_64

--- a/test/fixtures/generated/multiplatform/ubuntu2104-64c-vro71-64-ubuntu2104-64d
+++ b/test/fixtures/generated/multiplatform/ubuntu2104-64c-vro71-64-ubuntu2104-64d
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     ubuntu2104-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: ubuntu-21.04-amd64
       hypervisor: vmpooler
       template: ubuntu-2104-x86_64
@@ -15,21 +11,12 @@ expected_hash:
       - agent
       - dashboard
     vro71-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: sles-11-x86_64
-      packaging_platform: sles-11-x86_64
       template: vro-71-x86_64
       hypervisor: vmpooler
       roles:
       - agent
     ubuntu2104-64-2:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: ubuntu-21.04-amd64
       hypervisor: vmpooler
       template: ubuntu-2104-x86_64

--- a/test/fixtures/generated/multiplatform/ubuntu2110-64d-vro7-64-ubuntu2110-64c
+++ b/test/fixtures/generated/multiplatform/ubuntu2110-64d-vro7-64-ubuntu2110-64c
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     ubuntu2110-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: ubuntu-21.10-amd64
       hypervisor: vmpooler
       template: ubuntu-2110-x86_64
@@ -15,21 +11,12 @@ expected_hash:
       - agent
       - database
     vro7-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: sles-11-x86_64
-      packaging_platform: sles-11-x86_64
       template: vro-7-x86_64
       hypervisor: vmpooler
       roles:
       - agent
     ubuntu2110-64-2:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: ubuntu-21.10-amd64
       hypervisor: vmpooler
       template: ubuntu-2110-x86_64

--- a/test/fixtures/generated/multiplatform/vro6-64u-fedora20-32-vro6-64m
+++ b/test/fixtures/generated/multiplatform/vro6-64u-fedora20-32-vro6-64m
@@ -4,35 +4,21 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     vro6-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: sles-11-x86_64
-      packaging_platform: sles-11-x86_64
       template: vro-6-x86_64
       roles:
       - agent
       - ca
     fedora20-32-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: fedora-20-i386
       template: fedora-20-i386
       roles:
       - agent
     vro6-64-2:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: sles-11-x86_64
-      packaging_platform: sles-11-x86_64
       template: vro-6-x86_64
       roles:
       - agent

--- a/test/fixtures/generated/multiplatform/vro7-64l-fedora19-64-vro7-64f
+++ b/test/fixtures/generated/multiplatform/vro7-64l-fedora19-64-vro7-64f
@@ -4,35 +4,21 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     vro7-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: sles-11-x86_64
-      packaging_platform: sles-11-x86_64
       template: vro-7-x86_64
       roles:
       - agent
       - classifier
     fedora19-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: fedora-19-x86_64
       template: fedora-19-x86_64
       roles:
       - agent
     vro7-64-2:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: sles-11-x86_64
-      packaging_platform: sles-11-x86_64
       template: vro-7-x86_64
       roles:
       - agent

--- a/test/fixtures/generated/multiplatform/vro7-64u-ubuntu2110-64-vro7-64m
+++ b/test/fixtures/generated/multiplatform/vro7-64u-ubuntu2110-64-vro7-64m
@@ -4,34 +4,20 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     vro7-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: sles-11-x86_64
-      packaging_platform: sles-11-x86_64
       template: vro-7-x86_64
       hypervisor: vmpooler
       roles:
       - agent
       - ca
     ubuntu2110-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: ubuntu-21.10-amd64
       hypervisor: vmpooler
       template: ubuntu-2110-x86_64
       roles:
       - agent
     vro7-64-2:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: sles-11-x86_64
-      packaging_platform: sles-11-x86_64
       template: vro-7-x86_64
       hypervisor: vmpooler
       roles:

--- a/test/fixtures/generated/multiplatform/vro71-64d-fedora22-32-vro71-64c
+++ b/test/fixtures/generated/multiplatform/vro71-64d-fedora22-32-vro71-64c
@@ -4,35 +4,21 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     vro71-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: sles-11-x86_64
-      packaging_platform: sles-11-x86_64
       template: vro-71-x86_64
       roles:
       - agent
       - database
     fedora22-32-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: fedora-22-i386
       template: fedora-22-i386
       roles:
       - agent
     vro71-64-2:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: sles-11-x86_64
-      packaging_platform: sles-11-x86_64
       template: vro-71-x86_64
       roles:
       - agent

--- a/test/fixtures/generated/multiplatform/vro71-64l-ubuntu2104-64-vro71-64f
+++ b/test/fixtures/generated/multiplatform/vro71-64l-ubuntu2104-64-vro71-64f
@@ -4,34 +4,20 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     vro71-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: sles-11-x86_64
-      packaging_platform: sles-11-x86_64
       template: vro-71-x86_64
       hypervisor: vmpooler
       roles:
       - agent
       - classifier
     ubuntu2104-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: ubuntu-21.04-amd64
       hypervisor: vmpooler
       template: ubuntu-2104-x86_64
       roles:
       - agent
     vro71-64-2:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: sles-11-x86_64
-      packaging_platform: sles-11-x86_64
       template: vro-71-x86_64
       hypervisor: vmpooler
       roles:

--- a/test/fixtures/generated/multiplatform/vro73-64c-ubuntu2010-64-vro73-64d
+++ b/test/fixtures/generated/multiplatform/vro73-64c-ubuntu2010-64-vro73-64d
@@ -4,34 +4,20 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     vro73-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: sles-11-x86_64
-      packaging_platform: sles-11-x86_64
       template: vro-73-x86_64
       hypervisor: vmpooler
       roles:
       - agent
       - dashboard
     ubuntu2010-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: ubuntu-20.10-amd64
       hypervisor: vmpooler
       template: ubuntu-2010-x86_64
       roles:
       - agent
     vro73-64-2:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: sles-11-x86_64
-      packaging_platform: sles-11-x86_64
       template: vro-73-x86_64
       hypervisor: vmpooler
       roles:

--- a/test/fixtures/generated/multiplatform/vro73-64l-fedora19-64-vro73-64f
+++ b/test/fixtures/generated/multiplatform/vro73-64l-fedora19-64-vro73-64f
@@ -4,35 +4,21 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     vro73-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: sles-11-x86_64
-      packaging_platform: sles-11-x86_64
       template: vro-73-x86_64
       roles:
       - agent
       - classifier
     fedora19-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: fedora-19-x86_64
       template: fedora-19-x86_64
       roles:
       - agent
     vro73-64-2:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: sles-11-x86_64
-      packaging_platform: sles-11-x86_64
       template: vro-73-x86_64
       roles:
       - agent

--- a/test/fixtures/generated/multiplatform/vro74-64d-ubuntu2004-AARCH64-vro74-64c
+++ b/test/fixtures/generated/multiplatform/vro74-64d-ubuntu2004-AARCH64-vro74-64c
@@ -4,33 +4,19 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     vro74-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: sles-11-x86_64
-      packaging_platform: sles-11-x86_64
       template: vro-74-x86_64
       hypervisor: vmpooler
       roles:
       - agent
       - database
     ubuntu2004-AARCH64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: ubuntu-20.04-aarch64
       hypervisor: vmpooler
       roles:
       - agent
     vro74-64-2:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: sles-11-x86_64
-      packaging_platform: sles-11-x86_64
       template: vro-74-x86_64
       hypervisor: vmpooler
       roles:

--- a/test/fixtures/generated/multiplatform/vro74-64m-fedora21-32-vro74-64u
+++ b/test/fixtures/generated/multiplatform/vro74-64m-fedora21-32-vro74-64u
@@ -4,35 +4,21 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     vro74-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: sles-11-x86_64
-      packaging_platform: sles-11-x86_64
       template: vro-74-x86_64
       roles:
       - agent
       - master
     fedora21-32-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: fedora-21-i386
       template: fedora-21-i386
       roles:
       - agent
     vro74-64-2:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: sles-11-x86_64
-      packaging_platform: sles-11-x86_64
       template: vro-74-x86_64
       roles:
       - agent

--- a/test/fixtures/generated/multiplatform/windows10ent-32u-aix71-POWER-windows10ent-32m
+++ b/test/fixtures/generated/multiplatform/windows10ent-32u-aix71-POWER-windows10ent-32m
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     windows10ent-32-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-10ent-32
       packaging_platform: windows-2012-x86
@@ -17,20 +13,11 @@ expected_hash:
       - agent
       - ca
     aix71-POWER-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: aix-7.1-power
-      packaging_platform: aix-7.1-power
       roles:
       - agent
     windows10ent-32-2:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-10ent-32
       packaging_platform: windows-2012-x86

--- a/test/fixtures/generated/multiplatform/windows10ent-64l-aix61-POWER-windows10ent-64f
+++ b/test/fixtures/generated/multiplatform/windows10ent-64l-aix61-POWER-windows10ent-64f
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     windows10ent-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-10ent-64
       packaging_platform: windows-2012-x64
@@ -17,20 +13,11 @@ expected_hash:
       - agent
       - classifier
     aix61-POWER-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: aix-6.1-power
-      packaging_platform: aix-6.1-power
       roles:
       - agent
     windows10ent-64-2:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-10ent-64
       packaging_platform: windows-2012-x64

--- a/test/fixtures/generated/multiplatform/windows10pro-64c-aix53-POWER-windows10pro-64d
+++ b/test/fixtures/generated/multiplatform/windows10pro-64c-aix53-POWER-windows10pro-64d
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     windows10pro-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-10pro-64
       packaging_platform: windows-2012-x64
@@ -17,20 +13,11 @@ expected_hash:
       - agent
       - dashboard
     aix53-POWER-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: aix-5.3-power
-      packaging_platform: aix-5.3-power
       roles:
       - agent
     windows10pro-64-2:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-10pro-64
       packaging_platform: windows-2012-x64

--- a/test/fixtures/generated/multiplatform/windows2008-6432l-debian10-32-windows2008-6432f
+++ b/test/fixtures/generated/multiplatform/windows2008-6432l-debian10-32-windows2008-6432f
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     windows2008-6432-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: windows-2008-64
       packaging_platform: windows-2012-x64
       ruby_arch: x86
@@ -17,21 +13,12 @@ expected_hash:
       - agent
       - classifier
     debian10-32-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: debian-10-i386
-      packaging_platform: debian-10-i386
       template: debian-10-i386
       hypervisor: vmpooler
       roles:
       - agent
     windows2008-6432-2:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: windows-2008-64
       packaging_platform: windows-2012-x64
       ruby_arch: x86

--- a/test/fixtures/generated/multiplatform/windows2008-6432m-ubuntu2004-64-windows2008-6432u
+++ b/test/fixtures/generated/multiplatform/windows2008-6432m-ubuntu2004-64-windows2008-6432u
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     windows2008-6432-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: windows-2008-64
       packaging_platform: windows-2012-x64
       ruby_arch: x86
@@ -17,20 +13,12 @@ expected_hash:
       - agent
       - master
     ubuntu2004-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: ubuntu-20.04-amd64
       hypervisor: vmpooler
       template: ubuntu-2004-x86_64
       roles:
       - agent
     windows2008-6432-2:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: windows-2008-64
       packaging_platform: windows-2012-x64
       ruby_arch: x86

--- a/test/fixtures/generated/multiplatform/windows2008-6432u-debian7-64-windows2008-6432m
+++ b/test/fixtures/generated/multiplatform/windows2008-6432u-debian7-64-windows2008-6432m
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     windows2008-6432-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-2008-64
       packaging_platform: windows-2012-x64
@@ -17,21 +13,12 @@ expected_hash:
       - agent
       - ca
     debian7-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: debian-7-amd64
-      packaging_platform: debian-7-amd64
       template: debian-7-x86_64
       roles:
       - agent
     windows2008-6432-2:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-2008-64
       packaging_platform: windows-2012-x64

--- a/test/fixtures/generated/multiplatform/windows2008-64a-debian8-32-windows2008-64aulcdfm
+++ b/test/fixtures/generated/multiplatform/windows2008-64a-debian8-32-windows2008-64aulcdfm
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     windows2008-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-2008-64
       packaging_platform: windows-2012-x64
@@ -16,21 +12,12 @@ expected_hash:
       roles:
       - agent
     debian8-32-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: debian-8-i386
-      packaging_platform: debian-8-i386
       template: debian-8-i386
       roles:
       - agent
     windows2008-64-2:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-2008-64
       packaging_platform: windows-2012-x64

--- a/test/fixtures/generated/multiplatform/windows2008-64f-ubuntu2004-POWER-windows2008-64l
+++ b/test/fixtures/generated/multiplatform/windows2008-64f-ubuntu2004-POWER-windows2008-64l
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     windows2008-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: windows-2008-64
       packaging_platform: windows-2012-x64
       ruby_arch: x64
@@ -17,19 +13,11 @@ expected_hash:
       - agent
       - frictionless
     ubuntu2004-POWER-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: ubuntu-20.04-ppc64el
       hypervisor: vmpooler
       roles:
       - agent
     windows2008-64-2:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: windows-2008-64
       packaging_platform: windows-2012-x64
       ruby_arch: x64

--- a/test/fixtures/generated/multiplatform/windows2008r2-6432a-ubuntu1804-POWER-windows2008r2-6432aulcdfm
+++ b/test/fixtures/generated/multiplatform/windows2008r2-6432a-ubuntu1804-POWER-windows2008r2-6432aulcdfm
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     windows2008r2-6432-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: windows-2008r2-64
       packaging_platform: windows-2012-x64
       ruby_arch: x86
@@ -16,19 +12,11 @@ expected_hash:
       roles:
       - agent
     ubuntu1804-POWER-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: ubuntu-18.04-ppc64el
       hypervisor: vmpooler
       roles:
       - agent
     windows2008r2-6432-2:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: windows-2008r2-64
       packaging_platform: windows-2012-x64
       ruby_arch: x86

--- a/test/fixtures/generated/multiplatform/windows2008r2-6432c-debian6-64-windows2008r2-6432d
+++ b/test/fixtures/generated/multiplatform/windows2008r2-6432c-debian6-64-windows2008r2-6432d
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     windows2008r2-6432-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-2008r2-64
       packaging_platform: windows-2012-x64
@@ -17,20 +13,12 @@ expected_hash:
       - agent
       - dashboard
     debian6-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: debian-6-amd64
       template: debian-6-x86_64
       roles:
       - agent
     windows2008r2-6432-2:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-2008r2-64
       packaging_platform: windows-2012-x64

--- a/test/fixtures/generated/multiplatform/windows2008r2-64aulcdfm-ubuntu1804-AARCH64-windows2008r2-64a
+++ b/test/fixtures/generated/multiplatform/windows2008r2-64aulcdfm-ubuntu1804-AARCH64-windows2008r2-64a
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     windows2008r2-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: windows-2008r2-64
       packaging_platform: windows-2012-x64
       ruby_arch: x64
@@ -22,19 +18,11 @@ expected_hash:
       - frictionless
       - master
     ubuntu1804-AARCH64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: ubuntu-18.04-aarch64
       hypervisor: vmpooler
       roles:
       - agent
     windows2008r2-64-2:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: windows-2008r2-64
       packaging_platform: windows-2012-x64
       ruby_arch: x64

--- a/test/fixtures/generated/multiplatform/windows2008r2-64c-debian10-64-windows2008r2-64d
+++ b/test/fixtures/generated/multiplatform/windows2008r2-64c-debian10-64-windows2008r2-64d
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     windows2008r2-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: windows-2008r2-64
       packaging_platform: windows-2012-x64
       ruby_arch: x64
@@ -17,21 +13,12 @@ expected_hash:
       - agent
       - dashboard
     debian10-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: debian-10-amd64
-      packaging_platform: debian-10-amd64
       template: debian-10-x86_64
       hypervisor: vmpooler
       roles:
       - agent
     windows2008r2-64-2:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: windows-2008r2-64
       packaging_platform: windows-2012-x64
       ruby_arch: x64

--- a/test/fixtures/generated/multiplatform/windows2008r2-64l-debian7-32-windows2008r2-64f
+++ b/test/fixtures/generated/multiplatform/windows2008r2-64l-debian7-32-windows2008r2-64f
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     windows2008r2-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-2008r2-64
       packaging_platform: windows-2012-x64
@@ -17,21 +13,12 @@ expected_hash:
       - agent
       - classifier
     debian7-32-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: debian-7-i386
-      packaging_platform: debian-7-i386
       template: debian-7-i386
       roles:
       - agent
     windows2008r2-64-2:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-2008r2-64
       packaging_platform: windows-2012-x64

--- a/test/fixtures/generated/multiplatform/windows2012-6432f-cumulus25-64-windows2012-6432l
+++ b/test/fixtures/generated/multiplatform/windows2012-6432f-cumulus25-64-windows2012-6432l
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     windows2012-6432-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-2012-64
       packaging_platform: windows-2012-x64
@@ -17,10 +13,6 @@ expected_hash:
       - agent
       - frictionless
     cumulus25-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: cumulus-2.5-x86_64
       packaging_platform: cumulus-2.2-amd64
@@ -28,10 +20,6 @@ expected_hash:
       roles:
       - agent
     windows2012-6432-2:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-2012-64
       packaging_platform: windows-2012-x64

--- a/test/fixtures/generated/multiplatform/windows2012-6432l-ubuntu1604-AARCH64-windows2012-6432f
+++ b/test/fixtures/generated/multiplatform/windows2012-6432l-ubuntu1604-AARCH64-windows2012-6432f
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     windows2012-6432-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: windows-2012-64
       packaging_platform: windows-2012-x64
       ruby_arch: x86
@@ -17,19 +13,11 @@ expected_hash:
       - agent
       - classifier
     ubuntu1604-AARCH64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: ubuntu-16.04-aarch64
       hypervisor: vmpooler
       roles:
       - agent
     windows2012-6432-2:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: windows-2012-64
       packaging_platform: windows-2012-x64
       ruby_arch: x86

--- a/test/fixtures/generated/multiplatform/windows2012-64d-debian6-32-windows2012-64c
+++ b/test/fixtures/generated/multiplatform/windows2012-64d-debian6-32-windows2012-64c
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     windows2012-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-2012-64
       packaging_platform: windows-2012-x64
@@ -17,20 +13,12 @@ expected_hash:
       - agent
       - database
     debian6-32-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: debian-6-i386
       template: debian-6-i386
       roles:
       - agent
     windows2012-64-2:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-2012-64
       packaging_platform: windows-2012-x64

--- a/test/fixtures/generated/multiplatform/windows2012-64u-ubuntu1804-64-windows2012-64m
+++ b/test/fixtures/generated/multiplatform/windows2012-64u-ubuntu1804-64-windows2012-64m
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     windows2012-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: windows-2012-64
       packaging_platform: windows-2012-x64
       ruby_arch: x64
@@ -17,20 +13,12 @@ expected_hash:
       - agent
       - ca
     ubuntu1804-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: ubuntu-18.04-amd64
       hypervisor: vmpooler
       template: ubuntu-1804-x86_64
       roles:
       - agent
     windows2012-64-2:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: windows-2012-64
       packaging_platform: windows-2012-x64
       ruby_arch: x64

--- a/test/fixtures/generated/multiplatform/windows2012r2-6432aulcdfm-cisconx-64-windows2012r2-6432a
+++ b/test/fixtures/generated/multiplatform/windows2012r2-6432aulcdfm-cisconx-64-windows2012r2-6432a
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     windows2012r2-6432-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-2012r2-64
       packaging_platform: windows-2012-x64
@@ -22,10 +18,6 @@ expected_hash:
       - frictionless
       - master
     cisconx-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: cisco_nexus-7-x86_64
       packaging_platform: cisco-wrlinux-5-x86_64
@@ -36,10 +28,6 @@ expected_hash:
       roles:
       - agent
     windows2012r2-6432-2:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-2012r2-64
       packaging_platform: windows-2012-x64

--- a/test/fixtures/generated/multiplatform/windows2012r2-6432m-ubuntu1404-AARCH64-windows2012r2-6432u
+++ b/test/fixtures/generated/multiplatform/windows2012r2-6432m-ubuntu1404-AARCH64-windows2012r2-6432u
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     windows2012r2-6432-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: windows-2012r2-64
       packaging_platform: windows-2012-x64
       ruby_arch: x86
@@ -17,19 +13,11 @@ expected_hash:
       - agent
       - master
     ubuntu1404-AARCH64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: ubuntu-14.04-aarch64
       hypervisor: vmpooler
       roles:
       - agent
     windows2012r2-6432-2:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: windows-2012r2-64
       packaging_platform: windows-2012-x64
       ruby_arch: x86

--- a/test/fixtures/generated/multiplatform/windows2012r2-64c-ubuntu1604-POWER-windows2012r2-64d
+++ b/test/fixtures/generated/multiplatform/windows2012r2-64c-ubuntu1604-POWER-windows2012r2-64d
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     windows2012r2-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: windows-2012r2-64
       packaging_platform: windows-2012-x64
       ruby_arch: x64
@@ -17,19 +13,11 @@ expected_hash:
       - agent
       - dashboard
     ubuntu1604-POWER-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: ubuntu-16.04-ppc64el
       hypervisor: vmpooler
       roles:
       - agent
     windows2012r2-64-2:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: windows-2012r2-64
       packaging_platform: windows-2012-x64
       ruby_arch: x64

--- a/test/fixtures/generated/multiplatform/windows2012r2_fr-64d-fedora34-64-windows2012r2_fr-64c
+++ b/test/fixtures/generated/multiplatform/windows2012r2_fr-64d-fedora34-64-windows2012r2_fr-64c
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     windows2012r2_fr-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: windows-2012r2-64
       packaging_platform: windows-2012-x64
       ruby_arch: x64
@@ -19,20 +15,12 @@ expected_hash:
       - agent
       - database
     fedora34-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: fedora-34-x86_64
       hypervisor: vmpooler
       template: fedora-34-x86_64
       roles:
       - agent
     windows2012r2_fr-64-2:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: windows-2012r2-64
       packaging_platform: windows-2012-x64
       ruby_arch: x64

--- a/test/fixtures/generated/multiplatform/windows2012r2_ja-6432l-centos6-32-windows2012r2_ja-6432f
+++ b/test/fixtures/generated/multiplatform/windows2012r2_ja-6432l-centos6-32-windows2012r2_ja-6432f
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     windows2012r2_ja-6432-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-2012r2-64
       packaging_platform: windows-2012-x64
@@ -18,21 +14,12 @@ expected_hash:
       - agent
       - classifier
     centos6-32-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: el-6-i386
-      packaging_platform: el-6-i386
       template: centos-6-i386
       roles:
       - agent
     windows2012r2_ja-6432-2:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-2012r2-64
       packaging_platform: windows-2012-x64

--- a/test/fixtures/generated/multiplatform/windows2012r2_ja-6432u-ubuntu1404-32-windows2012r2_ja-6432m
+++ b/test/fixtures/generated/multiplatform/windows2012r2_ja-6432u-ubuntu1404-32-windows2012r2_ja-6432m
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     windows2012r2_ja-6432-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: windows-2012r2-64
       packaging_platform: windows-2012-x64
       ruby_arch: x86
@@ -18,20 +14,12 @@ expected_hash:
       - agent
       - ca
     ubuntu1404-32-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: ubuntu-14.04-i386
       hypervisor: vmpooler
       template: ubuntu-1404-i386
       roles:
       - agent
     windows2012r2_ja-6432-2:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: windows-2012r2-64
       packaging_platform: windows-2012-x64
       ruby_arch: x86

--- a/test/fixtures/generated/multiplatform/windows2012r2_ja-64a-ubuntu1404-64-windows2012r2_ja-64aulcdfm
+++ b/test/fixtures/generated/multiplatform/windows2012r2_ja-64a-ubuntu1404-64-windows2012r2_ja-64aulcdfm
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     windows2012r2_ja-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: windows-2012r2-64
       packaging_platform: windows-2012-x64
       ruby_arch: x64
@@ -17,20 +13,12 @@ expected_hash:
       roles:
       - agent
     ubuntu1404-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: ubuntu-14.04-amd64
       hypervisor: vmpooler
       template: ubuntu-1404-x86_64
       roles:
       - agent
     windows2012r2_ja-64-2:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: windows-2012r2-64
       packaging_platform: windows-2012-x64
       ruby_arch: x64

--- a/test/fixtures/generated/multiplatform/windows2012r2_ja-64u-centos6-64-windows2012r2_ja-64m
+++ b/test/fixtures/generated/multiplatform/windows2012r2_ja-64u-centos6-64-windows2012r2_ja-64m
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     windows2012r2_ja-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-2012r2-64
       packaging_platform: windows-2012-x64
@@ -18,21 +14,12 @@ expected_hash:
       - agent
       - ca
     centos6-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: el-6-x86_64
-      packaging_platform: el-6-x86_64
       template: centos-6-x86_64
       roles:
       - agent
     windows2012r2_ja-64-2:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-2012r2-64
       packaging_platform: windows-2012-x64

--- a/test/fixtures/generated/multiplatform/windows2012r2_wmf5-64a-centos7-64-windows2012r2_wmf5-64aulcdfm
+++ b/test/fixtures/generated/multiplatform/windows2012r2_wmf5-64a-centos7-64-windows2012r2_wmf5-64aulcdfm
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     windows2012r2_wmf5-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-2012r2-64
       packaging_platform: windows-2012-x64
@@ -16,21 +12,12 @@ expected_hash:
       roles:
       - agent
     centos7-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: el-7-x86_64
-      packaging_platform: el-7-x86_64
       template: centos-7-x86_64
       roles:
       - agent
     windows2012r2_wmf5-64-2:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-2012r2-64
       packaging_platform: windows-2012-x64

--- a/test/fixtures/generated/multiplatform/windows2012r2_wmf5-64aulcdfm-ubuntu1404-POWER-windows2012r2_wmf5-64a
+++ b/test/fixtures/generated/multiplatform/windows2012r2_wmf5-64aulcdfm-ubuntu1404-POWER-windows2012r2_wmf5-64a
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     windows2012r2_wmf5-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: windows-2012r2-64
       packaging_platform: windows-2012-x64
       ruby_arch: x64
@@ -22,19 +18,11 @@ expected_hash:
       - frictionless
       - master
     ubuntu1404-POWER-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: ubuntu-14.04-ppc64el
       hypervisor: vmpooler
       roles:
       - agent
     windows2012r2_wmf5-64-2:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: windows-2012r2-64
       packaging_platform: windows-2012-x64
       ruby_arch: x64

--- a/test/fixtures/generated/multiplatform/windows2016-6432d-centos5-32-windows2016-6432c
+++ b/test/fixtures/generated/multiplatform/windows2016-6432d-centos5-32-windows2016-6432c
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     windows2016-6432-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-2016-64
       packaging_platform: windows-2012-x64
@@ -17,21 +13,12 @@ expected_hash:
       - agent
       - database
     centos5-32-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: el-5-i386
-      packaging_platform: el-5-i386
       template: centos-5-i386
       roles:
       - agent
     windows2016-6432-2:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-2016-64
       packaging_platform: windows-2012-x64

--- a/test/fixtures/generated/multiplatform/windows2016-64c-centos5-64-windows2016-64d
+++ b/test/fixtures/generated/multiplatform/windows2016-64c-centos5-64-windows2016-64d
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     windows2016-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-2016-64
       packaging_platform: windows-2012-x64
@@ -17,21 +13,12 @@ expected_hash:
       - agent
       - dashboard
     centos5-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: el-5-x86_64
-      packaging_platform: el-5-x86_64
       template: centos-5-x86_64
       roles:
       - agent
     windows2016-64-2:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-2016-64
       packaging_platform: windows-2012-x64

--- a/test/fixtures/generated/multiplatform/windows2016_fr-6432f-centos5-64-windows2016_fr-6432l
+++ b/test/fixtures/generated/multiplatform/windows2016_fr-6432f-centos5-64-windows2016_fr-6432l
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     windows2016_fr-6432-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: windows-2016-64
       packaging_platform: windows-2012-x64
       ruby_arch: x86
@@ -19,21 +15,12 @@ expected_hash:
       - agent
       - frictionless
     centos5-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: el-5-x86_64
-      packaging_platform: el-5-x86_64
       template: centos-5-x86_64
       hypervisor: vmpooler
       roles:
       - agent
     windows2016_fr-6432-2:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: windows-2016-64
       packaging_platform: windows-2012-x64
       ruby_arch: x86

--- a/test/fixtures/generated/multiplatform/windows2016_fr-64d-centos6-32-windows2016_fr-64c
+++ b/test/fixtures/generated/multiplatform/windows2016_fr-64d-centos6-32-windows2016_fr-64c
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     windows2016_fr-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: windows-2016-64
       packaging_platform: windows-2012-x64
       ruby_arch: x64
@@ -19,21 +15,12 @@ expected_hash:
       - agent
       - database
     centos6-32-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: el-6-i386
-      packaging_platform: el-6-i386
       template: centos-6-i386
       hypervisor: vmpooler
       roles:
       - agent
     windows2016_fr-64-2:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: windows-2016-64
       packaging_platform: windows-2012-x64
       ruby_arch: x64

--- a/test/fixtures/generated/multiplatform/windows2019_ja-64aulcdfm-centos8-64-windows2019_ja-64a
+++ b/test/fixtures/generated/multiplatform/windows2019_ja-64aulcdfm-centos8-64-windows2019_ja-64a
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     windows2019_ja-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: windows-2019-64
       packaging_platform: windows-2012-x64
       ruby_arch: x64
@@ -23,21 +19,12 @@ expected_hash:
       - frictionless
       - master
     centos8-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: el-8-x86_64
-      packaging_platform: el-8-x86_64
       template: centos-8-x86_64
       hypervisor: vmpooler
       roles:
       - agent
     windows2019_ja-64-2:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: windows-2019-64
       packaging_platform: windows-2012-x64
       ruby_arch: x64

--- a/test/fixtures/generated/multiplatform/windows2022-64aulcdfm-fedora24-32-windows2022-64a
+++ b/test/fixtures/generated/multiplatform/windows2022-64aulcdfm-fedora24-32-windows2022-64a
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     windows2022-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: windows-2022-64
       packaging_platform: windows-2012-x64
       ruby_arch: x64
@@ -22,20 +18,12 @@ expected_hash:
       - frictionless
       - master
     fedora24-32-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: fedora-24-i386
       hypervisor: vmpooler
       template: fedora-24-i386
       roles:
       - agent
     windows2022-64-2:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: windows-2022-64
       packaging_platform: windows-2012-x64
       ruby_arch: x64

--- a/test/fixtures/generated/multiplatform/windows7-64f-centos4-64-windows7-64l
+++ b/test/fixtures/generated/multiplatform/windows7-64f-centos4-64-windows7-64l
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     windows7-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-7-64
       packaging_platform: windows-2012-x64
@@ -17,20 +13,12 @@ expected_hash:
       - agent
       - frictionless
     centos4-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: el-4-x86_64
       template: centos-4-x86_64
       roles:
       - agent
     windows7-64-2:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-7-64
       packaging_platform: windows-2012-x64

--- a/test/fixtures/generated/multiplatform/windows81-64aulcdfm-arista4-32-windows81-64a
+++ b/test/fixtures/generated/multiplatform/windows81-64aulcdfm-arista4-32-windows81-64a
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     windows81-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-8.1-64
       packaging_platform: windows-2012-x64
@@ -22,21 +18,12 @@ expected_hash:
       - frictionless
       - master
     arista4-32-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: eos-4-i386
-      packaging_platform: eos-4-i386
       template: arista-4-i386
       roles:
       - agent
     windows81-64-2:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-8.1-64
       packaging_platform: windows-2012-x64

--- a/test/fixtures/generated/multiplatform/windowsfips2012r2-6432f-debian8-64-windowsfips2012r2-6432l
+++ b/test/fixtures/generated/multiplatform/windowsfips2012r2-6432f-debian8-64-windowsfips2012r2-6432l
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     windowsfips2012r2-6432-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: windows-2012r2-64
       packaging_platform: windowsfips-2012-x64
       ruby_arch: x64
@@ -17,21 +13,12 @@ expected_hash:
       - agent
       - frictionless
     debian8-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: debian-8-amd64
-      packaging_platform: debian-8-amd64
       template: debian-8-x86_64
       hypervisor: vmpooler
       roles:
       - agent
     windowsfips2012r2-6432-2:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: windows-2012r2-64
       packaging_platform: windowsfips-2012-x64
       ruby_arch: x64

--- a/test/fixtures/generated/multiplatform/windowsfips2012r2-6432f-ubuntu1604-32-windowsfips2012r2-6432l
+++ b/test/fixtures/generated/multiplatform/windowsfips2012r2-6432f-ubuntu1604-32-windowsfips2012r2-6432l
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     windowsfips2012r2-6432-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: windows-2012r2-64
       packaging_platform: windowsfips-2012-x64
       ruby_arch: x64
@@ -17,20 +13,12 @@ expected_hash:
       - agent
       - frictionless
     ubuntu1604-32-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: ubuntu-16.04-i386
       hypervisor: vmpooler
       template: ubuntu-1604-i386
       roles:
       - agent
     windowsfips2012r2-6432-2:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: windows-2012r2-64
       packaging_platform: windowsfips-2012-x64
       ruby_arch: x64

--- a/test/fixtures/generated/multiplatform/windowsfips2012r2-64d-debian9-32-windowsfips2012r2-64c
+++ b/test/fixtures/generated/multiplatform/windowsfips2012r2-64d-debian9-32-windowsfips2012r2-64c
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     windowsfips2012r2-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: windows-2012r2-64
       packaging_platform: windowsfips-2012-x64
       ruby_arch: x64
@@ -17,21 +13,12 @@ expected_hash:
       - agent
       - database
     debian9-32-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: debian-9-i386
-      packaging_platform: debian-9-i386
       template: debian-9-i386
       hypervisor: vmpooler
       roles:
       - agent
     windowsfips2012r2-64-2:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: windows-2012r2-64
       packaging_platform: windowsfips-2012-x64
       ruby_arch: x64

--- a/test/fixtures/generated/multiplatform/windowsfips2012r2-64d-ubuntu1604-64-windowsfips2012r2-64c
+++ b/test/fixtures/generated/multiplatform/windowsfips2012r2-64d-ubuntu1604-64-windowsfips2012r2-64c
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     windowsfips2012r2-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: windows-2012r2-64
       packaging_platform: windowsfips-2012-x64
       ruby_arch: x64
@@ -17,20 +13,12 @@ expected_hash:
       - agent
       - database
     ubuntu1604-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: ubuntu-16.04-amd64
       hypervisor: vmpooler
       template: ubuntu-1604-x86_64
       roles:
       - agent
     windowsfips2012r2-64-2:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: windows-2012r2-64
       packaging_platform: windowsfips-2012-x64
       ruby_arch: x64

--- a/test/fixtures/generated/osinfo-version-0/aix53-POWERa
+++ b/test/fixtures/generated/osinfo-version-0/aix53-POWERa
@@ -4,13 +4,8 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     aix53-POWER-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: aix-5.3-power
-      packaging_platform: aix-5.3-power
       roles:
       - agent
   CONFIG:

--- a/test/fixtures/generated/osinfo-version-0/aix61-POWERu
+++ b/test/fixtures/generated/osinfo-version-0/aix61-POWERu
@@ -4,13 +4,8 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     aix61-POWER-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: aix-6.1-power
-      packaging_platform: aix-6.1-power
       roles:
       - agent
       - ca

--- a/test/fixtures/generated/osinfo-version-0/aix71-POWERl
+++ b/test/fixtures/generated/osinfo-version-0/aix71-POWERl
@@ -4,13 +4,8 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     aix71-POWER-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: aix-7.1-power
-      packaging_platform: aix-7.1-power
       roles:
       - agent
       - classifier

--- a/test/fixtures/generated/osinfo-version-0/aix72-POWERc
+++ b/test/fixtures/generated/osinfo-version-0/aix72-POWERc
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     aix72-POWER-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: aix-7.2-power
       packaging_platform: aix-7.1-power

--- a/test/fixtures/generated/osinfo-version-0/almalinux8-64u
+++ b/test/fixtures/generated/osinfo-version-0/almalinux8-64u
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     almalinux8-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: el-8-x86_64
       hypervisor: vmpooler
       template: almalinux-8-x86_64

--- a/test/fixtures/generated/osinfo-version-0/amazon6-64d
+++ b/test/fixtures/generated/osinfo-version-0/amazon6-64d
@@ -4,13 +4,8 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     amazon6-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: el-6-x86_64
-      packaging_platform: el-6-x86_64
       roles:
       - agent
       - database

--- a/test/fixtures/generated/osinfo-version-0/amazon7-64f
+++ b/test/fixtures/generated/osinfo-version-0/amazon7-64f
@@ -4,13 +4,8 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     amazon7-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: el-7-x86_64
-      packaging_platform: el-7-x86_64
       roles:
       - agent
       - frictionless

--- a/test/fixtures/generated/osinfo-version-0/amazon7-ARM64m
+++ b/test/fixtures/generated/osinfo-version-0/amazon7-ARM64m
@@ -4,12 +4,7 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     amazon7-ARM64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: el-7-aarch64
-      packaging_platform: el-7-aarch64
       hypervisor: vmpooler
       roles:
       - agent

--- a/test/fixtures/generated/osinfo-version-0/arista4-32d
+++ b/test/fixtures/generated/osinfo-version-0/arista4-32d
@@ -4,12 +4,7 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     arista4-32-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: eos-4-i386
-      packaging_platform: eos-4-i386
       template: arista-4-i386
       hypervisor: vmpooler
       roles:

--- a/test/fixtures/generated/osinfo-version-0/centos4-32f
+++ b/test/fixtures/generated/osinfo-version-0/centos4-32f
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     centos4-32-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: el-4-i386
       hypervisor: vmpooler
       template: centos-4-i386

--- a/test/fixtures/generated/osinfo-version-0/centos4-64m
+++ b/test/fixtures/generated/osinfo-version-0/centos4-64m
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     centos4-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: el-4-x86_64
       hypervisor: vmpooler
       template: centos-4-x86_64

--- a/test/fixtures/generated/osinfo-version-0/centos5-32aulcdfm
+++ b/test/fixtures/generated/osinfo-version-0/centos5-32aulcdfm
@@ -4,12 +4,7 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     centos5-32-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: el-5-i386
-      packaging_platform: el-5-i386
       hypervisor: vmpooler
       template: centos-5-i386
       roles:

--- a/test/fixtures/generated/osinfo-version-0/centos5-64a
+++ b/test/fixtures/generated/osinfo-version-0/centos5-64a
@@ -4,12 +4,7 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     centos5-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: el-5-x86_64
-      packaging_platform: el-5-x86_64
       hypervisor: vmpooler
       template: centos-5-x86_64
       roles:

--- a/test/fixtures/generated/osinfo-version-0/centos6-32u
+++ b/test/fixtures/generated/osinfo-version-0/centos6-32u
@@ -4,12 +4,7 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     centos6-32-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: el-6-i386
-      packaging_platform: el-6-i386
       hypervisor: vmpooler
       template: centos-6-i386
       roles:

--- a/test/fixtures/generated/osinfo-version-0/centos6-64l
+++ b/test/fixtures/generated/osinfo-version-0/centos6-64l
@@ -4,12 +4,7 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     centos6-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: el-6-x86_64
-      packaging_platform: el-6-x86_64
       hypervisor: vmpooler
       template: centos-6-x86_64
       roles:

--- a/test/fixtures/generated/osinfo-version-0/centos7-64c
+++ b/test/fixtures/generated/osinfo-version-0/centos7-64c
@@ -4,12 +4,7 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     centos7-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: el-7-x86_64
-      packaging_platform: el-7-x86_64
       hypervisor: vmpooler
       template: centos-7-x86_64
       roles:

--- a/test/fixtures/generated/osinfo-version-0/centos8-64aulcdfm
+++ b/test/fixtures/generated/osinfo-version-0/centos8-64aulcdfm
@@ -4,12 +4,7 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     centos8-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: el-8-x86_64
-      packaging_platform: el-8-x86_64
       template: centos-8-x86_64
       hypervisor: vmpooler
       roles:

--- a/test/fixtures/generated/osinfo-version-0/cisco_ios_c2960-HWm
+++ b/test/fixtures/generated/osinfo-version-0/cisco_ios_c2960-HWm
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     cisco_ios_c2960-HW-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: cisco_ios-12-arm32
       ssh:
         user: admin
@@ -19,4 +15,4 @@ expected_hash:
     nfs_server: none
     consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
-expected_exception: 
+expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/cisco_ios_c3560-HWaulcdfm
+++ b/test/fixtures/generated/osinfo-version-0/cisco_ios_c3560-HWaulcdfm
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     cisco_ios_c3560-HW-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: cisco_ios-12-arm32
       ssh:
         user: admin
@@ -24,4 +20,4 @@ expected_hash:
     nfs_server: none
     consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
-expected_exception: 
+expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/cisco_ios_c3750-HWa
+++ b/test/fixtures/generated/osinfo-version-0/cisco_ios_c3750-HWa
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     cisco_ios_c3750-HW-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: cisco_ios-12-arm32
       ssh:
         user: admin
@@ -18,4 +14,4 @@ expected_hash:
     nfs_server: none
     consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
-expected_exception: 
+expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/cisco_ios_c4507r-HWu
+++ b/test/fixtures/generated/osinfo-version-0/cisco_ios_c4507r-HWu
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     cisco_ios_c4507r-HW-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: cisco_ios-12-arm32
       ssh:
         user: admin
@@ -19,4 +15,4 @@ expected_hash:
     nfs_server: none
     consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
-expected_exception: 
+expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/cisco_ios_c4948-HWl
+++ b/test/fixtures/generated/osinfo-version-0/cisco_ios_c4948-HWl
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     cisco_ios_c4948-HW-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: cisco_ios-12-arm32
       ssh:
         user: admin
@@ -19,4 +15,4 @@ expected_hash:
     nfs_server: none
     consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
-expected_exception: 
+expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/cisco_ios_c6503-HWc
+++ b/test/fixtures/generated/osinfo-version-0/cisco_ios_c6503-HWc
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     cisco_ios_c6503-HW-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: cisco_ios-12-arm32
       ssh:
         user: admin
@@ -19,4 +15,4 @@ expected_hash:
     nfs_server: none
     consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
-expected_exception: 
+expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/cisco_iosxe_c3650-HWd
+++ b/test/fixtures/generated/osinfo-version-0/cisco_iosxe_c3650-HWd
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     cisco_iosxe_c3650-HW-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: cisco_iosxec3650-arm32
       ssh:
         user: admin
@@ -19,4 +15,4 @@ expected_hash:
     nfs_server: none
     consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
-expected_exception: 
+expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/cisco_iosxe_c4503-HWf
+++ b/test/fixtures/generated/osinfo-version-0/cisco_iosxe_c4503-HWf
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     cisco_iosxe_c4503-HW-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: cisco_iosxe-3-arm32
       ssh:
         user: admin
@@ -19,4 +15,4 @@ expected_hash:
     nfs_server: none
     consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
-expected_exception: 
+expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/cisco_n7k-HWc
+++ b/test/fixtures/generated/osinfo-version-0/cisco_n7k-HWc
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     cisco_n7k-HW-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: cisco_nexus-7k-x86_64
       packaging_platform: cisco-wrlinux-5-x86_64
       vrf: management
@@ -21,4 +17,4 @@ expected_hash:
     nfs_server: none
     consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
-expected_exception: 
+expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/cisco_n7k_vdc-HWd
+++ b/test/fixtures/generated/osinfo-version-0/cisco_n7k_vdc-HWd
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     cisco_n7k_vdc-HW-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: cisco_nexus-7k-x86_64
       packaging_platform: cisco-wrlinux-5-x86_64
       vrf: management
@@ -21,4 +17,4 @@ expected_hash:
     nfs_server: none
     consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
-expected_exception: 
+expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/cisco_n9k-HWf
+++ b/test/fixtures/generated/osinfo-version-0/cisco_n9k-HWf
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     cisco_n9k-HW-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: cisco_nexus-7-x86_64
       packaging_platform: cisco-wrlinux-5-x86_64
       vrf: management
@@ -21,4 +17,4 @@ expected_hash:
     nfs_server: none
     consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
-expected_exception: 
+expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/cisco_n9k-VMl
+++ b/test/fixtures/generated/osinfo-version-0/cisco_n9k-VMl
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     cisco_n9k-VM-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: cisco_nexus-7-x86_64
       packaging_platform: cisco-wrlinux-5-x86_64
       vrf: management
@@ -22,4 +18,4 @@ expected_hash:
     nfs_server: none
     consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
-expected_exception: 
+expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/cisco_xr_9k-VMm
+++ b/test/fixtures/generated/osinfo-version-0/cisco_xr_9k-VMm
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     cisco_xr_9k-VM-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: cisco_ios_xr-6-x86_64
       packaging_platform: cisco-wrlinux-7-x86_64
       template: cisco-exr-9k-x86_64
@@ -19,4 +15,4 @@ expected_hash:
     nfs_server: none
     consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
-expected_exception: 
+expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/ciscon7k-64a
+++ b/test/fixtures/generated/osinfo-version-0/ciscon7k-64a
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     ciscon7k-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: cisco_nexus-7k-x86_64
       packaging_platform: cisco-wrlinux-5-x86_64
       vrf: management
@@ -20,4 +16,4 @@ expected_hash:
     nfs_server: none
     consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
-expected_exception: 
+expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/cisconx-64aulcdfm
+++ b/test/fixtures/generated/osinfo-version-0/cisconx-64aulcdfm
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     cisconx-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: cisco_nexus-7-x86_64
       packaging_platform: cisco-wrlinux-5-x86_64
       vrf: management
@@ -27,4 +23,4 @@ expected_hash:
     nfs_server: none
     consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
-expected_exception: 
+expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/cisconx-64d
+++ b/test/fixtures/generated/osinfo-version-0/cisconx-64d
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     cisconx-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: cisco_nexus-7-x86_64
       packaging_platform: cisco-wrlinux-5-x86_64

--- a/test/fixtures/generated/osinfo-version-0/cisconxhw-64f
+++ b/test/fixtures/generated/osinfo-version-0/cisconxhw-64f
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     cisconxhw-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       hypervisor: vmpooler
       platform: cisco_nexus-7-x86_64
       packaging_platform: cisco-wrlinux-5-x86_64

--- a/test/fixtures/generated/osinfo-version-0/cisconxhw-64u
+++ b/test/fixtures/generated/osinfo-version-0/cisconxhw-64u
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     cisconxhw-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: cisco_nexus-7-x86_64
       packaging_platform: cisco-wrlinux-5-x86_64
       vrf: management
@@ -21,4 +17,4 @@ expected_hash:
     nfs_server: none
     consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
-expected_exception: 
+expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/cumulus25-64m
+++ b/test/fixtures/generated/osinfo-version-0/cumulus25-64m
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     cumulus25-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: cumulus-2.5-x86_64
       packaging_platform: cumulus-2.2-amd64
       template: cumulus-vx-25-x86_64

--- a/test/fixtures/generated/osinfo-version-0/debian10-32d
+++ b/test/fixtures/generated/osinfo-version-0/debian10-32d
@@ -4,12 +4,7 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     debian10-32-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: debian-10-i386
-      packaging_platform: debian-10-i386
       template: debian-10-i386
       hypervisor: vmpooler
       roles:

--- a/test/fixtures/generated/osinfo-version-0/debian10-64c
+++ b/test/fixtures/generated/osinfo-version-0/debian10-64c
@@ -4,12 +4,7 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     debian10-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: debian-10-amd64
-      packaging_platform: debian-10-amd64
       template: debian-10-x86_64
       hypervisor: vmpooler
       roles:

--- a/test/fixtures/generated/osinfo-version-0/debian11-64m
+++ b/test/fixtures/generated/osinfo-version-0/debian11-64m
@@ -4,12 +4,7 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     debian11-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: debian-11-amd64
-      packaging_platform: debian-11-amd64
       template: debian-11-x86_64
       hypervisor: vmpooler
       roles:

--- a/test/fixtures/generated/osinfo-version-0/debian6-32aulcdfm
+++ b/test/fixtures/generated/osinfo-version-0/debian6-32aulcdfm
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     debian6-32-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: debian-6-i386
       template: debian-6-i386
       hypervisor: vmpooler

--- a/test/fixtures/generated/osinfo-version-0/debian6-64a
+++ b/test/fixtures/generated/osinfo-version-0/debian6-64a
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     debian6-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: debian-6-amd64
       template: debian-6-x86_64
       hypervisor: vmpooler

--- a/test/fixtures/generated/osinfo-version-0/debian7-32u
+++ b/test/fixtures/generated/osinfo-version-0/debian7-32u
@@ -4,12 +4,7 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     debian7-32-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: debian-7-i386
-      packaging_platform: debian-7-i386
       template: debian-7-i386
       hypervisor: vmpooler
       roles:

--- a/test/fixtures/generated/osinfo-version-0/debian7-64l
+++ b/test/fixtures/generated/osinfo-version-0/debian7-64l
@@ -4,12 +4,7 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     debian7-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: debian-7-amd64
-      packaging_platform: debian-7-amd64
       template: debian-7-x86_64
       hypervisor: vmpooler
       roles:

--- a/test/fixtures/generated/osinfo-version-0/debian8-32c
+++ b/test/fixtures/generated/osinfo-version-0/debian8-32c
@@ -4,12 +4,7 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     debian8-32-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: debian-8-i386
-      packaging_platform: debian-8-i386
       template: debian-8-i386
       hypervisor: vmpooler
       roles:

--- a/test/fixtures/generated/osinfo-version-0/debian8-64d
+++ b/test/fixtures/generated/osinfo-version-0/debian8-64d
@@ -4,12 +4,7 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     debian8-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: debian-8-amd64
-      packaging_platform: debian-8-amd64
       template: debian-8-x86_64
       hypervisor: vmpooler
       roles:

--- a/test/fixtures/generated/osinfo-version-0/debian9-32f
+++ b/test/fixtures/generated/osinfo-version-0/debian9-32f
@@ -4,12 +4,7 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     debian9-32-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: debian-9-i386
-      packaging_platform: debian-9-i386
       template: debian-9-i386
       hypervisor: vmpooler
       roles:

--- a/test/fixtures/generated/osinfo-version-0/debian9-64m
+++ b/test/fixtures/generated/osinfo-version-0/debian9-64m
@@ -4,12 +4,7 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     debian9-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: debian-9-amd64
-      packaging_platform: debian-9-amd64
       template: debian-9-x86_64
       hypervisor: vmpooler
       roles:

--- a/test/fixtures/generated/osinfo-version-0/fedora14-32aulcdfm
+++ b/test/fixtures/generated/osinfo-version-0/fedora14-32aulcdfm
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     fedora14-32-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: fedora-14-i386
       template: fedora-14-i386

--- a/test/fixtures/generated/osinfo-version-0/fedora19-32a
+++ b/test/fixtures/generated/osinfo-version-0/fedora19-32a
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     fedora19-32-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: fedora-19-i386
       hypervisor: vmpooler
       template: fedora-19-i386

--- a/test/fixtures/generated/osinfo-version-0/fedora19-64u
+++ b/test/fixtures/generated/osinfo-version-0/fedora19-64u
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     fedora19-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: fedora-19-x86_64
       hypervisor: vmpooler
       template: fedora-19-x86_64

--- a/test/fixtures/generated/osinfo-version-0/fedora20-32l
+++ b/test/fixtures/generated/osinfo-version-0/fedora20-32l
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     fedora20-32-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: fedora-20-i386
       hypervisor: vmpooler
       template: fedora-20-i386

--- a/test/fixtures/generated/osinfo-version-0/fedora20-64c
+++ b/test/fixtures/generated/osinfo-version-0/fedora20-64c
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     fedora20-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: fedora-20-x86_64
       hypervisor: vmpooler
       template: fedora-20-x86_64

--- a/test/fixtures/generated/osinfo-version-0/fedora21-32d
+++ b/test/fixtures/generated/osinfo-version-0/fedora21-32d
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     fedora21-32-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: fedora-21-i386
       hypervisor: vmpooler
       template: fedora-21-i386

--- a/test/fixtures/generated/osinfo-version-0/fedora21-64f
+++ b/test/fixtures/generated/osinfo-version-0/fedora21-64f
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     fedora21-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: fedora-21-x86_64
       hypervisor: vmpooler
       template: fedora-21-x86_64

--- a/test/fixtures/generated/osinfo-version-0/fedora22-32m
+++ b/test/fixtures/generated/osinfo-version-0/fedora22-32m
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     fedora22-32-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: fedora-22-i386
       hypervisor: vmpooler
       template: fedora-22-i386

--- a/test/fixtures/generated/osinfo-version-0/fedora22-64aulcdfm
+++ b/test/fixtures/generated/osinfo-version-0/fedora22-64aulcdfm
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     fedora22-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: fedora-22-x86_64
       hypervisor: vmpooler
       template: fedora-22-x86_64

--- a/test/fixtures/generated/osinfo-version-0/fedora23-32a
+++ b/test/fixtures/generated/osinfo-version-0/fedora23-32a
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     fedora23-32-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: fedora-23-i386
       hypervisor: vmpooler
       template: fedora-23-i386

--- a/test/fixtures/generated/osinfo-version-0/fedora23-64u
+++ b/test/fixtures/generated/osinfo-version-0/fedora23-64u
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     fedora23-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: fedora-23-x86_64
       hypervisor: vmpooler
       template: fedora-23-x86_64

--- a/test/fixtures/generated/osinfo-version-0/fedora24-32l
+++ b/test/fixtures/generated/osinfo-version-0/fedora24-32l
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     fedora24-32-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: fedora-24-i386
       hypervisor: vmpooler
       template: fedora-24-i386

--- a/test/fixtures/generated/osinfo-version-0/fedora24-64c
+++ b/test/fixtures/generated/osinfo-version-0/fedora24-64c
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     fedora24-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: fedora-24-x86_64
       hypervisor: vmpooler
       template: fedora-24-x86_64

--- a/test/fixtures/generated/osinfo-version-0/fedora25-32d
+++ b/test/fixtures/generated/osinfo-version-0/fedora25-32d
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     fedora25-32-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: fedora-25-i386
       hypervisor: vmpooler
       template: fedora-25-i386

--- a/test/fixtures/generated/osinfo-version-0/fedora25-64f
+++ b/test/fixtures/generated/osinfo-version-0/fedora25-64f
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     fedora25-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: fedora-25-x86_64
       hypervisor: vmpooler
       template: fedora-25-x86_64

--- a/test/fixtures/generated/osinfo-version-0/fedora26-64m
+++ b/test/fixtures/generated/osinfo-version-0/fedora26-64m
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     fedora26-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: fedora-26-x86_64
       template: fedora-26-x86_64

--- a/test/fixtures/generated/osinfo-version-0/fedora27-64l
+++ b/test/fixtures/generated/osinfo-version-0/fedora27-64l
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     fedora27-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: fedora-27-x86_64
       template: fedora-27-x86_64

--- a/test/fixtures/generated/osinfo-version-0/fedora28-64d
+++ b/test/fixtures/generated/osinfo-version-0/fedora28-64d
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     fedora28-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: fedora-28-x86_64
       template: fedora-28-x86_64

--- a/test/fixtures/generated/osinfo-version-0/fedora29-64d
+++ b/test/fixtures/generated/osinfo-version-0/fedora29-64d
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     fedora29-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: fedora-29-x86_64
       template: fedora-29-x86_64

--- a/test/fixtures/generated/osinfo-version-0/fedora30-64aulcdfm
+++ b/test/fixtures/generated/osinfo-version-0/fedora30-64aulcdfm
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     fedora30-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: fedora-30-x86_64
       hypervisor: vmpooler
       template: fedora-30-x86_64

--- a/test/fixtures/generated/osinfo-version-0/fedora31-64aulcdfm
+++ b/test/fixtures/generated/osinfo-version-0/fedora31-64aulcdfm
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     fedora31-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: fedora-31-x86_64
       template: fedora-31-x86_64
       hypervisor: vmpooler

--- a/test/fixtures/generated/osinfo-version-0/fedora32-64a
+++ b/test/fixtures/generated/osinfo-version-0/fedora32-64a
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     fedora32-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: fedora-32-x86_64
       template: fedora-32-x86_64
       hypervisor: vmpooler

--- a/test/fixtures/generated/osinfo-version-0/fedora34-64c
+++ b/test/fixtures/generated/osinfo-version-0/fedora34-64c
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     fedora34-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: fedora-34-x86_64
       hypervisor: vmpooler
       template: fedora-34-x86_64

--- a/test/fixtures/generated/osinfo-version-0/huaweios6-POWERaulcdfm
+++ b/test/fixtures/generated/osinfo-version-0/huaweios6-POWERaulcdfm
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     huaweios6-POWER-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: huaweios-6-powerpc
       roles:

--- a/test/fixtures/generated/osinfo-version-0/opensuse11-32a
+++ b/test/fixtures/generated/osinfo-version-0/opensuse11-32a
@@ -4,17 +4,13 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     opensuse11-32-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
-      hypervisor: vmpooler
       platform: opensuse-11-i386
       template: opensuse-11-i386
+      hypervisor: vmpooler
       roles:
       - agent
   CONFIG:
     nfs_server: none
     consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
-expected_exception: 
+expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/opensuse11-64u
+++ b/test/fixtures/generated/osinfo-version-0/opensuse11-64u
@@ -4,13 +4,9 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     opensuse11-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
-      hypervisor: vmpooler
       platform: opensuse-11-x86_64
       template: opensuse-11-x86_64
+      hypervisor: vmpooler
       roles:
       - agent
       - ca
@@ -18,4 +14,4 @@ expected_hash:
     nfs_server: none
     consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
-expected_exception: 
+expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/oracle5-32l
+++ b/test/fixtures/generated/osinfo-version-0/oracle5-32l
@@ -4,13 +4,8 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     oracle5-32-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: el-5-i386
-      packaging_platform: el-5-i386
       template: oracle-5-i386
       roles:
       - agent

--- a/test/fixtures/generated/osinfo-version-0/oracle5-64c
+++ b/test/fixtures/generated/osinfo-version-0/oracle5-64c
@@ -4,13 +4,8 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     oracle5-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: el-5-x86_64
-      packaging_platform: el-5-x86_64
       template: oracle-5-x86_64
       roles:
       - agent

--- a/test/fixtures/generated/osinfo-version-0/oracle6-32d
+++ b/test/fixtures/generated/osinfo-version-0/oracle6-32d
@@ -4,13 +4,8 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     oracle6-32-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: el-6-i386
-      packaging_platform: el-6-i386
       template: oracle-6-i386
       roles:
       - agent

--- a/test/fixtures/generated/osinfo-version-0/oracle6-64f
+++ b/test/fixtures/generated/osinfo-version-0/oracle6-64f
@@ -4,13 +4,8 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     oracle6-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: el-6-x86_64
-      packaging_platform: el-6-x86_64
       template: oracle-6-x86_64
       roles:
       - agent

--- a/test/fixtures/generated/osinfo-version-0/oracle7-64m
+++ b/test/fixtures/generated/osinfo-version-0/oracle7-64m
@@ -4,13 +4,8 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     oracle7-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: el-7-x86_64
-      packaging_platform: el-7-x86_64
       template: oracle-7-x86_64
       roles:
       - agent

--- a/test/fixtures/generated/osinfo-version-0/osx1010-64a
+++ b/test/fixtures/generated/osinfo-version-0/osx1010-64a
@@ -4,13 +4,8 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     osx1010-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: osx-10.10-x86_64
-      packaging_platform: osx-10.10-x86_64
       template: osx-1010-x86_64
       roles:
       - agent

--- a/test/fixtures/generated/osinfo-version-0/osx1011-64u
+++ b/test/fixtures/generated/osinfo-version-0/osx1011-64u
@@ -4,13 +4,8 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     osx1011-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: osx-10.11-x86_64
-      packaging_platform: osx-10.11-x86_64
       template: osx-1011-x86_64
       roles:
       - agent

--- a/test/fixtures/generated/osinfo-version-0/osx1012-64l
+++ b/test/fixtures/generated/osinfo-version-0/osx1012-64l
@@ -4,13 +4,8 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     osx1012-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: osx-10.12-x86_64
-      packaging_platform: osx-10.12-x86_64
       template: osx-1012-x86_64
       roles:
       - agent

--- a/test/fixtures/generated/osinfo-version-0/osx1013-64f
+++ b/test/fixtures/generated/osinfo-version-0/osx1013-64f
@@ -4,12 +4,7 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     osx1013-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: osx-10.13-x86_64
-      packaging_platform: osx-10.13-x86_64
       template: osx-1013-x86_64
       hypervisor: vmpooler
       roles:

--- a/test/fixtures/generated/osinfo-version-0/osx1014-64f
+++ b/test/fixtures/generated/osinfo-version-0/osx1014-64f
@@ -4,13 +4,8 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     osx1014-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: osx-10.14-x86_64
-      packaging_platform: osx-10.14-x86_64
       template: osx-1014-x86_64
       roles:
       - agent

--- a/test/fixtures/generated/osinfo-version-0/osx1015-64u
+++ b/test/fixtures/generated/osinfo-version-0/osx1015-64u
@@ -4,12 +4,7 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     osx1015-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: osx-10.15-x86_64
-      packaging_platform: osx-10.15-x86_64
       template: osx-1015-x86_64
       hypervisor: vmpooler
       roles:
@@ -19,4 +14,4 @@ expected_hash:
     nfs_server: none
     consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
-expected_exception: 
+expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/osx109-64aulcdfm
+++ b/test/fixtures/generated/osinfo-version-0/osx109-64aulcdfm
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     osx109-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: osx-10.9-x86_64
       template: osx-109-x86_64

--- a/test/fixtures/generated/osinfo-version-0/osx11-64f
+++ b/test/fixtures/generated/osinfo-version-0/osx11-64f
@@ -4,12 +4,7 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     osx11-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: osx-11-x86_64
-      packaging_platform: osx-11-x86_64
       template: macos-112-x86_64
       hypervisor: vmpooler
       roles:

--- a/test/fixtures/generated/osinfo-version-0/panos61-64f
+++ b/test/fixtures/generated/osinfo-version-0/panos61-64f
@@ -4,13 +4,9 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     panos61-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
-      hypervisor: vmpooler
       platform: palo-alto-6.1.0-x86_64
       template: palo-alto-6.1.0-x86_64
+      hypervisor: vmpooler
       roles:
       - agent
       - frictionless
@@ -18,4 +14,4 @@ expected_hash:
     nfs_server: none
     consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
-expected_exception: 
+expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/panos71-64m
+++ b/test/fixtures/generated/osinfo-version-0/panos71-64m
@@ -4,13 +4,9 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     panos71-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
-      hypervisor: vmpooler
       platform: palo-alto-7.1.0-x86_64
       template: palo-alto-7.1.0-x86_64
+      hypervisor: vmpooler
       roles:
       - agent
       - master
@@ -18,4 +14,4 @@ expected_hash:
     nfs_server: none
     consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
-expected_exception: 
+expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/panos81-64aulcdfm
+++ b/test/fixtures/generated/osinfo-version-0/panos81-64aulcdfm
@@ -4,13 +4,9 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     panos81-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
-      hypervisor: vmpooler
       platform: palo-alto-8.1.0-x86_64
       template: palo-alto-8.1.0-x86_64
+      hypervisor: vmpooler
       roles:
       - agent
       - ca
@@ -23,4 +19,4 @@ expected_hash:
     nfs_server: none
     consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
-expected_exception: 
+expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/redhat4-32c
+++ b/test/fixtures/generated/osinfo-version-0/redhat4-32c
@@ -4,13 +4,9 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     redhat4-32-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
-      hypervisor: vmpooler
       platform: el-4-i386
       template: redhat-4-i386
+      hypervisor: vmpooler
       roles:
       - agent
       - dashboard
@@ -18,4 +14,4 @@ expected_hash:
     nfs_server: none
     consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
-expected_exception: 
+expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/redhat4-64d
+++ b/test/fixtures/generated/osinfo-version-0/redhat4-64d
@@ -4,13 +4,9 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     redhat4-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
-      hypervisor: vmpooler
       platform: el-4-x86_64
       template: redhat-4-x86_64
+      hypervisor: vmpooler
       roles:
       - agent
       - database
@@ -18,4 +14,4 @@ expected_hash:
     nfs_server: none
     consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
-expected_exception: 
+expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/redhat5-32f
+++ b/test/fixtures/generated/osinfo-version-0/redhat5-32f
@@ -4,14 +4,9 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     redhat5-32-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
-      hypervisor: vmpooler
       platform: el-5-i386
-      packaging_platform: el-5-i386
       template: redhat-5-i386
+      hypervisor: vmpooler
       roles:
       - agent
       - frictionless
@@ -19,4 +14,4 @@ expected_hash:
     nfs_server: none
     consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
-expected_exception: 
+expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/redhat5-64m
+++ b/test/fixtures/generated/osinfo-version-0/redhat5-64m
@@ -4,14 +4,9 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     redhat5-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
-      hypervisor: vmpooler
       platform: el-5-x86_64
-      packaging_platform: el-5-x86_64
       template: redhat-5-x86_64
+      hypervisor: vmpooler
       roles:
       - agent
       - master
@@ -19,4 +14,4 @@ expected_hash:
     nfs_server: none
     consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
-expected_exception: 
+expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/redhat6-32aulcdfm
+++ b/test/fixtures/generated/osinfo-version-0/redhat6-32aulcdfm
@@ -4,14 +4,9 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     redhat6-32-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
-      hypervisor: vmpooler
       platform: el-6-i386
-      packaging_platform: el-6-i386
       template: redhat-6-i386
+      hypervisor: vmpooler
       roles:
       - agent
       - ca
@@ -24,4 +19,4 @@ expected_hash:
     nfs_server: none
     consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
-expected_exception: 
+expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/redhat6-64a
+++ b/test/fixtures/generated/osinfo-version-0/redhat6-64a
@@ -4,18 +4,13 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     redhat6-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
-      hypervisor: vmpooler
       platform: el-6-x86_64
-      packaging_platform: el-6-x86_64
       template: redhat-6-x86_64
+      hypervisor: vmpooler
       roles:
       - agent
   CONFIG:
     nfs_server: none
     consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
-expected_exception: 
+expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/redhat7-64l
+++ b/test/fixtures/generated/osinfo-version-0/redhat7-64l
@@ -4,14 +4,9 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     redhat7-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
-      hypervisor: vmpooler
       platform: el-7-x86_64
-      packaging_platform: el-7-x86_64
       template: redhat-7-x86_64
+      hypervisor: vmpooler
       roles:
       - agent
       - classifier
@@ -19,4 +14,4 @@ expected_hash:
     nfs_server: none
     consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
-expected_exception: 
+expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/redhat7-AARCH64a
+++ b/test/fixtures/generated/osinfo-version-0/redhat7-AARCH64a
@@ -4,13 +4,8 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     redhat7-AARCH64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: el-7-aarch64
-      packaging_platform: el-7-aarch64
       template: redhat-7-x86_64
       roles:
       - agent

--- a/test/fixtures/generated/osinfo-version-0/redhat7-AARCH64aulcdfm
+++ b/test/fixtures/generated/osinfo-version-0/redhat7-AARCH64aulcdfm
@@ -4,13 +4,8 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     redhat7-AARCH64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: el-7-aarch64
-      packaging_platform: el-7-aarch64
       template: redhat-7-x86_64
       roles:
       - agent

--- a/test/fixtures/generated/osinfo-version-0/redhat7-POWERc
+++ b/test/fixtures/generated/osinfo-version-0/redhat7-POWERc
@@ -4,12 +4,7 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     redhat7-POWER-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: el-7-ppc64le
-      packaging_platform: el-7-ppc64le
       hypervisor: vmpooler
       template: redhat-7-ppc64le
       roles:

--- a/test/fixtures/generated/osinfo-version-0/redhat7-S390Xd
+++ b/test/fixtures/generated/osinfo-version-0/redhat7-S390Xd
@@ -4,12 +4,7 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     redhat7-S390X-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: el-7-s390x
-      packaging_platform: el-7-s390x
       hypervisor: vmpooler
       template: redhat-7-s390x
       roles:

--- a/test/fixtures/generated/osinfo-version-0/redhat8-64u
+++ b/test/fixtures/generated/osinfo-version-0/redhat8-64u
@@ -4,13 +4,8 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     redhat8-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: el-8-x86_64
-      packaging_platform: el-8-x86_64
       template: redhat-8-x86_64
       roles:
       - agent

--- a/test/fixtures/generated/osinfo-version-0/redhat8-AARCH64a
+++ b/test/fixtures/generated/osinfo-version-0/redhat8-AARCH64a
@@ -4,12 +4,7 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     redhat8-AARCH64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: el-8-aarch64
-      packaging_platform: el-8-aarch64
       template: redhat-8-x86_64
       hypervisor: vmpooler
       roles:

--- a/test/fixtures/generated/osinfo-version-0/redhat9-64l
+++ b/test/fixtures/generated/osinfo-version-0/redhat9-64l
@@ -4,12 +4,7 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     redhat9-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: el-9-x86_64
-      packaging_platform: el-9-x86_64
       template: redhat-9-x86_64
       hypervisor: vmpooler
       roles:

--- a/test/fixtures/generated/osinfo-version-0/redhatfips7-64aulcdfm
+++ b/test/fixtures/generated/osinfo-version-0/redhatfips7-64aulcdfm
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     redhatfips7-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: el-7-x86_64
       packaging_platform: redhatfips-7-x86_64

--- a/test/fixtures/generated/osinfo-version-0/redhatfips8-64m
+++ b/test/fixtures/generated/osinfo-version-0/redhatfips8-64m
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     redhatfips8-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: el-8-x86_64
       packaging_platform: redhatfips-8-x86_64
       template: redhat-fips-8-x86_64

--- a/test/fixtures/generated/osinfo-version-0/rocky8-64l
+++ b/test/fixtures/generated/osinfo-version-0/rocky8-64l
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     rocky8-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: el-8-x86_64
       hypervisor: vmpooler
       template: rocky-8-x86_64

--- a/test/fixtures/generated/osinfo-version-0/scientific5-32f
+++ b/test/fixtures/generated/osinfo-version-0/scientific5-32f
@@ -4,14 +4,9 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     scientific5-32-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
-      hypervisor: vmpooler
       platform: el-5-i386
-      packaging_platform: el-5-i386
       template: scientific-5-i386
+      hypervisor: vmpooler
       roles:
       - agent
       - frictionless
@@ -19,4 +14,4 @@ expected_hash:
     nfs_server: none
     consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
-expected_exception: 
+expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/scientific5-64m
+++ b/test/fixtures/generated/osinfo-version-0/scientific5-64m
@@ -4,14 +4,9 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     scientific5-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
-      hypervisor: vmpooler
       platform: el-5-x86_64
-      packaging_platform: el-5-x86_64
       template: scientific-5-x86_64
+      hypervisor: vmpooler
       roles:
       - agent
       - master
@@ -19,4 +14,4 @@ expected_hash:
     nfs_server: none
     consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
-expected_exception: 
+expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/scientific6-32aulcdfm
+++ b/test/fixtures/generated/osinfo-version-0/scientific6-32aulcdfm
@@ -4,14 +4,9 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     scientific6-32-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
-      hypervisor: vmpooler
       platform: el-6-i386
-      packaging_platform: el-6-i386
       template: scientific-6-i386
+      hypervisor: vmpooler
       roles:
       - agent
       - ca
@@ -24,4 +19,4 @@ expected_hash:
     nfs_server: none
     consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
-expected_exception: 
+expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/scientific6-64a
+++ b/test/fixtures/generated/osinfo-version-0/scientific6-64a
@@ -4,18 +4,13 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     scientific6-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
-      hypervisor: vmpooler
       platform: el-6-x86_64
-      packaging_platform: el-6-x86_64
       template: scientific-6-x86_64
+      hypervisor: vmpooler
       roles:
       - agent
   CONFIG:
     nfs_server: none
     consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
-expected_exception: 
+expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/scientific7-64u
+++ b/test/fixtures/generated/osinfo-version-0/scientific7-64u
@@ -4,14 +4,9 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     scientific7-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
-      hypervisor: vmpooler
       platform: el-7-x86_64
-      packaging_platform: el-7-x86_64
       template: scientific-7-x86_64
+      hypervisor: vmpooler
       roles:
       - agent
       - ca
@@ -19,4 +14,4 @@ expected_hash:
     nfs_server: none
     consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
-expected_exception: 
+expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/sles10-32l
+++ b/test/fixtures/generated/osinfo-version-0/sles10-32l
@@ -4,13 +4,9 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     sles10-32-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
-      hypervisor: vmpooler
       platform: sles-10-i386
       template: sles-10-i386
+      hypervisor: vmpooler
       roles:
       - agent
       - classifier
@@ -18,4 +14,4 @@ expected_hash:
     nfs_server: none
     consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
-expected_exception: 
+expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/sles10-64c
+++ b/test/fixtures/generated/osinfo-version-0/sles10-64c
@@ -4,13 +4,9 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     sles10-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
-      hypervisor: vmpooler
       platform: sles-10-x86_64
       template: sles-10-x86_64
+      hypervisor: vmpooler
       roles:
       - agent
       - dashboard
@@ -18,4 +14,4 @@ expected_hash:
     nfs_server: none
     consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
-expected_exception: 
+expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/sles11-32d
+++ b/test/fixtures/generated/osinfo-version-0/sles11-32d
@@ -4,14 +4,9 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     sles11-32-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
-      hypervisor: vmpooler
       platform: sles-11-i386
-      packaging_platform: sles-11-i386
       template: sles-11-i386
+      hypervisor: vmpooler
       roles:
       - agent
       - database
@@ -19,4 +14,4 @@ expected_hash:
     nfs_server: none
     consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
-expected_exception: 
+expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/sles11-64f
+++ b/test/fixtures/generated/osinfo-version-0/sles11-64f
@@ -4,14 +4,9 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     sles11-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
-      hypervisor: vmpooler
       platform: sles-11-x86_64
-      packaging_platform: sles-11-x86_64
       template: sles-11-x86_64
+      hypervisor: vmpooler
       roles:
       - agent
       - frictionless
@@ -19,4 +14,4 @@ expected_hash:
     nfs_server: none
     consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
-expected_exception: 
+expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/sles11-S390Xm
+++ b/test/fixtures/generated/osinfo-version-0/sles11-S390Xm
@@ -4,13 +4,8 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     sles11-S390X-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
-      hypervisor: vmpooler
       platform: sles-11-s390x
-      packaging_platform: sles-11-s390x
+      hypervisor: vmpooler
       roles:
       - agent
       - master
@@ -18,4 +13,4 @@ expected_hash:
     nfs_server: none
     consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
-expected_exception: 
+expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/sles12-64aulcdfm
+++ b/test/fixtures/generated/osinfo-version-0/sles12-64aulcdfm
@@ -4,14 +4,9 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     sles12-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
-      hypervisor: vmpooler
       platform: sles-12-x86_64
-      packaging_platform: sles-12-x86_64
       template: sles-12-x86_64
+      hypervisor: vmpooler
       roles:
       - agent
       - ca
@@ -24,4 +19,4 @@ expected_hash:
     nfs_server: none
     consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
-expected_exception: 
+expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/sles12-POWERu
+++ b/test/fixtures/generated/osinfo-version-0/sles12-POWERu
@@ -4,13 +4,8 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     sles12-POWER-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
-      hypervisor: vmpooler
       platform: sles-12-ppc64le
-      packaging_platform: sles-12-ppc64le
+      hypervisor: vmpooler
       roles:
       - agent
       - ca
@@ -18,4 +13,4 @@ expected_hash:
     nfs_server: none
     consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
-expected_exception: 
+expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/sles12-S390Xa
+++ b/test/fixtures/generated/osinfo-version-0/sles12-S390Xa
@@ -4,17 +4,12 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     sles12-S390X-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
-      hypervisor: vmpooler
       platform: sles-12-s390x
-      packaging_platform: sles-12-s390x
+      hypervisor: vmpooler
       roles:
       - agent
   CONFIG:
     nfs_server: none
     consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
-expected_exception: 
+expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/sles15-64l
+++ b/test/fixtures/generated/osinfo-version-0/sles15-64l
@@ -4,14 +4,9 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     sles15-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
-      hypervisor: vmpooler
       platform: sles-15-x86_64
-      packaging_platform: sles-15-x86_64
       template: sles-15-x86_64
+      hypervisor: vmpooler
       roles:
       - agent
       - classifier
@@ -19,4 +14,4 @@ expected_hash:
     nfs_server: none
     consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
-expected_exception: 
+expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/solaris10-32l
+++ b/test/fixtures/generated/osinfo-version-0/solaris10-32l
@@ -4,13 +4,8 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     solaris10-32-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: solaris-10-i386
-      packaging_platform: solaris-10-i386
       template: solaris-10-x86_64
       roles:
       - agent

--- a/test/fixtures/generated/osinfo-version-0/solaris10-64c
+++ b/test/fixtures/generated/osinfo-version-0/solaris10-64c
@@ -4,13 +4,8 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     solaris10-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: solaris-10-i386
-      packaging_platform: solaris-10-i386
       template: solaris-10-x86_64
       roles:
       - agent

--- a/test/fixtures/generated/osinfo-version-0/solaris10-SPARCd
+++ b/test/fixtures/generated/osinfo-version-0/solaris10-SPARCd
@@ -4,13 +4,8 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     solaris10-SPARC-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: solaris-10-sparc
-      packaging_platform: solaris-10-sparc
       roles:
       - agent
       - database

--- a/test/fixtures/generated/osinfo-version-0/solaris11-32f
+++ b/test/fixtures/generated/osinfo-version-0/solaris11-32f
@@ -4,13 +4,8 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     solaris11-32-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: solaris-11-i386
-      packaging_platform: solaris-11-i386
       template: solaris-11-x86_64
       roles:
       - agent

--- a/test/fixtures/generated/osinfo-version-0/solaris11-64m
+++ b/test/fixtures/generated/osinfo-version-0/solaris11-64m
@@ -4,13 +4,8 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     solaris11-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: solaris-11-i386
-      packaging_platform: solaris-11-i386
       template: solaris-11-x86_64
       roles:
       - agent

--- a/test/fixtures/generated/osinfo-version-0/solaris11-SPARCaulcdfm
+++ b/test/fixtures/generated/osinfo-version-0/solaris11-SPARCaulcdfm
@@ -4,13 +4,8 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     solaris11-SPARC-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: solaris-11-sparc
-      packaging_platform: solaris-11-sparc
       roles:
       - agent
       - ca

--- a/test/fixtures/generated/osinfo-version-0/solaris112-32a
+++ b/test/fixtures/generated/osinfo-version-0/solaris112-32a
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     solaris112-32-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: solaris-11.2-i386
       packaging_platform: solaris-11-i386

--- a/test/fixtures/generated/osinfo-version-0/solaris112-64u
+++ b/test/fixtures/generated/osinfo-version-0/solaris112-64u
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     solaris112-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: solaris-11.2-i386
       packaging_platform: solaris-11-i386

--- a/test/fixtures/generated/osinfo-version-0/ubuntu1404-32d
+++ b/test/fixtures/generated/osinfo-version-0/ubuntu1404-32d
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     ubuntu1404-32-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: ubuntu-14.04-i386
       hypervisor: vmpooler
       template: ubuntu-1404-i386

--- a/test/fixtures/generated/osinfo-version-0/ubuntu1404-32m
+++ b/test/fixtures/generated/osinfo-version-0/ubuntu1404-32m
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     ubuntu1404-32-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: ubuntu-14.04-i386
       template: ubuntu-1404-i386

--- a/test/fixtures/generated/osinfo-version-0/ubuntu1404-64aulcdfm
+++ b/test/fixtures/generated/osinfo-version-0/ubuntu1404-64aulcdfm
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     ubuntu1404-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: ubuntu-14.04-amd64
       template: ubuntu-1404-x86_64

--- a/test/fixtures/generated/osinfo-version-0/ubuntu1404-64f
+++ b/test/fixtures/generated/osinfo-version-0/ubuntu1404-64f
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     ubuntu1404-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: ubuntu-14.04-amd64
       hypervisor: vmpooler
       template: ubuntu-1404-x86_64

--- a/test/fixtures/generated/osinfo-version-0/ubuntu1404-AARCH64aulcdfm
+++ b/test/fixtures/generated/osinfo-version-0/ubuntu1404-AARCH64aulcdfm
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     ubuntu1404-AARCH64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: ubuntu-14.04-aarch64
       hypervisor: vmpooler
       roles:

--- a/test/fixtures/generated/osinfo-version-0/ubuntu1404-POWERm
+++ b/test/fixtures/generated/osinfo-version-0/ubuntu1404-POWERm
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     ubuntu1404-POWER-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: ubuntu-14.04-ppc64el
       hypervisor: vmpooler
       roles:

--- a/test/fixtures/generated/osinfo-version-0/ubuntu1604-32a
+++ b/test/fixtures/generated/osinfo-version-0/ubuntu1604-32a
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     ubuntu1604-32-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: ubuntu-16.04-i386
       hypervisor: vmpooler
       template: ubuntu-1604-i386

--- a/test/fixtures/generated/osinfo-version-0/ubuntu1604-32d
+++ b/test/fixtures/generated/osinfo-version-0/ubuntu1604-32d
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     ubuntu1604-32-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: ubuntu-16.04-i386
       template: ubuntu-1604-i386

--- a/test/fixtures/generated/osinfo-version-0/ubuntu1604-64f
+++ b/test/fixtures/generated/osinfo-version-0/ubuntu1604-64f
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     ubuntu1604-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: ubuntu-16.04-amd64
       template: ubuntu-1604-x86_64

--- a/test/fixtures/generated/osinfo-version-0/ubuntu1604-64u
+++ b/test/fixtures/generated/osinfo-version-0/ubuntu1604-64u
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     ubuntu1604-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: ubuntu-16.04-amd64
       hypervisor: vmpooler
       template: ubuntu-1604-x86_64

--- a/test/fixtures/generated/osinfo-version-0/ubuntu1604-AARCH64c
+++ b/test/fixtures/generated/osinfo-version-0/ubuntu1604-AARCH64c
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     ubuntu1604-AARCH64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: ubuntu-16.04-aarch64
       hypervisor: vmpooler
       roles:

--- a/test/fixtures/generated/osinfo-version-0/ubuntu1604-POWERl
+++ b/test/fixtures/generated/osinfo-version-0/ubuntu1604-POWERl
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     ubuntu1604-POWER-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: ubuntu-16.04-ppc64el
       hypervisor: vmpooler
       roles:

--- a/test/fixtures/generated/osinfo-version-0/ubuntu1604-POWERm
+++ b/test/fixtures/generated/osinfo-version-0/ubuntu1604-POWERm
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     ubuntu1604-POWER-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: ubuntu-16.04-ppc64el
       roles:

--- a/test/fixtures/generated/osinfo-version-0/ubuntu1804-64a
+++ b/test/fixtures/generated/osinfo-version-0/ubuntu1804-64a
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     ubuntu1804-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: ubuntu-18.04-amd64
       template: ubuntu-1804-x86_64

--- a/test/fixtures/generated/osinfo-version-0/ubuntu1804-64d
+++ b/test/fixtures/generated/osinfo-version-0/ubuntu1804-64d
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     ubuntu1804-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: ubuntu-18.04-amd64
       hypervisor: vmpooler
       template: ubuntu-1804-x86_64

--- a/test/fixtures/generated/osinfo-version-0/ubuntu1804-AARCH64m
+++ b/test/fixtures/generated/osinfo-version-0/ubuntu1804-AARCH64m
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     ubuntu1804-AARCH64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: ubuntu-18.04-aarch64
       hypervisor: vmpooler
       roles:

--- a/test/fixtures/generated/osinfo-version-0/ubuntu1804-POWERf
+++ b/test/fixtures/generated/osinfo-version-0/ubuntu1804-POWERf
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     ubuntu1804-POWER-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: ubuntu-18.04-ppc64el
       hypervisor: vmpooler
       roles:

--- a/test/fixtures/generated/osinfo-version-0/ubuntu2004-64a
+++ b/test/fixtures/generated/osinfo-version-0/ubuntu2004-64a
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     ubuntu2004-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: ubuntu-20.04-amd64
       template: ubuntu-2004-x86_64
       hypervisor: vmpooler

--- a/test/fixtures/generated/osinfo-version-0/ubuntu2004-64aulcdfm
+++ b/test/fixtures/generated/osinfo-version-0/ubuntu2004-64aulcdfm
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     ubuntu2004-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: ubuntu-20.04-amd64
       hypervisor: vmpooler
       template: ubuntu-2004-x86_64

--- a/test/fixtures/generated/osinfo-version-0/ubuntu2004-AARCH64c
+++ b/test/fixtures/generated/osinfo-version-0/ubuntu2004-AARCH64c
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     ubuntu2004-AARCH64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: ubuntu-20.04-aarch64
       hypervisor: vmpooler
       roles:

--- a/test/fixtures/generated/osinfo-version-0/ubuntu2004-AARCH64u
+++ b/test/fixtures/generated/osinfo-version-0/ubuntu2004-AARCH64u
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     ubuntu2004-AARCH64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: ubuntu-20.04-aarch64
       hypervisor: vmpooler
       roles:

--- a/test/fixtures/generated/osinfo-version-0/ubuntu2004-POWERa
+++ b/test/fixtures/generated/osinfo-version-0/ubuntu2004-POWERa
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     ubuntu2004-POWER-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: ubuntu-20.04-ppc64el
       hypervisor: vmpooler
       roles:

--- a/test/fixtures/generated/osinfo-version-0/ubuntu2010-64l
+++ b/test/fixtures/generated/osinfo-version-0/ubuntu2010-64l
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     ubuntu2010-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: ubuntu-20.10-amd64
       hypervisor: vmpooler
       template: ubuntu-2010-x86_64

--- a/test/fixtures/generated/osinfo-version-0/ubuntu2104-64c
+++ b/test/fixtures/generated/osinfo-version-0/ubuntu2104-64c
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     ubuntu2104-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: ubuntu-21.04-amd64
       hypervisor: vmpooler
       template: ubuntu-2104-x86_64

--- a/test/fixtures/generated/osinfo-version-0/ubuntu2110-64d
+++ b/test/fixtures/generated/osinfo-version-0/ubuntu2110-64d
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     ubuntu2110-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: ubuntu-21.10-amd64
       hypervisor: vmpooler
       template: ubuntu-2110-x86_64

--- a/test/fixtures/generated/osinfo-version-0/vro6-64u
+++ b/test/fixtures/generated/osinfo-version-0/vro6-64u
@@ -4,12 +4,7 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     vro6-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: sles-11-x86_64
-      packaging_platform: sles-11-x86_64
       template: vro-6-x86_64
       hypervisor: vmpooler
       roles:

--- a/test/fixtures/generated/osinfo-version-0/vro7-64l
+++ b/test/fixtures/generated/osinfo-version-0/vro7-64l
@@ -4,12 +4,7 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     vro7-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: sles-11-x86_64
-      packaging_platform: sles-11-x86_64
       template: vro-7-x86_64
       hypervisor: vmpooler
       roles:

--- a/test/fixtures/generated/osinfo-version-0/vro71-64d
+++ b/test/fixtures/generated/osinfo-version-0/vro71-64d
@@ -4,13 +4,8 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     vro71-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: sles-11-x86_64
-      packaging_platform: sles-11-x86_64
       template: vro-71-x86_64
       roles:
       - agent

--- a/test/fixtures/generated/osinfo-version-0/vro73-64l
+++ b/test/fixtures/generated/osinfo-version-0/vro73-64l
@@ -4,13 +4,8 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     vro73-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: sles-11-x86_64
-      packaging_platform: sles-11-x86_64
       template: vro-73-x86_64
       roles:
       - agent

--- a/test/fixtures/generated/osinfo-version-0/vro74-64m
+++ b/test/fixtures/generated/osinfo-version-0/vro74-64m
@@ -4,13 +4,8 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     vro74-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: sles-11-x86_64
-      packaging_platform: sles-11-x86_64
       template: vro-74-x86_64
       roles:
       - agent

--- a/test/fixtures/generated/osinfo-version-0/windows10ent-32u
+++ b/test/fixtures/generated/osinfo-version-0/windows10ent-32u
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     windows10ent-32-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: windows-10ent-32
       packaging_platform: windows-2012-x86
       ruby_arch: x86

--- a/test/fixtures/generated/osinfo-version-0/windows10ent-64l
+++ b/test/fixtures/generated/osinfo-version-0/windows10ent-64l
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     windows10ent-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: windows-10ent-64
       packaging_platform: windows-2012-x64
       ruby_arch: x64

--- a/test/fixtures/generated/osinfo-version-0/windows10pro-64c
+++ b/test/fixtures/generated/osinfo-version-0/windows10pro-64c
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     windows10pro-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: windows-10pro-64
       packaging_platform: windows-2012-x64
       ruby_arch: x64

--- a/test/fixtures/generated/osinfo-version-0/windows2008-6432u
+++ b/test/fixtures/generated/osinfo-version-0/windows2008-6432u
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     windows2008-6432-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: windows-2008-64
       packaging_platform: windows-2012-x64
       ruby_arch: x86

--- a/test/fixtures/generated/osinfo-version-0/windows2008-64a
+++ b/test/fixtures/generated/osinfo-version-0/windows2008-64a
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     windows2008-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: windows-2008-64
       packaging_platform: windows-2012-x64
       ruby_arch: x64

--- a/test/fixtures/generated/osinfo-version-0/windows2008r2-6432c
+++ b/test/fixtures/generated/osinfo-version-0/windows2008r2-6432c
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     windows2008r2-6432-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: windows-2008r2-64
       packaging_platform: windows-2012-x64
       ruby_arch: x86

--- a/test/fixtures/generated/osinfo-version-0/windows2008r2-64l
+++ b/test/fixtures/generated/osinfo-version-0/windows2008r2-64l
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     windows2008r2-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: windows-2008r2-64
       packaging_platform: windows-2012-x64
       ruby_arch: x64

--- a/test/fixtures/generated/osinfo-version-0/windows2012-6432f
+++ b/test/fixtures/generated/osinfo-version-0/windows2012-6432f
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     windows2012-6432-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: windows-2012-64
       packaging_platform: windows-2012-x64
       ruby_arch: x86

--- a/test/fixtures/generated/osinfo-version-0/windows2012-64d
+++ b/test/fixtures/generated/osinfo-version-0/windows2012-64d
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     windows2012-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: windows-2012-64
       packaging_platform: windows-2012-x64
       ruby_arch: x64

--- a/test/fixtures/generated/osinfo-version-0/windows2012r2-6432aulcdfm
+++ b/test/fixtures/generated/osinfo-version-0/windows2012r2-6432aulcdfm
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     windows2012r2-6432-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: windows-2012r2-64
       packaging_platform: windows-2012-x64
       ruby_arch: x86

--- a/test/fixtures/generated/osinfo-version-0/windows2012r2-64m
+++ b/test/fixtures/generated/osinfo-version-0/windows2012r2-64m
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     windows2012r2-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: windows-2012r2-64
       packaging_platform: windows-2012-x64
       ruby_arch: x64

--- a/test/fixtures/generated/osinfo-version-0/windows2012r2_ja-6432l
+++ b/test/fixtures/generated/osinfo-version-0/windows2012r2_ja-6432l
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     windows2012r2_ja-6432-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: windows-2012r2-64
       packaging_platform: windows-2012-x64
       ruby_arch: x86

--- a/test/fixtures/generated/osinfo-version-0/windows2012r2_ja-64u
+++ b/test/fixtures/generated/osinfo-version-0/windows2012r2_ja-64u
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     windows2012r2_ja-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: windows-2012r2-64
       packaging_platform: windows-2012-x64
       ruby_arch: x64

--- a/test/fixtures/generated/osinfo-version-0/windows2012r2_wmf5-64a
+++ b/test/fixtures/generated/osinfo-version-0/windows2012r2_wmf5-64a
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     windows2012r2_wmf5-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: windows-2012r2-64
       packaging_platform: windows-2012-x64
       ruby_arch: x64

--- a/test/fixtures/generated/osinfo-version-0/windows2016-6432d
+++ b/test/fixtures/generated/osinfo-version-0/windows2016-6432d
@@ -4,15 +4,11 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     windows2016-6432-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
-      hypervisor: vmpooler
       platform: windows-2016-64
       packaging_platform: windows-2012-x64
       ruby_arch: x86
       template: win-2016-x86_64
+      hypervisor: vmpooler
       roles:
       - agent
       - database
@@ -20,4 +16,4 @@ expected_hash:
     nfs_server: none
     consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
-expected_exception: 
+expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/windows2016-64c
+++ b/test/fixtures/generated/osinfo-version-0/windows2016-64c
@@ -4,15 +4,11 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     windows2016-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
-      hypervisor: vmpooler
       platform: windows-2016-64
       packaging_platform: windows-2012-x64
       ruby_arch: x64
       template: win-2016-x86_64
+      hypervisor: vmpooler
       roles:
       - agent
       - dashboard
@@ -20,4 +16,4 @@ expected_hash:
     nfs_server: none
     consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
-expected_exception: 
+expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/windows2016_fr-6432f
+++ b/test/fixtures/generated/osinfo-version-0/windows2016_fr-6432f
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     windows2016_fr-6432-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: windows-2016-64
       packaging_platform: windows-2012-x64
       ruby_arch: x86

--- a/test/fixtures/generated/osinfo-version-0/windows2016_fr-64d
+++ b/test/fixtures/generated/osinfo-version-0/windows2016_fr-64d
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     windows2016_fr-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: windows-2016-64
       packaging_platform: windows-2012-x64
       ruby_arch: x64

--- a/test/fixtures/generated/osinfo-version-0/windows2022-64aulcdfm
+++ b/test/fixtures/generated/osinfo-version-0/windows2022-64aulcdfm
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     windows2022-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: windows-2022-64
       packaging_platform: windows-2012-x64
       ruby_arch: x64

--- a/test/fixtures/generated/osinfo-version-0/windows7-64f
+++ b/test/fixtures/generated/osinfo-version-0/windows7-64f
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     windows7-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: windows-7-64
       packaging_platform: windows-2012-x64
       ruby_arch: x64

--- a/test/fixtures/generated/osinfo-version-0/windows81-64aulcdfm
+++ b/test/fixtures/generated/osinfo-version-0/windows81-64aulcdfm
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     windows81-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-8.1-64
       packaging_platform: windows-2012-x64

--- a/test/fixtures/generated/osinfo-version-0/windowsfips2012r2-6432f
+++ b/test/fixtures/generated/osinfo-version-0/windowsfips2012r2-6432f
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     windowsfips2012r2-6432-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: windows-2012r2-64
       packaging_platform: windowsfips-2012-x64
       ruby_arch: x64

--- a/test/fixtures/generated/osinfo-version-0/windowsfips2012r2-64d
+++ b/test/fixtures/generated/osinfo-version-0/windowsfips2012r2-64d
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     windowsfips2012r2-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: windows-2012r2-64
       packaging_platform: windowsfips-2012-x64
       ruby_arch: x64

--- a/test/fixtures/generated/osinfo-version-1/aix53-POWERa
+++ b/test/fixtures/generated/osinfo-version-1/aix53-POWERa
@@ -4,13 +4,8 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     aix53-POWER-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: aix-5.3-power
-      packaging_platform: aix-5.3-power
       roles:
       - agent
   CONFIG:

--- a/test/fixtures/generated/osinfo-version-1/aix61-POWERu
+++ b/test/fixtures/generated/osinfo-version-1/aix61-POWERu
@@ -4,13 +4,8 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     aix61-POWER-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: aix-6.1-power
-      packaging_platform: aix-6.1-power
       roles:
       - agent
       - ca

--- a/test/fixtures/generated/osinfo-version-1/aix71-POWERl
+++ b/test/fixtures/generated/osinfo-version-1/aix71-POWERl
@@ -4,13 +4,8 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     aix71-POWER-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: aix-7.1-power
-      packaging_platform: aix-7.1-power
       roles:
       - agent
       - classifier

--- a/test/fixtures/generated/osinfo-version-1/aix72-POWERc
+++ b/test/fixtures/generated/osinfo-version-1/aix72-POWERc
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     aix72-POWER-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: aix-7.2-power
       packaging_platform: aix-7.1-power

--- a/test/fixtures/generated/osinfo-version-1/almalinux8-64u
+++ b/test/fixtures/generated/osinfo-version-1/almalinux8-64u
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     almalinux8-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: el-8-x86_64
       hypervisor: vmpooler
       template: almalinux-8-x86_64

--- a/test/fixtures/generated/osinfo-version-1/amazon6-64d
+++ b/test/fixtures/generated/osinfo-version-1/amazon6-64d
@@ -4,13 +4,8 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     amazon6-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: el-6-x86_64
-      packaging_platform: el-6-x86_64
       roles:
       - agent
       - database

--- a/test/fixtures/generated/osinfo-version-1/amazon7-64f
+++ b/test/fixtures/generated/osinfo-version-1/amazon7-64f
@@ -4,13 +4,8 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     amazon7-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: el-7-x86_64
-      packaging_platform: el-7-x86_64
       roles:
       - agent
       - frictionless

--- a/test/fixtures/generated/osinfo-version-1/amazon7-ARM64m
+++ b/test/fixtures/generated/osinfo-version-1/amazon7-ARM64m
@@ -4,12 +4,7 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     amazon7-ARM64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: el-7-aarch64
-      packaging_platform: el-7-aarch64
       hypervisor: vmpooler
       roles:
       - agent

--- a/test/fixtures/generated/osinfo-version-1/arista4-32d
+++ b/test/fixtures/generated/osinfo-version-1/arista4-32d
@@ -4,12 +4,7 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     arista4-32-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: eos-4-i386
-      packaging_platform: eos-4-i386
       template: arista-4-i386
       hypervisor: vmpooler
       roles:

--- a/test/fixtures/generated/osinfo-version-1/centos4-32f
+++ b/test/fixtures/generated/osinfo-version-1/centos4-32f
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     centos4-32-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: centos-4-i386
       template: centos-4-i386
       hypervisor: vmpooler

--- a/test/fixtures/generated/osinfo-version-1/centos4-64m
+++ b/test/fixtures/generated/osinfo-version-1/centos4-64m
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     centos4-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: centos-4-x86_64
       template: centos-4-x86_64
       hypervisor: vmpooler

--- a/test/fixtures/generated/osinfo-version-1/centos5-32aulcdfm
+++ b/test/fixtures/generated/osinfo-version-1/centos5-32aulcdfm
@@ -4,12 +4,7 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     centos5-32-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: centos-5-i386
-      packaging_platform: el-5-i386
       template: centos-5-i386
       hypervisor: vmpooler
       roles:

--- a/test/fixtures/generated/osinfo-version-1/centos5-64a
+++ b/test/fixtures/generated/osinfo-version-1/centos5-64a
@@ -4,12 +4,7 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     centos5-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: centos-5-x86_64
-      packaging_platform: el-5-x86_64
       template: centos-5-x86_64
       hypervisor: vmpooler
       roles:

--- a/test/fixtures/generated/osinfo-version-1/centos6-32u
+++ b/test/fixtures/generated/osinfo-version-1/centos6-32u
@@ -4,12 +4,7 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     centos6-32-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: centos-6-i386
-      packaging_platform: el-6-i386
       template: centos-6-i386
       hypervisor: vmpooler
       roles:

--- a/test/fixtures/generated/osinfo-version-1/centos6-64l
+++ b/test/fixtures/generated/osinfo-version-1/centos6-64l
@@ -4,12 +4,7 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     centos6-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: centos-6-x86_64
-      packaging_platform: el-6-x86_64
       template: centos-6-x86_64
       hypervisor: vmpooler
       roles:

--- a/test/fixtures/generated/osinfo-version-1/centos7-64c
+++ b/test/fixtures/generated/osinfo-version-1/centos7-64c
@@ -4,12 +4,7 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     centos7-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: centos-7-x86_64
-      packaging_platform: el-7-x86_64
       template: centos-7-x86_64
       hypervisor: vmpooler
       roles:

--- a/test/fixtures/generated/osinfo-version-1/centos8-64aulcdfm
+++ b/test/fixtures/generated/osinfo-version-1/centos8-64aulcdfm
@@ -4,12 +4,7 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     centos8-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: el-8-x86_64
-      packaging_platform: el-8-x86_64
       template: centos-8-x86_64
       hypervisor: vmpooler
       roles:

--- a/test/fixtures/generated/osinfo-version-1/centos8-64m
+++ b/test/fixtures/generated/osinfo-version-1/centos8-64m
@@ -4,14 +4,9 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     centos8-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: el-8-x86_64
-      packaging_platform: el-8-x86_64
-      template: centos-8-x86_64
       hypervisor: vmpooler
+      template: centos-8-x86_64
       roles:
       - agent
       - master
@@ -19,4 +14,4 @@ expected_hash:
     nfs_server: none
     consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
-expected_exception: 
+expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/cisco_ios_c2960-HWm
+++ b/test/fixtures/generated/osinfo-version-1/cisco_ios_c2960-HWm
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     cisco_ios_c2960-HW-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: cisco_ios-12-arm32
       ssh:
         user: admin
@@ -19,4 +15,4 @@ expected_hash:
     nfs_server: none
     consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
-expected_exception: 
+expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/cisco_ios_c3560-HWaulcdfm
+++ b/test/fixtures/generated/osinfo-version-1/cisco_ios_c3560-HWaulcdfm
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     cisco_ios_c3560-HW-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: cisco_ios-12-arm32
       ssh:
         user: admin
@@ -24,4 +20,4 @@ expected_hash:
     nfs_server: none
     consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
-expected_exception: 
+expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/cisco_ios_c3750-HWa
+++ b/test/fixtures/generated/osinfo-version-1/cisco_ios_c3750-HWa
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     cisco_ios_c3750-HW-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: cisco_ios-12-arm32
       ssh:
         user: admin
@@ -18,4 +14,4 @@ expected_hash:
     nfs_server: none
     consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
-expected_exception: 
+expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/cisco_ios_c4507r-HWu
+++ b/test/fixtures/generated/osinfo-version-1/cisco_ios_c4507r-HWu
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     cisco_ios_c4507r-HW-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: cisco_ios-12-arm32
       ssh:
         user: admin
@@ -19,4 +15,4 @@ expected_hash:
     nfs_server: none
     consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
-expected_exception: 
+expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/cisco_ios_c4948-HWl
+++ b/test/fixtures/generated/osinfo-version-1/cisco_ios_c4948-HWl
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     cisco_ios_c4948-HW-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: cisco_ios-12-arm32
       ssh:
         user: admin
@@ -19,4 +15,4 @@ expected_hash:
     nfs_server: none
     consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
-expected_exception: 
+expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/cisco_ios_c6503-HWc
+++ b/test/fixtures/generated/osinfo-version-1/cisco_ios_c6503-HWc
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     cisco_ios_c6503-HW-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: cisco_ios-12-arm32
       ssh:
         user: admin
@@ -19,4 +15,4 @@ expected_hash:
     nfs_server: none
     consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
-expected_exception: 
+expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/cisco_iosxe_c3650-HWd
+++ b/test/fixtures/generated/osinfo-version-1/cisco_iosxe_c3650-HWd
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     cisco_iosxe_c3650-HW-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: cisco_iosxec3650-arm32
       ssh:
         user: admin
@@ -19,4 +15,4 @@ expected_hash:
     nfs_server: none
     consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
-expected_exception: 
+expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/cisco_iosxe_c4503-HWf
+++ b/test/fixtures/generated/osinfo-version-1/cisco_iosxe_c4503-HWf
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     cisco_iosxe_c4503-HW-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: cisco_iosxe-3-arm32
       ssh:
         user: admin
@@ -19,4 +15,4 @@ expected_hash:
     nfs_server: none
     consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
-expected_exception: 
+expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/cisco_n7k-HWc
+++ b/test/fixtures/generated/osinfo-version-1/cisco_n7k-HWc
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     cisco_n7k-HW-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: cisco_nexus-7k-x86_64
       packaging_platform: cisco-wrlinux-5-x86_64
       vrf: management
@@ -21,4 +17,4 @@ expected_hash:
     nfs_server: none
     consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
-expected_exception: 
+expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/cisco_n7k_vdc-HWd
+++ b/test/fixtures/generated/osinfo-version-1/cisco_n7k_vdc-HWd
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     cisco_n7k_vdc-HW-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: cisco_nexus-7k-x86_64
       packaging_platform: cisco-wrlinux-5-x86_64
       vrf: management
@@ -21,4 +17,4 @@ expected_hash:
     nfs_server: none
     consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
-expected_exception: 
+expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/cisco_n9k-HWf
+++ b/test/fixtures/generated/osinfo-version-1/cisco_n9k-HWf
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     cisco_n9k-HW-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: cisco_nexus-7-x86_64
       packaging_platform: cisco-wrlinux-5-x86_64
       vrf: management
@@ -21,4 +17,4 @@ expected_hash:
     nfs_server: none
     consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
-expected_exception: 
+expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/cisco_n9k-VMl
+++ b/test/fixtures/generated/osinfo-version-1/cisco_n9k-VMl
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     cisco_n9k-VM-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: cisco_nexus-7-x86_64
       packaging_platform: cisco-wrlinux-5-x86_64
       vrf: management
@@ -22,4 +18,4 @@ expected_hash:
     nfs_server: none
     consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
-expected_exception: 
+expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/cisco_xr_9k-VMm
+++ b/test/fixtures/generated/osinfo-version-1/cisco_xr_9k-VMm
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     cisco_xr_9k-VM-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: cisco_ios_xr-6-x86_64
       packaging_platform: cisco-wrlinux-7-x86_64
       template: cisco-exr-9k-x86_64
@@ -19,4 +15,4 @@ expected_hash:
     nfs_server: none
     consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
-expected_exception: 
+expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/ciscon7k-64a
+++ b/test/fixtures/generated/osinfo-version-1/ciscon7k-64a
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     ciscon7k-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: cisco_nexus-7k-x86_64
       packaging_platform: cisco-wrlinux-5-x86_64
       vrf: management
@@ -20,4 +16,4 @@ expected_hash:
     nfs_server: none
     consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
-expected_exception: 
+expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/cisconx-64aulcdfm
+++ b/test/fixtures/generated/osinfo-version-1/cisconx-64aulcdfm
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     cisconx-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: cisco_nexus-7-x86_64
       packaging_platform: cisco-wrlinux-5-x86_64
       vrf: management
@@ -27,4 +23,4 @@ expected_hash:
     nfs_server: none
     consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
-expected_exception: 
+expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/cisconx-64d
+++ b/test/fixtures/generated/osinfo-version-1/cisconx-64d
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     cisconx-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: cisco_nexus-7-x86_64
       packaging_platform: cisco-wrlinux-5-x86_64

--- a/test/fixtures/generated/osinfo-version-1/cisconxhw-64f
+++ b/test/fixtures/generated/osinfo-version-1/cisconxhw-64f
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     cisconxhw-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       hypervisor: vmpooler
       platform: cisco_nexus-7-x86_64
       packaging_platform: cisco-wrlinux-5-x86_64

--- a/test/fixtures/generated/osinfo-version-1/cisconxhw-64u
+++ b/test/fixtures/generated/osinfo-version-1/cisconxhw-64u
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     cisconxhw-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: cisco_nexus-7-x86_64
       packaging_platform: cisco-wrlinux-5-x86_64
       vrf: management
@@ -21,4 +17,4 @@ expected_hash:
     nfs_server: none
     consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
-expected_exception: 
+expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/cumulus25-64m
+++ b/test/fixtures/generated/osinfo-version-1/cumulus25-64m
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     cumulus25-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: cumulus-2.5-x86_64
       packaging_platform: cumulus-2.2-amd64
       template: cumulus-vx-25-x86_64

--- a/test/fixtures/generated/osinfo-version-1/debian10-32d
+++ b/test/fixtures/generated/osinfo-version-1/debian10-32d
@@ -4,12 +4,7 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     debian10-32-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: debian-10-i386
-      packaging_platform: debian-10-i386
       template: debian-10-i386
       hypervisor: vmpooler
       roles:

--- a/test/fixtures/generated/osinfo-version-1/debian10-64c
+++ b/test/fixtures/generated/osinfo-version-1/debian10-64c
@@ -4,12 +4,7 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     debian10-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: debian-10-amd64
-      packaging_platform: debian-10-amd64
       template: debian-10-x86_64
       hypervisor: vmpooler
       roles:

--- a/test/fixtures/generated/osinfo-version-1/debian11-64m
+++ b/test/fixtures/generated/osinfo-version-1/debian11-64m
@@ -4,12 +4,7 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     debian11-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: debian-11-amd64
-      packaging_platform: debian-11-amd64
       template: debian-11-x86_64
       hypervisor: vmpooler
       roles:

--- a/test/fixtures/generated/osinfo-version-1/debian6-32aulcdfm
+++ b/test/fixtures/generated/osinfo-version-1/debian6-32aulcdfm
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     debian6-32-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: debian-6-i386
       template: debian-6-i386
       hypervisor: vmpooler

--- a/test/fixtures/generated/osinfo-version-1/debian6-64a
+++ b/test/fixtures/generated/osinfo-version-1/debian6-64a
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     debian6-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: debian-6-amd64
       template: debian-6-x86_64
       hypervisor: vmpooler

--- a/test/fixtures/generated/osinfo-version-1/debian7-32u
+++ b/test/fixtures/generated/osinfo-version-1/debian7-32u
@@ -4,12 +4,7 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     debian7-32-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: debian-7-i386
-      packaging_platform: debian-7-i386
       template: debian-7-i386
       hypervisor: vmpooler
       roles:

--- a/test/fixtures/generated/osinfo-version-1/debian7-64l
+++ b/test/fixtures/generated/osinfo-version-1/debian7-64l
@@ -4,12 +4,7 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     debian7-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: debian-7-amd64
-      packaging_platform: debian-7-amd64
       template: debian-7-x86_64
       hypervisor: vmpooler
       roles:

--- a/test/fixtures/generated/osinfo-version-1/debian8-32c
+++ b/test/fixtures/generated/osinfo-version-1/debian8-32c
@@ -4,12 +4,7 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     debian8-32-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: debian-8-i386
-      packaging_platform: debian-8-i386
       template: debian-8-i386
       hypervisor: vmpooler
       roles:

--- a/test/fixtures/generated/osinfo-version-1/debian8-64d
+++ b/test/fixtures/generated/osinfo-version-1/debian8-64d
@@ -4,12 +4,7 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     debian8-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: debian-8-amd64
-      packaging_platform: debian-8-amd64
       template: debian-8-x86_64
       hypervisor: vmpooler
       roles:

--- a/test/fixtures/generated/osinfo-version-1/debian9-32f
+++ b/test/fixtures/generated/osinfo-version-1/debian9-32f
@@ -4,12 +4,7 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     debian9-32-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: debian-9-i386
-      packaging_platform: debian-9-i386
       template: debian-9-i386
       hypervisor: vmpooler
       roles:

--- a/test/fixtures/generated/osinfo-version-1/debian9-64m
+++ b/test/fixtures/generated/osinfo-version-1/debian9-64m
@@ -4,12 +4,7 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     debian9-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: debian-9-amd64
-      packaging_platform: debian-9-amd64
       template: debian-9-x86_64
       hypervisor: vmpooler
       roles:

--- a/test/fixtures/generated/osinfo-version-1/fedora14-32aulcdfm
+++ b/test/fixtures/generated/osinfo-version-1/fedora14-32aulcdfm
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     fedora14-32-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: fedora-14-i386
       template: fedora-14-i386

--- a/test/fixtures/generated/osinfo-version-1/fedora19-32a
+++ b/test/fixtures/generated/osinfo-version-1/fedora19-32a
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     fedora19-32-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: fedora-19-i386
       hypervisor: vmpooler
       template: fedora-19-i386

--- a/test/fixtures/generated/osinfo-version-1/fedora19-64u
+++ b/test/fixtures/generated/osinfo-version-1/fedora19-64u
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     fedora19-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: fedora-19-x86_64
       hypervisor: vmpooler
       template: fedora-19-x86_64

--- a/test/fixtures/generated/osinfo-version-1/fedora20-32l
+++ b/test/fixtures/generated/osinfo-version-1/fedora20-32l
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     fedora20-32-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: fedora-20-i386
       hypervisor: vmpooler
       template: fedora-20-i386

--- a/test/fixtures/generated/osinfo-version-1/fedora20-64c
+++ b/test/fixtures/generated/osinfo-version-1/fedora20-64c
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     fedora20-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: fedora-20-x86_64
       hypervisor: vmpooler
       template: fedora-20-x86_64

--- a/test/fixtures/generated/osinfo-version-1/fedora21-32d
+++ b/test/fixtures/generated/osinfo-version-1/fedora21-32d
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     fedora21-32-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: fedora-21-i386
       hypervisor: vmpooler
       template: fedora-21-i386

--- a/test/fixtures/generated/osinfo-version-1/fedora21-64f
+++ b/test/fixtures/generated/osinfo-version-1/fedora21-64f
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     fedora21-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: fedora-21-x86_64
       hypervisor: vmpooler
       template: fedora-21-x86_64

--- a/test/fixtures/generated/osinfo-version-1/fedora22-32m
+++ b/test/fixtures/generated/osinfo-version-1/fedora22-32m
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     fedora22-32-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: fedora-22-i386
       hypervisor: vmpooler
       template: fedora-22-i386

--- a/test/fixtures/generated/osinfo-version-1/fedora22-64aulcdfm
+++ b/test/fixtures/generated/osinfo-version-1/fedora22-64aulcdfm
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     fedora22-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: fedora-22-x86_64
       hypervisor: vmpooler
       template: fedora-22-x86_64

--- a/test/fixtures/generated/osinfo-version-1/fedora23-32a
+++ b/test/fixtures/generated/osinfo-version-1/fedora23-32a
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     fedora23-32-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: fedora-23-i386
       hypervisor: vmpooler
       template: fedora-23-i386

--- a/test/fixtures/generated/osinfo-version-1/fedora23-64u
+++ b/test/fixtures/generated/osinfo-version-1/fedora23-64u
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     fedora23-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: fedora-23-x86_64
       hypervisor: vmpooler
       template: fedora-23-x86_64

--- a/test/fixtures/generated/osinfo-version-1/fedora24-32l
+++ b/test/fixtures/generated/osinfo-version-1/fedora24-32l
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     fedora24-32-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: fedora-24-i386
       hypervisor: vmpooler
       template: fedora-24-i386

--- a/test/fixtures/generated/osinfo-version-1/fedora24-64c
+++ b/test/fixtures/generated/osinfo-version-1/fedora24-64c
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     fedora24-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: fedora-24-x86_64
       hypervisor: vmpooler
       template: fedora-24-x86_64

--- a/test/fixtures/generated/osinfo-version-1/fedora25-32d
+++ b/test/fixtures/generated/osinfo-version-1/fedora25-32d
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     fedora25-32-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: fedora-25-i386
       hypervisor: vmpooler
       template: fedora-25-i386

--- a/test/fixtures/generated/osinfo-version-1/fedora25-64f
+++ b/test/fixtures/generated/osinfo-version-1/fedora25-64f
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     fedora25-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: fedora-25-x86_64
       hypervisor: vmpooler
       template: fedora-25-x86_64

--- a/test/fixtures/generated/osinfo-version-1/fedora26-64m
+++ b/test/fixtures/generated/osinfo-version-1/fedora26-64m
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     fedora26-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: fedora-26-x86_64
       template: fedora-26-x86_64

--- a/test/fixtures/generated/osinfo-version-1/fedora27-64l
+++ b/test/fixtures/generated/osinfo-version-1/fedora27-64l
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     fedora27-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: fedora-27-x86_64
       template: fedora-27-x86_64

--- a/test/fixtures/generated/osinfo-version-1/fedora28-64d
+++ b/test/fixtures/generated/osinfo-version-1/fedora28-64d
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     fedora28-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: fedora-28-x86_64
       template: fedora-28-x86_64

--- a/test/fixtures/generated/osinfo-version-1/fedora29-64d
+++ b/test/fixtures/generated/osinfo-version-1/fedora29-64d
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     fedora29-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: fedora-29-x86_64
       template: fedora-29-x86_64

--- a/test/fixtures/generated/osinfo-version-1/fedora30-64aulcdfm
+++ b/test/fixtures/generated/osinfo-version-1/fedora30-64aulcdfm
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     fedora30-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: fedora-30-x86_64
       hypervisor: vmpooler
       template: fedora-30-x86_64

--- a/test/fixtures/generated/osinfo-version-1/fedora31-64aulcdfm
+++ b/test/fixtures/generated/osinfo-version-1/fedora31-64aulcdfm
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     fedora31-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: fedora-31-x86_64
       template: fedora-31-x86_64
       hypervisor: vmpooler

--- a/test/fixtures/generated/osinfo-version-1/fedora32-64a
+++ b/test/fixtures/generated/osinfo-version-1/fedora32-64a
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     fedora32-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: fedora-32-x86_64
       template: fedora-32-x86_64
       hypervisor: vmpooler

--- a/test/fixtures/generated/osinfo-version-1/fedora34-64c
+++ b/test/fixtures/generated/osinfo-version-1/fedora34-64c
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     fedora34-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: fedora-34-x86_64
       hypervisor: vmpooler
       template: fedora-34-x86_64

--- a/test/fixtures/generated/osinfo-version-1/huaweios6-POWERaulcdfm
+++ b/test/fixtures/generated/osinfo-version-1/huaweios6-POWERaulcdfm
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     huaweios6-POWER-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: huaweios-6-powerpc
       roles:

--- a/test/fixtures/generated/osinfo-version-1/opensuse11-32a
+++ b/test/fixtures/generated/osinfo-version-1/opensuse11-32a
@@ -4,17 +4,13 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     opensuse11-32-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
-      hypervisor: vmpooler
       platform: opensuse-11-i386
       template: opensuse-11-i386
+      hypervisor: vmpooler
       roles:
       - agent
   CONFIG:
     nfs_server: none
     consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
-expected_exception: 
+expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/opensuse11-64u
+++ b/test/fixtures/generated/osinfo-version-1/opensuse11-64u
@@ -4,13 +4,9 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     opensuse11-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
-      hypervisor: vmpooler
       platform: opensuse-11-x86_64
       template: opensuse-11-x86_64
+      hypervisor: vmpooler
       roles:
       - agent
       - ca
@@ -18,4 +14,4 @@ expected_hash:
     nfs_server: none
     consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
-expected_exception: 
+expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/oracle5-32l
+++ b/test/fixtures/generated/osinfo-version-1/oracle5-32l
@@ -4,13 +4,8 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     oracle5-32-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: el-5-i386
-      packaging_platform: el-5-i386
       template: oracle-5-i386
       roles:
       - agent

--- a/test/fixtures/generated/osinfo-version-1/oracle5-64c
+++ b/test/fixtures/generated/osinfo-version-1/oracle5-64c
@@ -4,13 +4,8 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     oracle5-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: el-5-x86_64
-      packaging_platform: el-5-x86_64
       template: oracle-5-x86_64
       roles:
       - agent

--- a/test/fixtures/generated/osinfo-version-1/oracle6-32d
+++ b/test/fixtures/generated/osinfo-version-1/oracle6-32d
@@ -4,13 +4,8 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     oracle6-32-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: el-6-i386
-      packaging_platform: el-6-i386
       template: oracle-6-i386
       roles:
       - agent

--- a/test/fixtures/generated/osinfo-version-1/oracle6-64f
+++ b/test/fixtures/generated/osinfo-version-1/oracle6-64f
@@ -4,13 +4,8 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     oracle6-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: el-6-x86_64
-      packaging_platform: el-6-x86_64
       template: oracle-6-x86_64
       roles:
       - agent

--- a/test/fixtures/generated/osinfo-version-1/oracle7-64m
+++ b/test/fixtures/generated/osinfo-version-1/oracle7-64m
@@ -4,13 +4,8 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     oracle7-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: el-7-x86_64
-      packaging_platform: el-7-x86_64
       template: oracle-7-x86_64
       roles:
       - agent

--- a/test/fixtures/generated/osinfo-version-1/osx1010-64a
+++ b/test/fixtures/generated/osinfo-version-1/osx1010-64a
@@ -4,13 +4,8 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     osx1010-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: osx-10.10-x86_64
-      packaging_platform: osx-10.10-x86_64
       template: osx-1010-x86_64
       roles:
       - agent

--- a/test/fixtures/generated/osinfo-version-1/osx1011-64u
+++ b/test/fixtures/generated/osinfo-version-1/osx1011-64u
@@ -4,13 +4,8 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     osx1011-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: osx-10.11-x86_64
-      packaging_platform: osx-10.11-x86_64
       template: osx-1011-x86_64
       roles:
       - agent

--- a/test/fixtures/generated/osinfo-version-1/osx1012-64l
+++ b/test/fixtures/generated/osinfo-version-1/osx1012-64l
@@ -4,13 +4,8 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     osx1012-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: osx-10.12-x86_64
-      packaging_platform: osx-10.12-x86_64
       template: osx-1012-x86_64
       roles:
       - agent

--- a/test/fixtures/generated/osinfo-version-1/osx1013-64f
+++ b/test/fixtures/generated/osinfo-version-1/osx1013-64f
@@ -4,12 +4,7 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     osx1013-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: osx-10.13-x86_64
-      packaging_platform: osx-10.13-x86_64
       template: osx-1013-x86_64
       hypervisor: vmpooler
       roles:

--- a/test/fixtures/generated/osinfo-version-1/osx1014-64f
+++ b/test/fixtures/generated/osinfo-version-1/osx1014-64f
@@ -4,13 +4,8 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     osx1014-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: osx-10.14-x86_64
-      packaging_platform: osx-10.14-x86_64
       template: osx-1014-x86_64
       roles:
       - agent

--- a/test/fixtures/generated/osinfo-version-1/osx1015-64u
+++ b/test/fixtures/generated/osinfo-version-1/osx1015-64u
@@ -4,12 +4,7 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     osx1015-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: osx-10.15-x86_64
-      packaging_platform: osx-10.15-x86_64
       template: osx-1015-x86_64
       hypervisor: vmpooler
       roles:
@@ -19,4 +14,4 @@ expected_hash:
     nfs_server: none
     consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
-expected_exception: 
+expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/osx109-64aulcdfm
+++ b/test/fixtures/generated/osinfo-version-1/osx109-64aulcdfm
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     osx109-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: osx-10.9-x86_64
       template: osx-109-x86_64

--- a/test/fixtures/generated/osinfo-version-1/osx11-64f
+++ b/test/fixtures/generated/osinfo-version-1/osx11-64f
@@ -4,12 +4,7 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     osx11-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: osx-11-x86_64
-      packaging_platform: osx-11-x86_64
       template: macos-112-x86_64
       hypervisor: vmpooler
       roles:

--- a/test/fixtures/generated/osinfo-version-1/panos61-64f
+++ b/test/fixtures/generated/osinfo-version-1/panos61-64f
@@ -4,13 +4,9 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     panos61-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
-      hypervisor: vmpooler
       platform: palo-alto-6.1.0-x86_64
       template: palo-alto-6.1.0-x86_64
+      hypervisor: vmpooler
       roles:
       - agent
       - frictionless
@@ -18,4 +14,4 @@ expected_hash:
     nfs_server: none
     consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
-expected_exception: 
+expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/panos71-64m
+++ b/test/fixtures/generated/osinfo-version-1/panos71-64m
@@ -4,13 +4,9 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     panos71-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
-      hypervisor: vmpooler
       platform: palo-alto-7.1.0-x86_64
       template: palo-alto-7.1.0-x86_64
+      hypervisor: vmpooler
       roles:
       - agent
       - master
@@ -18,4 +14,4 @@ expected_hash:
     nfs_server: none
     consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
-expected_exception: 
+expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/panos81-64aulcdfm
+++ b/test/fixtures/generated/osinfo-version-1/panos81-64aulcdfm
@@ -4,13 +4,9 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     panos81-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
-      hypervisor: vmpooler
       platform: palo-alto-8.1.0-x86_64
       template: palo-alto-8.1.0-x86_64
+      hypervisor: vmpooler
       roles:
       - agent
       - ca
@@ -23,4 +19,4 @@ expected_hash:
     nfs_server: none
     consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
-expected_exception: 
+expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/redhat4-32c
+++ b/test/fixtures/generated/osinfo-version-1/redhat4-32c
@@ -4,13 +4,9 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     redhat4-32-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
-      hypervisor: vmpooler
       platform: el-4-i386
       template: redhat-4-i386
+      hypervisor: vmpooler
       roles:
       - agent
       - dashboard
@@ -18,4 +14,4 @@ expected_hash:
     nfs_server: none
     consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
-expected_exception: 
+expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/redhat4-64d
+++ b/test/fixtures/generated/osinfo-version-1/redhat4-64d
@@ -4,13 +4,9 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     redhat4-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
-      hypervisor: vmpooler
       platform: el-4-x86_64
       template: redhat-4-x86_64
+      hypervisor: vmpooler
       roles:
       - agent
       - database
@@ -18,4 +14,4 @@ expected_hash:
     nfs_server: none
     consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
-expected_exception: 
+expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/redhat5-32f
+++ b/test/fixtures/generated/osinfo-version-1/redhat5-32f
@@ -4,14 +4,9 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     redhat5-32-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
-      hypervisor: vmpooler
       platform: el-5-i386
-      packaging_platform: el-5-i386
       template: redhat-5-i386
+      hypervisor: vmpooler
       roles:
       - agent
       - frictionless
@@ -19,4 +14,4 @@ expected_hash:
     nfs_server: none
     consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
-expected_exception: 
+expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/redhat5-64m
+++ b/test/fixtures/generated/osinfo-version-1/redhat5-64m
@@ -4,14 +4,9 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     redhat5-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
-      hypervisor: vmpooler
       platform: el-5-x86_64
-      packaging_platform: el-5-x86_64
       template: redhat-5-x86_64
+      hypervisor: vmpooler
       roles:
       - agent
       - master
@@ -19,4 +14,4 @@ expected_hash:
     nfs_server: none
     consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
-expected_exception: 
+expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/redhat6-32aulcdfm
+++ b/test/fixtures/generated/osinfo-version-1/redhat6-32aulcdfm
@@ -4,14 +4,9 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     redhat6-32-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
-      hypervisor: vmpooler
       platform: el-6-i386
-      packaging_platform: el-6-i386
       template: redhat-6-i386
+      hypervisor: vmpooler
       roles:
       - agent
       - ca
@@ -24,4 +19,4 @@ expected_hash:
     nfs_server: none
     consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
-expected_exception: 
+expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/redhat6-64a
+++ b/test/fixtures/generated/osinfo-version-1/redhat6-64a
@@ -4,18 +4,13 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     redhat6-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
-      hypervisor: vmpooler
       platform: el-6-x86_64
-      packaging_platform: el-6-x86_64
       template: redhat-6-x86_64
+      hypervisor: vmpooler
       roles:
       - agent
   CONFIG:
     nfs_server: none
     consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
-expected_exception: 
+expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/redhat7-64l
+++ b/test/fixtures/generated/osinfo-version-1/redhat7-64l
@@ -4,14 +4,9 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     redhat7-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
-      hypervisor: vmpooler
       platform: el-7-x86_64
-      packaging_platform: el-7-x86_64
       template: redhat-7-x86_64
+      hypervisor: vmpooler
       roles:
       - agent
       - classifier
@@ -19,4 +14,4 @@ expected_hash:
     nfs_server: none
     consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
-expected_exception: 
+expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/redhat7-AARCH64a
+++ b/test/fixtures/generated/osinfo-version-1/redhat7-AARCH64a
@@ -4,13 +4,8 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     redhat7-AARCH64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: el-7-aarch64
-      packaging_platform: el-7-aarch64
       template: redhat-7-x86_64
       roles:
       - agent

--- a/test/fixtures/generated/osinfo-version-1/redhat7-AARCH64aulcdfm
+++ b/test/fixtures/generated/osinfo-version-1/redhat7-AARCH64aulcdfm
@@ -4,13 +4,8 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     redhat7-AARCH64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: el-7-aarch64
-      packaging_platform: el-7-aarch64
       template: redhat-7-x86_64
       roles:
       - agent

--- a/test/fixtures/generated/osinfo-version-1/redhat7-POWERc
+++ b/test/fixtures/generated/osinfo-version-1/redhat7-POWERc
@@ -4,12 +4,7 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     redhat7-POWER-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: el-7-ppc64le
-      packaging_platform: el-7-ppc64le
       hypervisor: vmpooler
       template: redhat-7-ppc64le
       roles:

--- a/test/fixtures/generated/osinfo-version-1/redhat7-S390Xd
+++ b/test/fixtures/generated/osinfo-version-1/redhat7-S390Xd
@@ -4,12 +4,7 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     redhat7-S390X-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: el-7-s390x
-      packaging_platform: el-7-s390x
       hypervisor: vmpooler
       template: redhat-7-s390x
       roles:

--- a/test/fixtures/generated/osinfo-version-1/redhat8-64u
+++ b/test/fixtures/generated/osinfo-version-1/redhat8-64u
@@ -4,13 +4,8 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     redhat8-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: el-8-x86_64
-      packaging_platform: el-8-x86_64
       template: redhat-8-x86_64
       roles:
       - agent

--- a/test/fixtures/generated/osinfo-version-1/redhat8-AARCH64a
+++ b/test/fixtures/generated/osinfo-version-1/redhat8-AARCH64a
@@ -4,12 +4,7 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     redhat8-AARCH64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: el-8-aarch64
-      packaging_platform: el-8-aarch64
       template: redhat-8-x86_64
       hypervisor: vmpooler
       roles:

--- a/test/fixtures/generated/osinfo-version-1/redhat9-64l
+++ b/test/fixtures/generated/osinfo-version-1/redhat9-64l
@@ -4,12 +4,7 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     redhat9-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: el-9-x86_64
-      packaging_platform: el-9-x86_64
       template: redhat-9-x86_64
       hypervisor: vmpooler
       roles:

--- a/test/fixtures/generated/osinfo-version-1/redhatfips7-64aulcdfm
+++ b/test/fixtures/generated/osinfo-version-1/redhatfips7-64aulcdfm
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     redhatfips7-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: el-7-x86_64
       packaging_platform: redhatfips-7-x86_64

--- a/test/fixtures/generated/osinfo-version-1/redhatfips8-64m
+++ b/test/fixtures/generated/osinfo-version-1/redhatfips8-64m
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     redhatfips8-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: el-8-x86_64
       packaging_platform: redhatfips-8-x86_64
       template: redhat-fips-8-x86_64

--- a/test/fixtures/generated/osinfo-version-1/rocky8-64l
+++ b/test/fixtures/generated/osinfo-version-1/rocky8-64l
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     rocky8-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: el-8-x86_64
       hypervisor: vmpooler
       template: rocky-8-x86_64

--- a/test/fixtures/generated/osinfo-version-1/scientific5-32f
+++ b/test/fixtures/generated/osinfo-version-1/scientific5-32f
@@ -4,14 +4,9 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     scientific5-32-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
-      hypervisor: vmpooler
       platform: el-5-i386
-      packaging_platform: el-5-i386
       template: scientific-5-i386
+      hypervisor: vmpooler
       roles:
       - agent
       - frictionless
@@ -19,4 +14,4 @@ expected_hash:
     nfs_server: none
     consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
-expected_exception: 
+expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/scientific5-64m
+++ b/test/fixtures/generated/osinfo-version-1/scientific5-64m
@@ -4,14 +4,9 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     scientific5-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
-      hypervisor: vmpooler
       platform: el-5-x86_64
-      packaging_platform: el-5-x86_64
       template: scientific-5-x86_64
+      hypervisor: vmpooler
       roles:
       - agent
       - master
@@ -19,4 +14,4 @@ expected_hash:
     nfs_server: none
     consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
-expected_exception: 
+expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/scientific6-32aulcdfm
+++ b/test/fixtures/generated/osinfo-version-1/scientific6-32aulcdfm
@@ -4,14 +4,9 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     scientific6-32-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
-      hypervisor: vmpooler
       platform: el-6-i386
-      packaging_platform: el-6-i386
       template: scientific-6-i386
+      hypervisor: vmpooler
       roles:
       - agent
       - ca
@@ -24,4 +19,4 @@ expected_hash:
     nfs_server: none
     consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
-expected_exception: 
+expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/scientific6-64a
+++ b/test/fixtures/generated/osinfo-version-1/scientific6-64a
@@ -4,18 +4,13 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     scientific6-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
-      hypervisor: vmpooler
       platform: el-6-x86_64
-      packaging_platform: el-6-x86_64
       template: scientific-6-x86_64
+      hypervisor: vmpooler
       roles:
       - agent
   CONFIG:
     nfs_server: none
     consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
-expected_exception: 
+expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/scientific7-64u
+++ b/test/fixtures/generated/osinfo-version-1/scientific7-64u
@@ -4,14 +4,9 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     scientific7-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
-      hypervisor: vmpooler
       platform: el-7-x86_64
-      packaging_platform: el-7-x86_64
       template: scientific-7-x86_64
+      hypervisor: vmpooler
       roles:
       - agent
       - ca
@@ -19,4 +14,4 @@ expected_hash:
     nfs_server: none
     consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
-expected_exception: 
+expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/sles10-32l
+++ b/test/fixtures/generated/osinfo-version-1/sles10-32l
@@ -4,13 +4,9 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     sles10-32-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
-      hypervisor: vmpooler
       platform: sles-10-i386
       template: sles-10-i386
+      hypervisor: vmpooler
       roles:
       - agent
       - classifier
@@ -18,4 +14,4 @@ expected_hash:
     nfs_server: none
     consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
-expected_exception: 
+expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/sles10-64c
+++ b/test/fixtures/generated/osinfo-version-1/sles10-64c
@@ -4,13 +4,9 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     sles10-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
-      hypervisor: vmpooler
       platform: sles-10-x86_64
       template: sles-10-x86_64
+      hypervisor: vmpooler
       roles:
       - agent
       - dashboard
@@ -18,4 +14,4 @@ expected_hash:
     nfs_server: none
     consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
-expected_exception: 
+expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/sles11-32d
+++ b/test/fixtures/generated/osinfo-version-1/sles11-32d
@@ -4,14 +4,9 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     sles11-32-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
-      hypervisor: vmpooler
       platform: sles-11-i386
-      packaging_platform: sles-11-i386
       template: sles-11-i386
+      hypervisor: vmpooler
       roles:
       - agent
       - database
@@ -19,4 +14,4 @@ expected_hash:
     nfs_server: none
     consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
-expected_exception: 
+expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/sles11-64f
+++ b/test/fixtures/generated/osinfo-version-1/sles11-64f
@@ -4,14 +4,9 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     sles11-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
-      hypervisor: vmpooler
       platform: sles-11-x86_64
-      packaging_platform: sles-11-x86_64
       template: sles-11-x86_64
+      hypervisor: vmpooler
       roles:
       - agent
       - frictionless
@@ -19,4 +14,4 @@ expected_hash:
     nfs_server: none
     consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
-expected_exception: 
+expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/sles11-S390Xm
+++ b/test/fixtures/generated/osinfo-version-1/sles11-S390Xm
@@ -4,13 +4,8 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     sles11-S390X-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
-      hypervisor: vmpooler
       platform: sles-11-s390x
-      packaging_platform: sles-11-s390x
+      hypervisor: vmpooler
       roles:
       - agent
       - master
@@ -18,4 +13,4 @@ expected_hash:
     nfs_server: none
     consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
-expected_exception: 
+expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/sles12-64aulcdfm
+++ b/test/fixtures/generated/osinfo-version-1/sles12-64aulcdfm
@@ -4,14 +4,9 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     sles12-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
-      hypervisor: vmpooler
       platform: sles-12-x86_64
-      packaging_platform: sles-12-x86_64
       template: sles-12-x86_64
+      hypervisor: vmpooler
       roles:
       - agent
       - ca
@@ -24,4 +19,4 @@ expected_hash:
     nfs_server: none
     consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
-expected_exception: 
+expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/sles12-POWERu
+++ b/test/fixtures/generated/osinfo-version-1/sles12-POWERu
@@ -4,13 +4,8 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     sles12-POWER-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
-      hypervisor: vmpooler
       platform: sles-12-ppc64le
-      packaging_platform: sles-12-ppc64le
+      hypervisor: vmpooler
       roles:
       - agent
       - ca
@@ -18,4 +13,4 @@ expected_hash:
     nfs_server: none
     consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
-expected_exception: 
+expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/sles12-S390Xa
+++ b/test/fixtures/generated/osinfo-version-1/sles12-S390Xa
@@ -4,17 +4,12 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     sles12-S390X-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
-      hypervisor: vmpooler
       platform: sles-12-s390x
-      packaging_platform: sles-12-s390x
+      hypervisor: vmpooler
       roles:
       - agent
   CONFIG:
     nfs_server: none
     consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
-expected_exception: 
+expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/sles15-64l
+++ b/test/fixtures/generated/osinfo-version-1/sles15-64l
@@ -4,14 +4,9 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     sles15-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
-      hypervisor: vmpooler
       platform: sles-15-x86_64
-      packaging_platform: sles-15-x86_64
       template: sles-15-x86_64
+      hypervisor: vmpooler
       roles:
       - agent
       - classifier
@@ -19,4 +14,4 @@ expected_hash:
     nfs_server: none
     consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
-expected_exception: 
+expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/solaris10-32l
+++ b/test/fixtures/generated/osinfo-version-1/solaris10-32l
@@ -4,13 +4,8 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     solaris10-32-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: solaris-10-i386
-      packaging_platform: solaris-10-i386
       template: solaris-10-x86_64
       roles:
       - agent

--- a/test/fixtures/generated/osinfo-version-1/solaris10-64c
+++ b/test/fixtures/generated/osinfo-version-1/solaris10-64c
@@ -4,13 +4,8 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     solaris10-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: solaris-10-i386
-      packaging_platform: solaris-10-i386
       template: solaris-10-x86_64
       roles:
       - agent

--- a/test/fixtures/generated/osinfo-version-1/solaris10-SPARCd
+++ b/test/fixtures/generated/osinfo-version-1/solaris10-SPARCd
@@ -4,13 +4,8 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     solaris10-SPARC-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: solaris-10-sparc
-      packaging_platform: solaris-10-sparc
       roles:
       - agent
       - database

--- a/test/fixtures/generated/osinfo-version-1/solaris11-32f
+++ b/test/fixtures/generated/osinfo-version-1/solaris11-32f
@@ -4,13 +4,8 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     solaris11-32-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: solaris-11-i386
-      packaging_platform: solaris-11-i386
       template: solaris-11-x86_64
       roles:
       - agent

--- a/test/fixtures/generated/osinfo-version-1/solaris11-64m
+++ b/test/fixtures/generated/osinfo-version-1/solaris11-64m
@@ -4,13 +4,8 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     solaris11-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: solaris-11-i386
-      packaging_platform: solaris-11-i386
       template: solaris-11-x86_64
       roles:
       - agent

--- a/test/fixtures/generated/osinfo-version-1/solaris11-SPARCaulcdfm
+++ b/test/fixtures/generated/osinfo-version-1/solaris11-SPARCaulcdfm
@@ -4,13 +4,8 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     solaris11-SPARC-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: solaris-11-sparc
-      packaging_platform: solaris-11-sparc
       roles:
       - agent
       - ca

--- a/test/fixtures/generated/osinfo-version-1/solaris112-32a
+++ b/test/fixtures/generated/osinfo-version-1/solaris112-32a
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     solaris112-32-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: solaris-11.2-i386
       packaging_platform: solaris-11-i386

--- a/test/fixtures/generated/osinfo-version-1/solaris112-64u
+++ b/test/fixtures/generated/osinfo-version-1/solaris112-64u
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     solaris112-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: solaris-11.2-i386
       packaging_platform: solaris-11-i386

--- a/test/fixtures/generated/osinfo-version-1/ubuntu1404-32d
+++ b/test/fixtures/generated/osinfo-version-1/ubuntu1404-32d
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     ubuntu1404-32-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: ubuntu-14.04-i386
       hypervisor: vmpooler
       template: ubuntu-1404-i386

--- a/test/fixtures/generated/osinfo-version-1/ubuntu1404-32m
+++ b/test/fixtures/generated/osinfo-version-1/ubuntu1404-32m
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     ubuntu1404-32-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: ubuntu-14.04-i386
       template: ubuntu-1404-i386

--- a/test/fixtures/generated/osinfo-version-1/ubuntu1404-64aulcdfm
+++ b/test/fixtures/generated/osinfo-version-1/ubuntu1404-64aulcdfm
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     ubuntu1404-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: ubuntu-14.04-amd64
       template: ubuntu-1404-x86_64

--- a/test/fixtures/generated/osinfo-version-1/ubuntu1404-64f
+++ b/test/fixtures/generated/osinfo-version-1/ubuntu1404-64f
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     ubuntu1404-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: ubuntu-14.04-amd64
       hypervisor: vmpooler
       template: ubuntu-1404-x86_64

--- a/test/fixtures/generated/osinfo-version-1/ubuntu1404-AARCH64aulcdfm
+++ b/test/fixtures/generated/osinfo-version-1/ubuntu1404-AARCH64aulcdfm
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     ubuntu1404-AARCH64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: ubuntu-14.04-aarch64
       hypervisor: vmpooler
       roles:

--- a/test/fixtures/generated/osinfo-version-1/ubuntu1404-POWERm
+++ b/test/fixtures/generated/osinfo-version-1/ubuntu1404-POWERm
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     ubuntu1404-POWER-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: ubuntu-14.04-ppc64el
       hypervisor: vmpooler
       roles:

--- a/test/fixtures/generated/osinfo-version-1/ubuntu1604-32a
+++ b/test/fixtures/generated/osinfo-version-1/ubuntu1604-32a
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     ubuntu1604-32-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: ubuntu-16.04-i386
       hypervisor: vmpooler
       template: ubuntu-1604-i386

--- a/test/fixtures/generated/osinfo-version-1/ubuntu1604-32d
+++ b/test/fixtures/generated/osinfo-version-1/ubuntu1604-32d
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     ubuntu1604-32-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: ubuntu-16.04-i386
       template: ubuntu-1604-i386

--- a/test/fixtures/generated/osinfo-version-1/ubuntu1604-64f
+++ b/test/fixtures/generated/osinfo-version-1/ubuntu1604-64f
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     ubuntu1604-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: ubuntu-16.04-amd64
       template: ubuntu-1604-x86_64

--- a/test/fixtures/generated/osinfo-version-1/ubuntu1604-64u
+++ b/test/fixtures/generated/osinfo-version-1/ubuntu1604-64u
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     ubuntu1604-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: ubuntu-16.04-amd64
       hypervisor: vmpooler
       template: ubuntu-1604-x86_64

--- a/test/fixtures/generated/osinfo-version-1/ubuntu1604-AARCH64c
+++ b/test/fixtures/generated/osinfo-version-1/ubuntu1604-AARCH64c
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     ubuntu1604-AARCH64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: ubuntu-16.04-aarch64
       hypervisor: vmpooler
       roles:

--- a/test/fixtures/generated/osinfo-version-1/ubuntu1604-POWERl
+++ b/test/fixtures/generated/osinfo-version-1/ubuntu1604-POWERl
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     ubuntu1604-POWER-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: ubuntu-16.04-ppc64el
       hypervisor: vmpooler
       roles:

--- a/test/fixtures/generated/osinfo-version-1/ubuntu1604-POWERm
+++ b/test/fixtures/generated/osinfo-version-1/ubuntu1604-POWERm
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     ubuntu1604-POWER-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: ubuntu-16.04-ppc64el
       roles:

--- a/test/fixtures/generated/osinfo-version-1/ubuntu1804-64a
+++ b/test/fixtures/generated/osinfo-version-1/ubuntu1804-64a
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     ubuntu1804-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: ubuntu-18.04-amd64
       template: ubuntu-1804-x86_64

--- a/test/fixtures/generated/osinfo-version-1/ubuntu1804-64d
+++ b/test/fixtures/generated/osinfo-version-1/ubuntu1804-64d
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     ubuntu1804-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: ubuntu-18.04-amd64
       hypervisor: vmpooler
       template: ubuntu-1804-x86_64

--- a/test/fixtures/generated/osinfo-version-1/ubuntu1804-AARCH64m
+++ b/test/fixtures/generated/osinfo-version-1/ubuntu1804-AARCH64m
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     ubuntu1804-AARCH64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: ubuntu-18.04-aarch64
       hypervisor: vmpooler
       roles:

--- a/test/fixtures/generated/osinfo-version-1/ubuntu1804-POWERf
+++ b/test/fixtures/generated/osinfo-version-1/ubuntu1804-POWERf
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     ubuntu1804-POWER-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: ubuntu-18.04-ppc64el
       hypervisor: vmpooler
       roles:

--- a/test/fixtures/generated/osinfo-version-1/ubuntu2004-64a
+++ b/test/fixtures/generated/osinfo-version-1/ubuntu2004-64a
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     ubuntu2004-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: ubuntu-20.04-amd64
       template: ubuntu-2004-x86_64
       hypervisor: vmpooler

--- a/test/fixtures/generated/osinfo-version-1/ubuntu2004-64aulcdfm
+++ b/test/fixtures/generated/osinfo-version-1/ubuntu2004-64aulcdfm
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     ubuntu2004-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: ubuntu-20.04-amd64
       hypervisor: vmpooler
       template: ubuntu-2004-x86_64

--- a/test/fixtures/generated/osinfo-version-1/ubuntu2004-AARCH64c
+++ b/test/fixtures/generated/osinfo-version-1/ubuntu2004-AARCH64c
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     ubuntu2004-AARCH64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: ubuntu-20.04-aarch64
       hypervisor: vmpooler
       roles:

--- a/test/fixtures/generated/osinfo-version-1/ubuntu2004-AARCH64u
+++ b/test/fixtures/generated/osinfo-version-1/ubuntu2004-AARCH64u
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     ubuntu2004-AARCH64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: ubuntu-20.04-aarch64
       hypervisor: vmpooler
       roles:

--- a/test/fixtures/generated/osinfo-version-1/ubuntu2004-POWERa
+++ b/test/fixtures/generated/osinfo-version-1/ubuntu2004-POWERa
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     ubuntu2004-POWER-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: ubuntu-20.04-ppc64el
       hypervisor: vmpooler
       roles:

--- a/test/fixtures/generated/osinfo-version-1/ubuntu2010-64l
+++ b/test/fixtures/generated/osinfo-version-1/ubuntu2010-64l
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     ubuntu2010-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: ubuntu-20.10-amd64
       hypervisor: vmpooler
       template: ubuntu-2010-x86_64

--- a/test/fixtures/generated/osinfo-version-1/ubuntu2104-64c
+++ b/test/fixtures/generated/osinfo-version-1/ubuntu2104-64c
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     ubuntu2104-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: ubuntu-21.04-amd64
       hypervisor: vmpooler
       template: ubuntu-2104-x86_64

--- a/test/fixtures/generated/osinfo-version-1/ubuntu2110-64d
+++ b/test/fixtures/generated/osinfo-version-1/ubuntu2110-64d
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     ubuntu2110-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: ubuntu-21.10-amd64
       hypervisor: vmpooler
       template: ubuntu-2110-x86_64

--- a/test/fixtures/generated/osinfo-version-1/vro6-64u
+++ b/test/fixtures/generated/osinfo-version-1/vro6-64u
@@ -4,12 +4,7 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     vro6-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: sles-11-x86_64
-      packaging_platform: sles-11-x86_64
       template: vro-6-x86_64
       hypervisor: vmpooler
       roles:

--- a/test/fixtures/generated/osinfo-version-1/vro7-64l
+++ b/test/fixtures/generated/osinfo-version-1/vro7-64l
@@ -4,12 +4,7 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     vro7-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: sles-11-x86_64
-      packaging_platform: sles-11-x86_64
       template: vro-7-x86_64
       hypervisor: vmpooler
       roles:

--- a/test/fixtures/generated/osinfo-version-1/vro71-64d
+++ b/test/fixtures/generated/osinfo-version-1/vro71-64d
@@ -4,13 +4,8 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     vro71-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: sles-11-x86_64
-      packaging_platform: sles-11-x86_64
       template: vro-71-x86_64
       roles:
       - agent

--- a/test/fixtures/generated/osinfo-version-1/vro73-64l
+++ b/test/fixtures/generated/osinfo-version-1/vro73-64l
@@ -4,13 +4,8 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     vro73-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: sles-11-x86_64
-      packaging_platform: sles-11-x86_64
       template: vro-73-x86_64
       roles:
       - agent

--- a/test/fixtures/generated/osinfo-version-1/vro74-64m
+++ b/test/fixtures/generated/osinfo-version-1/vro74-64m
@@ -4,13 +4,8 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     vro74-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: sles-11-x86_64
-      packaging_platform: sles-11-x86_64
       template: vro-74-x86_64
       roles:
       - agent

--- a/test/fixtures/generated/osinfo-version-1/windows10ent-32u
+++ b/test/fixtures/generated/osinfo-version-1/windows10ent-32u
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     windows10ent-32-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: windows-10ent-32
       packaging_platform: windows-2012-x86
       ruby_arch: x86

--- a/test/fixtures/generated/osinfo-version-1/windows10ent-64l
+++ b/test/fixtures/generated/osinfo-version-1/windows10ent-64l
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     windows10ent-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: windows-10ent-64
       packaging_platform: windows-2012-x64
       ruby_arch: x64

--- a/test/fixtures/generated/osinfo-version-1/windows10pro-64c
+++ b/test/fixtures/generated/osinfo-version-1/windows10pro-64c
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     windows10pro-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: windows-10pro-64
       packaging_platform: windows-2012-x64
       ruby_arch: x64

--- a/test/fixtures/generated/osinfo-version-1/windows2008-6432u
+++ b/test/fixtures/generated/osinfo-version-1/windows2008-6432u
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     windows2008-6432-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: windows-2008-64
       packaging_platform: windows-2012-x64
       ruby_arch: x86

--- a/test/fixtures/generated/osinfo-version-1/windows2008-64a
+++ b/test/fixtures/generated/osinfo-version-1/windows2008-64a
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     windows2008-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: windows-2008-64
       packaging_platform: windows-2012-x64
       ruby_arch: x64

--- a/test/fixtures/generated/osinfo-version-1/windows2008r2-6432c
+++ b/test/fixtures/generated/osinfo-version-1/windows2008r2-6432c
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     windows2008r2-6432-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: windows-2008r2-64
       packaging_platform: windows-2012-x64
       ruby_arch: x86

--- a/test/fixtures/generated/osinfo-version-1/windows2008r2-64l
+++ b/test/fixtures/generated/osinfo-version-1/windows2008r2-64l
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     windows2008r2-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: windows-2008r2-64
       packaging_platform: windows-2012-x64
       ruby_arch: x64

--- a/test/fixtures/generated/osinfo-version-1/windows2012-6432f
+++ b/test/fixtures/generated/osinfo-version-1/windows2012-6432f
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     windows2012-6432-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: windows-2012-64
       packaging_platform: windows-2012-x64
       ruby_arch: x86

--- a/test/fixtures/generated/osinfo-version-1/windows2012-64d
+++ b/test/fixtures/generated/osinfo-version-1/windows2012-64d
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     windows2012-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: windows-2012-64
       packaging_platform: windows-2012-x64
       ruby_arch: x64

--- a/test/fixtures/generated/osinfo-version-1/windows2012r2-6432aulcdfm
+++ b/test/fixtures/generated/osinfo-version-1/windows2012r2-6432aulcdfm
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     windows2012r2-6432-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: windows-2012r2-64
       packaging_platform: windows-2012-x64
       ruby_arch: x86

--- a/test/fixtures/generated/osinfo-version-1/windows2012r2-64m
+++ b/test/fixtures/generated/osinfo-version-1/windows2012r2-64m
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     windows2012r2-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: windows-2012r2-64
       packaging_platform: windows-2012-x64
       ruby_arch: x64

--- a/test/fixtures/generated/osinfo-version-1/windows2012r2_ja-6432l
+++ b/test/fixtures/generated/osinfo-version-1/windows2012r2_ja-6432l
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     windows2012r2_ja-6432-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: windows-2012r2-64
       packaging_platform: windows-2012-x64
       ruby_arch: x86

--- a/test/fixtures/generated/osinfo-version-1/windows2012r2_ja-64u
+++ b/test/fixtures/generated/osinfo-version-1/windows2012r2_ja-64u
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     windows2012r2_ja-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: windows-2012r2-64
       packaging_platform: windows-2012-x64
       ruby_arch: x64

--- a/test/fixtures/generated/osinfo-version-1/windows2012r2_wmf5-64a
+++ b/test/fixtures/generated/osinfo-version-1/windows2012r2_wmf5-64a
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     windows2012r2_wmf5-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: windows-2012r2-64
       packaging_platform: windows-2012-x64
       ruby_arch: x64

--- a/test/fixtures/generated/osinfo-version-1/windows2016-6432d
+++ b/test/fixtures/generated/osinfo-version-1/windows2016-6432d
@@ -4,15 +4,11 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     windows2016-6432-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
-      hypervisor: vmpooler
       platform: windows-2016-64
       packaging_platform: windows-2012-x64
       ruby_arch: x86
       template: win-2016-x86_64
+      hypervisor: vmpooler
       roles:
       - agent
       - database
@@ -20,4 +16,4 @@ expected_hash:
     nfs_server: none
     consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
-expected_exception: 
+expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/windows2016-64c
+++ b/test/fixtures/generated/osinfo-version-1/windows2016-64c
@@ -4,15 +4,11 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     windows2016-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
-      hypervisor: vmpooler
       platform: windows-2016-64
       packaging_platform: windows-2012-x64
       ruby_arch: x64
       template: win-2016-x86_64
+      hypervisor: vmpooler
       roles:
       - agent
       - dashboard
@@ -20,4 +16,4 @@ expected_hash:
     nfs_server: none
     consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
-expected_exception: 
+expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/windows2016_fr-6432f
+++ b/test/fixtures/generated/osinfo-version-1/windows2016_fr-6432f
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     windows2016_fr-6432-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: windows-2016-64
       packaging_platform: windows-2012-x64
       ruby_arch: x86

--- a/test/fixtures/generated/osinfo-version-1/windows2016_fr-64d
+++ b/test/fixtures/generated/osinfo-version-1/windows2016_fr-64d
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     windows2016_fr-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: windows-2016-64
       packaging_platform: windows-2012-x64
       ruby_arch: x64

--- a/test/fixtures/generated/osinfo-version-1/windows2022-64aulcdfm
+++ b/test/fixtures/generated/osinfo-version-1/windows2022-64aulcdfm
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     windows2022-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: windows-2022-64
       packaging_platform: windows-2012-x64
       ruby_arch: x64

--- a/test/fixtures/generated/osinfo-version-1/windows7-64f
+++ b/test/fixtures/generated/osinfo-version-1/windows7-64f
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     windows7-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: windows-7-64
       packaging_platform: windows-2012-x64
       ruby_arch: x64

--- a/test/fixtures/generated/osinfo-version-1/windows81-64aulcdfm
+++ b/test/fixtures/generated/osinfo-version-1/windows81-64aulcdfm
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     windows81-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-8.1-64
       packaging_platform: windows-2012-x64

--- a/test/fixtures/generated/osinfo-version-1/windowsfips2012r2-6432f
+++ b/test/fixtures/generated/osinfo-version-1/windowsfips2012r2-6432f
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     windowsfips2012r2-6432-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: windows-2012r2-64
       packaging_platform: windowsfips-2012-x64
       ruby_arch: x64

--- a/test/fixtures/generated/osinfo-version-1/windowsfips2012r2-64d
+++ b/test/fixtures/generated/osinfo-version-1/windowsfips2012r2-64d
@@ -4,10 +4,6 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     windowsfips2012r2-64-1:
-      pe_dir: 
-      pe_ver: 
-      pe_upgrade_dir: 
-      pe_upgrade_ver: 
       platform: windows-2012r2-64
       packaging_platform: windowsfips-2012-x64
       ruby_arch: x64

--- a/test/fixtures/generated/pe_dir/centos6-64mdc
+++ b/test/fixtures/generated/pe_dir/centos6-64mdc
@@ -5,11 +5,7 @@ expected_hash:
   HOSTS:
     centos6-64-1:
       pe_dir: "/opt/hello"
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: el-6-x86_64
-      packaging_platform: el-6-x86_64
       hypervisor: vmpooler
       template: centos-6-x86_64
       roles:

--- a/test/fixtures/generated/pe_upgrade_dir/centos6-64mdc
+++ b/test/fixtures/generated/pe_upgrade_dir/centos6-64mdc
@@ -4,12 +4,8 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     centos6-64-1:
-      pe_dir:
-      pe_ver:
       pe_upgrade_dir: "/opt/whatever"
-      pe_upgrade_ver:
       platform: el-6-x86_64
-      packaging_platform: el-6-x86_64
       hypervisor: vmpooler
       template: centos-6-x86_64
       roles:

--- a/test/fixtures/generated/pe_upgrade_ver/centos6-64mdc
+++ b/test/fixtures/generated/pe_upgrade_ver/centos6-64mdc
@@ -4,12 +4,8 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     centos6-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
       pe_upgrade_ver: 2020.7.3
       platform: el-6-x86_64
-      packaging_platform: el-6-x86_64
       hypervisor: vmpooler
       template: centos-6-x86_64
       roles:

--- a/test/fixtures/generated/pe_ver/centos6-64mdc
+++ b/test/fixtures/generated/pe_ver/centos6-64mdc
@@ -4,12 +4,8 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     centos6-64-1:
-      pe_dir:
       pe_ver: '2020.7'
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: el-6-x86_64
-      packaging_platform: el-6-x86_64
       hypervisor: vmpooler
       template: centos-6-x86_64
       roles:

--- a/test/fixtures/per-host-settings/arbitrary-hypervisor.yaml
+++ b/test/fixtures/per-host-settings/arbitrary-hypervisor.yaml
@@ -4,34 +4,19 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     centos6-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       hypervisor: vmpooler
       platform: el-6-x86_64
-      packaging_platform: el-6-x86_64
       template: centos-6-x86_64
       roles:
       - agent
       - master
     debian8-32-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: debian-8-i386
-      packaging_platform: debian-8-i386
       hypervisor: none
       roles:
       - agent
     redhat7-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: el-7-x86_64
-      packaging_platform: el-7-x86_64
       hypervisor: custom
       roles:
       - agent

--- a/test/fixtures/per-host-settings/arbitrary-settings.yaml
+++ b/test/fixtures/per-host-settings/arbitrary-settings.yaml
@@ -4,12 +4,7 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     redhat:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: el-7-x86_64
-      packaging_platform: el-7-x86_64
       hypervisor: none
       vmhostname: vm-redhat
       ip: 1.2.3.4
@@ -19,20 +14,12 @@ expected_hash:
       - role_a
       - role_b
     sles10-32-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       hypervisor: vmpooler
       platform: sles-10-i386
       template: sles-10-i386
       roles:
       - agent
     sles10-64-2:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       hypervisor: vmpooler
       platform: sles-10-x86_64
       template: sles-10-x86_64
@@ -40,10 +27,6 @@ expected_hash:
       roles:
       - agent
     sles10-64-3:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       hypervisor: vmpooler
       platform: sles-10-x86_64
       template: sles-10-x86_64

--- a/test/fixtures/per-host-settings/docker-regex-validation.yaml
+++ b/test/fixtures/per-host-settings/docker-regex-validation.yaml
@@ -3,23 +3,14 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     oracle7-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       docker_cmd:
       - "/sbin/init"
       image: amd64/oraclelinux:7
       platform: el-7-x86_64
-      packaging_platform: el-7-x86_64
       hypervisor: docker
       roles:
       - agent
     opensuse15-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       docker_cmd:
       - "/sbin/init"
       image: amd64/opensuse/leap:15
@@ -31,10 +22,6 @@ expected_hash:
       roles:
       - agent
     ubuntu2004-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       docker_cmd:
       - "/sbin/init"
       image: amd64/ubuntu:20.04

--- a/test/fixtures/per-host-settings/every-hypervisor.yaml
+++ b/test/fixtures/per-host-settings/every-hypervisor.yaml
@@ -4,50 +4,30 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     centos6-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       hypervisor: vmpooler
       platform: el-6-x86_64
-      packaging_platform: el-6-x86_64
       template: centos-6-x86_64
       roles:
       - agent
       - master
     debian8-32-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: debian-8-i386
-      packaging_platform: debian-8-i386
       hypervisor: none
       roles:
       - agent
     redhat7-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       hypervisor: abs
       platform: el-7-x86_64
-      packaging_platform: el-7-x86_64
       template: redhat-7-x86_64
       roles:
       - agent
       - frictionless
     debian9-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       hypervisor: docker
       docker_cmd:
       - /sbin/init
       image: amd64/debian:9
       platform: debian-9-amd64
-      packaging_platform: debian-9-amd64
       docker_image_commands:
       - cp /bin/true /sbin/agetty
       - rm -f /usr/sbin/policy-rc.d
@@ -55,10 +35,6 @@ expected_hash:
       roles:
       - agent
     ubuntu1804-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       hypervisor: vagrant
       box: generic/ubuntu1804
       synced_folder: disabled
@@ -66,15 +42,10 @@ expected_hash:
       roles:
       - agent
     debian7-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       hypervisor: vagrant_libvirt
       box: debian/wheezy64
       synced_folder: disabled
       platform: debian-7-amd64
-      packaging_platform: debian-7-amd64
       roles:
       - agent
 

--- a/test/fixtures/per-host-settings/url-encoded.yaml
+++ b/test/fixtures/per-host-settings/url-encoded.yaml
@@ -4,13 +4,8 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     centos6-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       hypervisor: vmpooler
       platform: el-6-x86_64
-      packaging_platform: el-6-x86_64
       template: centos-6-x86_64
       roles:
       - agent
@@ -18,25 +13,15 @@ expected_hash:
       - dashboard
       - database
     aix53-POWER-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       platform: aix-5.3-power
-      packaging_platform: aix-5.3-power
       hypervisor: aix
       vmhostname: pe-aix-53-acceptance.delivery.puppetlabs.net
       roles:
       - agent
       - frictionless
     aix53-POWER-2:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       hypervisor: vmpooler
       platform: aix-5.3-power
-      packaging_platform: aix-5.3-power
       foo: bar
       roles:
       - agent

--- a/test/fixtures/per-host-settings/vagrant-hypervisor.yaml
+++ b/test/fixtures/per-host-settings/vagrant-hypervisor.yaml
@@ -4,39 +4,24 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     centos6-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       box: centos/6
       synced_folder: disabled
       platform: el-6-x86_64
-      packaging_platform: el-6-x86_64
       hypervisor: vagrant_libvirt
       roles:
       - agent
       - master
     debian8-32-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       box: generic/debian8
       synced_folder: disabled
       platform: debian-8-i386
-      packaging_platform: debian-8-i386
       hypervisor: vagrant_libvirt
       roles:
       - agent
     redhat7-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       box: generic/redhat7
       synced_folder: disabled
       platform: el-7-x86_64
-      packaging_platform: el-7-x86_64
       hypervisor: vagrant
       roles:
       - agent

--- a/test/fixtures/per-host-settings/with-global-settings-overwrite.yaml
+++ b/test/fixtures/per-host-settings/with-global-settings-overwrite.yaml
@@ -4,13 +4,8 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     redhat7-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       hypervisor: vmpooler
       platform: el-7-x86_64
-      packaging_platform: el-7-x86_64
       template: redhat-7-x86_64
       roles:
         - agent

--- a/test/fixtures/per-host-settings/with-global-settings.yaml
+++ b/test/fixtures/per-host-settings/with-global-settings.yaml
@@ -4,13 +4,8 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     redhat7-64-1:
-      pe_dir:
-      pe_ver:
-      pe_upgrade_dir:
-      pe_upgrade_ver:
       hypervisor: vmpooler
       platform: el-7-x86_64
-      packaging_platform: el-7-x86_64
       template: redhat-7-x86_64
       type: o-negative
       roles:


### PR DESCRIPTION
This drop packaging_platform where it matches platform. Beaker already returns the platform when packaging_platform isn't set. This means specifying if it matches is redundant.

It also omits the empty entries for pe_*.