### PR TITLE
Install hostname on CentOS 8 Stream in docker

### DIFF
--- a/lib/beaker-hostgenerator/data.rb
+++ b/lib/beaker-hostgenerator/data.rb
@@ -304,7 +304,7 @@ module BeakerHostGenerator
             'image'                 => 'quay.io/centos/centos:stream8',
             'docker_image_commands' => [
               'cp /bin/true /sbin/agetty',
-              'yum install -y crontabs initscripts iproute openssl wget which glibc-langpack-en'
+              'yum install -y crontabs initscripts iproute openssl wget which glibc-langpack-en hostname'
             ]
           }
         },


### PR DESCRIPTION
This is not available in the minimal CentOS 8 Stream containers and specinfra relies on this for the hostname -f command to determine the FQDN.

Fixes: a4bdd3b3c51ccc65d6e75a9fa245a2f240b0d12d