### PR TITLE
Use CentOS Stream 8 instead of CentOS Linux 8

### DIFF
--- a/lib/beaker-hostgenerator/data.rb
+++ b/lib/beaker-hostgenerator/data.rb
@@ -297,7 +297,11 @@ module BeakerHostGenerator
           :general => {
             'platform' => 'el-8-x86_64'
           },
+          :vagrant => {
+            'box' => 'centos/stream8',
+          },
           :docker => {
+            'image'                 => 'quay.io/centos/centos:stream8',
             'docker_image_commands' => [
               'cp /bin/true /sbin/agetty',
               'yum install -y crontabs initscripts iproute openssl wget which glibc-langpack-en'


### PR DESCRIPTION
CentOS Linux 8 went End Of Life at the end of 2021 and at the end of January it will disappear from the mirrors. Stream is the supported replacement. By using the Vagrant box and container image it should mean most testing will not notice the difference.