### PR TITLE
Add Windows 11 Enterprise, Fedora 36

### DIFF
--- a/lib/beaker-hostgenerator/data.rb
+++ b/lib/beaker-hostgenerator/data.rb
@@ -1275,7 +1275,7 @@ module BeakerHostGenerator
           :general => {
             'platform'           => 'windows-2008-64',
             'packaging_platform' => 'windows-2012-x64',
-            'ruby_arch' => 'x64'
+            'ruby_arch'          => 'x64'
           },
           :vmpooler => {
             'template' => 'win-2008-x86_64'
@@ -1285,7 +1285,7 @@ module BeakerHostGenerator
           :general => {
             'platform'           => 'windows-2008-64',
             'packaging_platform' => 'windows-2012-x64',
-            'ruby_arch' => 'x86'
+            'ruby_arch'          => 'x86'
           },
           :vmpooler => {
             'template' => 'win-2008-x86_64'
@@ -1295,7 +1295,7 @@ module BeakerHostGenerator
           :general => {
             'platform'           => 'windows-2008r2-64',
             'packaging_platform' => 'windows-2012-x64',
-            'ruby_arch' => 'x64'
+            'ruby_arch'          => 'x64'
           },
           :vmpooler => {
             'template' => 'win-2008r2-x86_64'
@@ -1305,7 +1305,7 @@ module BeakerHostGenerator
           :general => {
             'platform'           => 'windows-2008r2-64',
             'packaging_platform' => 'windows-2012-x64',
-            'ruby_arch' => 'x86'
+            'ruby_arch'          => 'x86'
           },
           :vmpooler => {
             'template' => 'win-2008r2-x86_64'
@@ -1315,7 +1315,7 @@ module BeakerHostGenerator
           :general => {
             'platform'           => 'windows-2012-64',
             'packaging_platform' => 'windows-2012-x64',
-            'ruby_arch' => 'x64'
+            'ruby_arch'          => 'x64'
           },
           :vmpooler => {
             'template' => 'win-2012-x86_64'
@@ -1325,7 +1325,7 @@ module BeakerHostGenerator
           :general => {
             'platform'           => 'windows-2012-64',
             'packaging_platform' => 'windows-2012-x64',
-            'ruby_arch' => 'x86'
+            'ruby_arch'          => 'x86'
           },
           :vmpooler => {
             'template' => 'win-2012-x86_64'
@@ -1335,7 +1335,7 @@ module BeakerHostGenerator
           :general => {
             'platform'           => 'windows-2012r2-64',
             'packaging_platform' => 'windows-2012-x64',
-            'ruby_arch' => 'x64'
+            'ruby_arch'          => 'x64'
           },
           :vmpooler => {
             'template' => 'win-2012r2-x86_64'
@@ -1345,7 +1345,7 @@ module BeakerHostGenerator
           :general => {
             'platform'           => 'windows-2012r2-64',
             'packaging_platform' => 'windowsfips-2012-x64',
-            'ruby_arch' => 'x64'
+            'ruby_arch'          => 'x64'
           },
           :vmpooler => {
             'template' => 'win-2012r2-fips-x86_64'
@@ -1355,7 +1355,7 @@ module BeakerHostGenerator
           :general => {
             'platform'           => 'windows-2012r2-64',
             'packaging_platform' => 'windowsfips-2012-x64',
-            'ruby_arch' => 'x64'
+            'ruby_arch'          => 'x64'
           },
           :vmpooler => {
             'template' => 'win-2012r2-fips-x86_64'
@@ -1365,7 +1365,7 @@ module BeakerHostGenerator
           :general => {
             'platform'           => 'windows-2012r2-64',
             'packaging_platform' => 'windows-2012-x64',
-            'ruby_arch' => 'x86'
+            'ruby_arch'          => 'x86'
           },
           :vmpooler => {
             'template' => 'win-2012r2-x86_64'
@@ -1375,7 +1375,7 @@ module BeakerHostGenerator
           :general => {
             'platform'           => 'windows-2012r2-64',
             'packaging_platform' => 'windows-2012-x64',
-            'ruby_arch' => 'x64'
+            'ruby_arch'          => 'x64'
           },
           :vmpooler => {
             'template' => 'win-2012r2-wmf5-x86_64'
@@ -1385,7 +1385,7 @@ module BeakerHostGenerator
           :general => {
             'platform'           => 'windows-2012r2-64',
             'packaging_platform' => 'windows-2012-x64',
-            'ruby_arch' => 'x64'
+            'ruby_arch'          => 'x64'
           },
           :vmpooler => {
             'template' => 'win-2012r2-ja-x86_64',
@@ -1396,7 +1396,7 @@ module BeakerHostGenerator
           :general => {
             'platform'           => 'windows-2012r2-64',
             'packaging_platform' => 'windows-2012-x64',
-            'ruby_arch' => 'x86'
+            'ruby_arch'          => 'x86'
           },
           :vmpooler => {
             'template' => 'win-2012r2-ja-x86_64',
@@ -1407,7 +1407,7 @@ module BeakerHostGenerator
           :general => {
             'platform'           => 'windows-2012r2-64',
             'packaging_platform' => 'windows-2012-x64',
-            'ruby_arch' => 'x64'
+            'ruby_arch'          => 'x64'
           },
           :vmpooler => {
             'template' => 'win-2012r2-fr-x86_64',
@@ -1419,7 +1419,7 @@ module BeakerHostGenerator
           :general => {
             'platform'           => 'windows-2012r2-64',
             'packaging_platform' => 'windows-2012-x64',
-            'ruby_arch' => 'x86'
+            'ruby_arch'          => 'x86'
           },
           :vmpooler => {
             'template' => 'win-2012r2-fr-x86_64',
@@ -1431,7 +1431,7 @@ module BeakerHostGenerator
           :general => {
             'platform'           => 'windows-2012r2-64',
             'packaging_platform' => 'windows-2012-x64',
-            'ruby_arch' => 'x64'
+            'ruby_arch'          => 'x64'
           },
           :vmpooler => {
             'template' => 'win-2012r2-core-x86_64'
@@ -1441,7 +1441,7 @@ module BeakerHostGenerator
           :general => {
             'platform'           => 'windows-2012r2-64',
             'packaging_platform' => 'windows-2012-x64',
-            'ruby_arch' => 'x86'
+            'ruby_arch'          => 'x86'
           },
           :vmpooler => {
             'template' => 'win-2012r2-core-x86_64'
@@ -1451,7 +1451,7 @@ module BeakerHostGenerator
           :general => {
             'platform'           => 'windows-2016-64',
             'packaging_platform' => 'windows-2012-x64',
-            'ruby_arch' => 'x64'
+            'ruby_arch'          => 'x64'
           },
           :vmpooler => {
             'template' => 'win-2016-x86_64'
@@ -1461,7 +1461,7 @@ module BeakerHostGenerator
           :general => {
             'platform'           => 'windows-2016-64',
             'packaging_platform' => 'windows-2012-x64',
-            'ruby_arch' => 'x86'
+            'ruby_arch'          => 'x86'
           },
           :vmpooler => {
             'template' => 'win-2016-x86_64'
@@ -1471,7 +1471,7 @@ module BeakerHostGenerator
           :general => {
             'platform'           => 'windows-2016-64',
             'packaging_platform' => 'windows-2012-x64',
-            'ruby_arch' => 'x64'
+            'ruby_arch'          => 'x64'
           },
           :vmpooler => {
             'template' => 'win-2016-core-x86_64'
@@ -1481,7 +1481,7 @@ module BeakerHostGenerator
           :general => {
             'platform'           => 'windows-2016-64',
             'packaging_platform' => 'windows-2012-x64',
-            'ruby_arch' => 'x86'
+            'ruby_arch'          => 'x86'
           },
           :vmpooler => {
             'template' => 'win-2016-core-x86_64'
@@ -1491,7 +1491,7 @@ module BeakerHostGenerator
           :general => {
             'platform'           => 'windows-2016-64',
             'packaging_platform' => 'windows-2012-x64',
-            'ruby_arch' => 'x64'
+            'ruby_arch'          => 'x64'
           },
           :vmpooler => {
             'template' => 'win-2016-fr-x86_64',
@@ -1503,7 +1503,7 @@ module BeakerHostGenerator
           :general => {
             'platform'           => 'windows-2016-64',
             'packaging_platform' => 'windows-2012-x64',
-            'ruby_arch' => 'x86'
+            'ruby_arch'          => 'x86'
           },
           :vmpooler => {
             'template' => 'win-2016-fr-x86_64',
@@ -1515,7 +1515,7 @@ module BeakerHostGenerator
           :general => {
             'platform'           => 'windows-2019-64',
             'packaging_platform' => 'windows-2012-x64',
-            'ruby_arch' => 'x64'
+            'ruby_arch'          => 'x64'
           },
           :vmpooler => {
             'template' => 'win-2019-x86_64'
@@ -1525,7 +1525,7 @@ module BeakerHostGenerator
           :general => {
             'platform'           => 'windows-2019-64',
             'packaging_platform' => 'windows-2012-x64',
-            'ruby_arch' => 'x86'
+            'ruby_arch'          => 'x86'
           },
           :vmpooler => {
             'template' => 'win-2019-x86_64'
@@ -1535,7 +1535,7 @@ module BeakerHostGenerator
           :general => {
             'platform'           => 'windows-2019-64',
             'packaging_platform' => 'windows-2012-x64',
-            'ruby_arch' => 'x64'
+            'ruby_arch'          => 'x64'
           },
           :vmpooler => {
             'template' => 'win-2019-ja-x86_64',
@@ -1546,7 +1546,7 @@ module BeakerHostGenerator
           :general => {
             'platform'           => 'windows-2019-64',
             'packaging_platform' => 'windows-2012-x64',
-            'ruby_arch' => 'x86'
+            'ruby_arch'          => 'x86'
           },
           :vmpooler => {
             'template' => 'win-2019-ja-x86_64',
@@ -1557,7 +1557,7 @@ module BeakerHostGenerator
           :general => {
             'platform'           => 'windows-2019-64',
             'packaging_platform' => 'windows-2012-x64',
-            'ruby_arch' => 'x64'
+            'ruby_arch'          => 'x64'
           },
           :vmpooler => {
             'template' => 'win-2019-fr-x86_64',
@@ -1569,7 +1569,7 @@ module BeakerHostGenerator
           :general => {
             'platform'           => 'windows-2019-64',
             'packaging_platform' => 'windows-2012-x64',
-            'ruby_arch' => 'x86'
+            'ruby_arch'          => 'x86'
           },
           :vmpooler => {
             'template' => 'win-2019-fr-x86_64',
@@ -1581,7 +1581,7 @@ module BeakerHostGenerator
           :general => {
             'platform'           => 'windows-2019-64',
             'packaging_platform' => 'windows-2012-x64',
-            'ruby_arch' => 'x64'
+            'ruby_arch'          => 'x64'
           },
           :vmpooler => {
             'template' => 'win-2019-core-x86_64'
@@ -1591,7 +1591,7 @@ module BeakerHostGenerator
           :general => {
             'platform'           => 'windows-2019-64',
             'packaging_platform' => 'windows-2012-x64',
-            'ruby_arch' => 'x86'
+            'ruby_arch'          => 'x86'
           },
           :vmpooler => {
             'template' => 'win-2019-core-x86_64'
@@ -1601,7 +1601,7 @@ module BeakerHostGenerator
           :general => {
             'platform'           => 'windows-2022-64',
             'packaging_platform' => 'windows-2012-x64',
-            'ruby_arch' => 'x64'
+            'ruby_arch'          => 'x64'
           },
           :vmpooler => {
             'template' => 'win-2022-x86_64'
@@ -1611,7 +1611,7 @@ module BeakerHostGenerator
           :general => {
             'platform'           => 'windows-7-64',
             'packaging_platform' => 'windows-2012-x64',
-            'ruby_arch' => 'x64'
+            'ruby_arch'          => 'x64'
           },
           :vmpooler => {
             'template' => 'win-7-x86_64'
@@ -1621,7 +1621,7 @@ module BeakerHostGenerator
           :general => {
             'platform'           => 'windows-8.1-64',
             'packaging_platform' => 'windows-2012-x64',
-            'ruby_arch' => 'x64'
+            'ruby_arch'          => 'x64'
           },
           :vmpooler => {
             'template' => 'win-81-x86_64'
@@ -1631,7 +1631,7 @@ module BeakerHostGenerator
           :general => {
             'platform'           => 'windows-10ent-32',
             'packaging_platform' => 'windows-2012-x86',
-            'ruby_arch' => 'x86'
+            'ruby_arch'          => 'x86'
           },
           :vmpooler => {
             'template' => 'win-10-ent-i386'
@@ -1641,7 +1641,7 @@ module BeakerHostGenerator
           :general => {
             'platform'           => 'windows-10ent-64',
             'packaging_platform' => 'windows-2012-x64',
-            'ruby_arch' => 'x64'
+            'ruby_arch'          => 'x64'
           },
           :vmpooler => {
             'template' => 'win-10-ent-x86_64'
@@ -1651,7 +1651,7 @@ module BeakerHostGenerator
           :general => {
             'platform'           => 'windows-10ent-32',
             'packaging_platform' => 'windows-2012-x86',
-            'ruby_arch' => 'x86'
+            'ruby_arch'          => 'x86'
           },
           :vmpooler => {
             'template' => 'win-10-next-i386'
@@ -1661,7 +1661,7 @@ module BeakerHostGenerator
           :general => {
             'platform'           => 'windows-10ent-64',
             'packaging_platform' => 'windows-2012-x64',
-            'ruby_arch' => 'x64'
+            'ruby_arch'          => 'x64'
           },
           :vmpooler => {
             'template' => 'win-10-next-x86_64'
@@ -1671,7 +1671,7 @@ module BeakerHostGenerator
           :general => {
             'platform'           => 'windows-10pro-64',
             'packaging_platform' => 'windows-2012-x64',
-            'ruby_arch' => 'x64'
+            'ruby_arch'          => 'x64'
           },
           :vmpooler => {
             'template' => 'win-10-pro-x86_64'
@@ -1681,7 +1681,7 @@ module BeakerHostGenerator
           :general => {
             'platform'           => 'windows-10ent-64',
             'packaging_platform' => 'windows-2012-x64',
-            'ruby_arch' => 'x64'
+            'ruby_arch'          => 'x64'
           },
           :vmpooler => {
             'template' => 'win-10-1511-x86_64'
@@ -1691,7 +1691,7 @@ module BeakerHostGenerator
           :general => {
             'platform'           => 'windows-10ent-64',
             'packaging_platform' => 'windows-2012-x64',
-            'ruby_arch' => 'x64'
+            'ruby_arch'          => 'x64'
           },
           :vmpooler => {
             'template' => 'win-10-1607-x86_64'
@@ -1701,7 +1701,7 @@ module BeakerHostGenerator
           :general => {
             'platform'           => 'windows-10ent-64',
             'packaging_platform' => 'windows-2012-x64',
-            'ruby_arch' => 'x64'
+            'ruby_arch'          => 'x64'
           },
           :vmpooler => {
             'template' => 'win-10-1809-x86_64'
@@ -1711,7 +1711,7 @@ module BeakerHostGenerator
           :general => {
             'platform'           => 'windows-11ent-64',
             'packaging_platform' => 'windows-2012-x64',
-            'ruby_arch' => 'x64'
+            'ruby_arch'          => 'x64'
           },
           :vmpooler => {
             'template' => 'win-11-ent-x86_64'

--- a/lib/beaker-hostgenerator/data.rb
+++ b/lib/beaker-hostgenerator/data.rb
@@ -83,7 +83,7 @@ module BeakerHostGenerator
       result = {}
 
       # Fedora
-      (19..34).each do |release|
+      (19..36).each do |release|
         # 32 bit support was dropped in Fedora 31
         if release < 31
           result["fedora#{release}-32"] = {
@@ -1705,6 +1705,16 @@ module BeakerHostGenerator
           },
           :vmpooler => {
             'template' => 'win-10-1809-x86_64'
+          }
+        },
+        'windows11ent-64' => {
+          :general => {
+            'platform'           => 'windows-11ent-64',
+            'packaging_platform' => 'windows-2012-x64',
+            'ruby_arch' => 'x64'
+          },
+          :vmpooler => {
+            'template' => 'win-11-ent-x86_64'
           }
         }
       })

--- a/test/fixtures/generated/default/fedora36-64f
+++ b/test/fixtures/generated/default/fedora36-64f
@@ -1,0 +1,17 @@
+---
+arguments_string: fedora36-64f
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    fedora36-64-1:
+      platform: fedora-36-x86_64
+      hypervisor: vmpooler
+      template: fedora-36-x86_64
+      roles:
+      - agent
+      - frictionless
+  CONFIG:
+    nfs_server: none
+    consoleport: 443
+    pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
+expected_exception:

--- a/test/fixtures/generated/default/windows11ent-64c
+++ b/test/fixtures/generated/default/windows11ent-64c
@@ -1,0 +1,19 @@
+---
+arguments_string: windows11ent-64c
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    windows11ent-64-1:
+      platform: windows-11ent-64
+      packaging_platform: windows-2012-x64
+      ruby_arch: x64
+      template: win-11-ent-x86_64
+      hypervisor: vmpooler
+      roles:
+      - agent
+      - dashboard
+  CONFIG:
+    nfs_server: none
+    consoleport: 443
+    pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
+expected_exception:

--- a/test/fixtures/generated/multiplatform/fedora19-64u-windows11ent-64-fedora19-64m
+++ b/test/fixtures/generated/multiplatform/fedora19-64u-windows11ent-64-fedora19-64m
@@ -1,0 +1,32 @@
+---
+arguments_string: fedora19-64u-windows11ent-64-fedora19-64m
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    fedora19-64-1:
+      platform: fedora-19-x86_64
+      hypervisor: vmpooler
+      template: fedora-19-x86_64
+      roles:
+      - agent
+      - ca
+    windows11ent-64-1:
+      platform: windows-11ent-64
+      packaging_platform: windows-2012-x64
+      ruby_arch: x64
+      template: win-11-ent-x86_64
+      hypervisor: vmpooler
+      roles:
+      - agent
+    fedora19-64-2:
+      platform: fedora-19-x86_64
+      hypervisor: vmpooler
+      template: fedora-19-x86_64
+      roles:
+      - agent
+      - master
+  CONFIG:
+    nfs_server: none
+    consoleport: 443
+    pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
+expected_exception:

--- a/test/fixtures/generated/multiplatform/fedora36-64f-windows2012r2_fr-6432-fedora36-64l
+++ b/test/fixtures/generated/multiplatform/fedora36-64f-windows2012r2_fr-6432-fedora36-64l
@@ -1,0 +1,34 @@
+---
+arguments_string: fedora36-64f-windows2012r2_fr-6432-fedora36-64l
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    fedora36-64-1:
+      platform: fedora-36-x86_64
+      hypervisor: vmpooler
+      template: fedora-36-x86_64
+      roles:
+      - agent
+      - frictionless
+    windows2012r2_fr-6432-1:
+      platform: windows-2012r2-64
+      packaging_platform: windows-2012-x64
+      ruby_arch: x86
+      template: win-2012r2-fr-x86_64
+      user: Administrateur
+      locale: fr
+      hypervisor: vmpooler
+      roles:
+      - agent
+    fedora36-64-2:
+      platform: fedora-36-x86_64
+      hypervisor: vmpooler
+      template: fedora-36-x86_64
+      roles:
+      - agent
+      - classifier
+  CONFIG:
+    nfs_server: none
+    consoleport: 443
+    pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
+expected_exception:

--- a/test/fixtures/generated/multiplatform/windows11ent-64c-fedora19-64-windows11ent-64d
+++ b/test/fixtures/generated/multiplatform/windows11ent-64c-fedora19-64-windows11ent-64d
@@ -1,0 +1,34 @@
+---
+arguments_string: windows11ent-64c-fedora19-64-windows11ent-64d
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    windows11ent-64-1:
+      platform: windows-11ent-64
+      packaging_platform: windows-2012-x64
+      ruby_arch: x64
+      template: win-11-ent-x86_64
+      hypervisor: vmpooler
+      roles:
+      - agent
+      - dashboard
+    fedora19-64-1:
+      platform: fedora-19-x86_64
+      hypervisor: vmpooler
+      template: fedora-19-x86_64
+      roles:
+      - agent
+    windows11ent-64-2:
+      platform: windows-11ent-64
+      packaging_platform: windows-2012-x64
+      ruby_arch: x64
+      template: win-11-ent-x86_64
+      hypervisor: vmpooler
+      roles:
+      - agent
+      - database
+  CONFIG:
+    nfs_server: none
+    consoleport: 443
+    pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
+expected_exception:

--- a/test/fixtures/generated/multiplatform/windows2012r2_fr-6432aulcdfm-fedora36-64-windows2012r2_fr-6432a
+++ b/test/fixtures/generated/multiplatform/windows2012r2_fr-6432aulcdfm-fedora36-64-windows2012r2_fr-6432a
@@ -1,0 +1,42 @@
+---
+arguments_string: windows2012r2_fr-6432aulcdfm-fedora36-64-windows2012r2_fr-6432a
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    windows2012r2_fr-6432-1:
+      platform: windows-2012r2-64
+      packaging_platform: windows-2012-x64
+      ruby_arch: x86
+      template: win-2012r2-fr-x86_64
+      user: Administrateur
+      locale: fr
+      hypervisor: vmpooler
+      roles:
+      - agent
+      - ca
+      - classifier
+      - dashboard
+      - database
+      - frictionless
+      - master
+    fedora36-64-1:
+      platform: fedora-36-x86_64
+      hypervisor: vmpooler
+      template: fedora-36-x86_64
+      roles:
+      - agent
+    windows2012r2_fr-6432-2:
+      platform: windows-2012r2-64
+      packaging_platform: windows-2012-x64
+      ruby_arch: x86
+      template: win-2012r2-fr-x86_64
+      user: Administrateur
+      locale: fr
+      hypervisor: vmpooler
+      roles:
+      - agent
+  CONFIG:
+    nfs_server: none
+    consoleport: 443
+    pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
+expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/fedora36-64f
+++ b/test/fixtures/generated/osinfo-version-0/fedora36-64f
@@ -1,0 +1,17 @@
+---
+arguments_string: "--osinfo-version 0 fedora36-64f"
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    fedora36-64-1:
+      platform: fedora-36-x86_64
+      hypervisor: vmpooler
+      template: fedora-36-x86_64
+      roles:
+      - agent
+      - frictionless
+  CONFIG:
+    nfs_server: none
+    consoleport: 443
+    pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
+expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/windows11ent-64c
+++ b/test/fixtures/generated/osinfo-version-0/windows11ent-64c
@@ -1,0 +1,19 @@
+---
+arguments_string: "--osinfo-version 0 windows11ent-64c"
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    windows11ent-64-1:
+      platform: windows-11ent-64
+      packaging_platform: windows-2012-x64
+      ruby_arch: x64
+      template: win-11-ent-x86_64
+      hypervisor: vmpooler
+      roles:
+      - agent
+      - dashboard
+  CONFIG:
+    nfs_server: none
+    consoleport: 443
+    pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
+expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/fedora36-64f
+++ b/test/fixtures/generated/osinfo-version-1/fedora36-64f
@@ -1,0 +1,17 @@
+---
+arguments_string: "--osinfo-version 1 fedora36-64f"
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    fedora36-64-1:
+      platform: fedora-36-x86_64
+      hypervisor: vmpooler
+      template: fedora-36-x86_64
+      roles:
+      - agent
+      - frictionless
+  CONFIG:
+    nfs_server: none
+    consoleport: 443
+    pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
+expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/windows11ent-64c
+++ b/test/fixtures/generated/osinfo-version-1/windows11ent-64c
@@ -1,0 +1,19 @@
+---
+arguments_string: "--osinfo-version 1 windows11ent-64c"
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    windows11ent-64-1:
+      platform: windows-11ent-64
+      packaging_platform: windows-2012-x64
+      ruby_arch: x64
+      template: win-11-ent-x86_64
+      hypervisor: vmpooler
+      roles:
+      - agent
+      - dashboard
+  CONFIG:
+    nfs_server: none
+    consoleport: 443
+    pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
+expected_exception:


### PR DESCRIPTION
Supercedes [this PR](https://github.com/voxpupuli/beaker-hostgenerator/pull/252) while we wait for macOS M1 testing infrastructure to become available.

041996359d282054940a897cb148a7c1d6eddbcf is in response to [this comment](https://github.com/voxpupuli/beaker-hostgenerator/pull/252#discussion_r897227461) from @ekohl 