### PR TITLE
Install lsb-release on Ubuntu 16/18 docker images

### DIFF
--- a/lib/beaker-hostgenerator/hypervisor/docker.rb
+++ b/lib/beaker-hostgenerator/hypervisor/docker.rb
@@ -32,9 +32,9 @@ module BeakerHostGenerator
                                       when /1404/
                                         ['apt-transport-https']
                                       when /1604/
-                                        ['locales']
+                                        ['locales', 'lsb-release']
                                       else
-                                        ['locales', 'iproute2', 'gnupg']
+                                        ['locales', 'iproute2', 'gnupg', 'lsb-release']
                                       end
 
           docker_commands << "apt-get install -y net-tools wget #{extra_packages_to_install.join(' ')}"

--- a/test/fixtures/per-host-settings/docker-regex-validation.yaml
+++ b/test/fixtures/per-host-settings/docker-regex-validation.yaml
@@ -28,7 +28,7 @@ expected_hash:
       platform: ubuntu-20.04-amd64
       docker_image_commands:
       - cp /bin/true /sbin/agetty
-      - apt-get install -y net-tools wget locales iproute2 gnupg
+      - apt-get install -y net-tools wget locales iproute2 gnupg lsb-release
       - locale-gen en_US.UTF-8
       - echo LANG=en_US.UTF-8 > /etc/default/locale
       hypervisor: docker


### PR DESCRIPTION
`lsb_release` tools is now missing from Ubuntu 16/18 docker images causing acceptance puppet 6 tests to fail.
Facter 3.x utilizes `lsb_release` tool for obtaining `os.distro` fact.

Some PRs that are failing due to this:

* https://github.com/voxpupuli/puppet-zabbix/pull/813
* https://github.com/voxpupuli/puppet-cvmfs/pull/148 (workaround on this specific module)
* https://github.com/voxpupuli/puppet-nginx/pull/1496

And probably all of the modules that use `os.distro` fact will fail on Ubuntu 16/18 platforms.

P.S it's the first time touching this utility so any help is appreciated it :smile: