### PR TITLE
(IMAGES-1297) Adds macOS 11/12 M1 support

### DIFF
--- a/lib/beaker-hostgenerator/data.rb
+++ b/lib/beaker-hostgenerator/data.rb
@@ -884,12 +884,28 @@ module BeakerHostGenerator
             'template' => 'macos-112-x86_64'
           }
         },
+        'osx11-ARM64' => {
+          :general => {
+            'platform' => 'osx-11-arm64'
+          },
+          :vmpooler => {
+            'template' => 'macos-11-arm64'
+          }
+        },
         'osx12-64' => {
           :general => {
             'platform' => 'osx-12-x86_64'
           },
           :vmpooler => {
             'template' => 'macos-12-x86_64'
+          }
+        },
+        'osx12-ARM64' => {
+          :general => {
+            'platform' => 'osx-12-arm64'
+          },
+          :vmpooler => {
+            'template' => 'macos-12-arm64'
           }
         },
         'redhat4-32' => {

--- a/test/fixtures/generated/default/osx11-ARM64u
+++ b/test/fixtures/generated/default/osx11-ARM64u
@@ -1,0 +1,17 @@
+---
+arguments_string: osx11-ARM64u
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    osx11-ARM64-1:
+      platform: osx-11-arm64
+      template: macos-11-arm64
+      hypervisor: vmpooler
+      roles:
+      - agent
+      - ca
+  CONFIG:
+    nfs_server: none
+    consoleport: 443
+    pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
+expected_exception:

--- a/test/fixtures/generated/default/osx12-ARM64c
+++ b/test/fixtures/generated/default/osx12-ARM64c
@@ -1,0 +1,17 @@
+---
+arguments_string: osx12-ARM64c
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    osx12-ARM64-1:
+      platform: osx-12-arm64
+      template: macos-12-arm64
+      hypervisor: vmpooler
+      roles:
+      - agent
+      - dashboard
+  CONFIG:
+    nfs_server: none
+    consoleport: 443
+    pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
+expected_exception:

--- a/test/fixtures/generated/multiplatform/debian8-64c-osx12-ARM64-debian8-64d
+++ b/test/fixtures/generated/multiplatform/debian8-64c-osx12-ARM64-debian8-64d
@@ -1,0 +1,30 @@
+---
+arguments_string: debian8-64c-osx12-ARM64-debian8-64d
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    debian8-64-1:
+      platform: debian-8-amd64
+      template: debian-8-x86_64
+      hypervisor: vmpooler
+      roles:
+      - agent
+      - dashboard
+    osx12-ARM64-1:
+      platform: osx-12-arm64
+      template: macos-12-arm64
+      hypervisor: vmpooler
+      roles:
+      - agent
+    debian8-64-2:
+      platform: debian-8-amd64
+      template: debian-8-x86_64
+      hypervisor: vmpooler
+      roles:
+      - agent
+      - database
+  CONFIG:
+    nfs_server: none
+    consoleport: 443
+    pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
+expected_exception:

--- a/test/fixtures/generated/multiplatform/debian9-64f-osx11-ARM64-debian9-64l
+++ b/test/fixtures/generated/multiplatform/debian9-64f-osx11-ARM64-debian9-64l
@@ -1,0 +1,30 @@
+---
+arguments_string: debian9-64f-osx11-ARM64-debian9-64l
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    debian9-64-1:
+      platform: debian-9-amd64
+      template: debian-9-x86_64
+      hypervisor: vmpooler
+      roles:
+      - agent
+      - frictionless
+    osx11-ARM64-1:
+      platform: osx-11-arm64
+      template: macos-11-arm64
+      hypervisor: vmpooler
+      roles:
+      - agent
+    debian9-64-2:
+      platform: debian-9-amd64
+      template: debian-9-x86_64
+      hypervisor: vmpooler
+      roles:
+      - agent
+      - classifier
+  CONFIG:
+    nfs_server: none
+    consoleport: 443
+    pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
+expected_exception:

--- a/test/fixtures/generated/multiplatform/osx11-ARM64u-debian9-64-osx11-ARM64m
+++ b/test/fixtures/generated/multiplatform/osx11-ARM64u-debian9-64-osx11-ARM64m
@@ -1,0 +1,30 @@
+---
+arguments_string: osx11-ARM64u-debian9-64-osx11-ARM64m
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    osx11-ARM64-1:
+      platform: osx-11-arm64
+      template: macos-11-arm64
+      hypervisor: vmpooler
+      roles:
+      - agent
+      - ca
+    debian9-64-1:
+      platform: debian-9-amd64
+      template: debian-9-x86_64
+      hypervisor: vmpooler
+      roles:
+      - agent
+    osx11-ARM64-2:
+      platform: osx-11-arm64
+      template: macos-11-arm64
+      hypervisor: vmpooler
+      roles:
+      - agent
+      - master
+  CONFIG:
+    nfs_server: none
+    consoleport: 443
+    pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
+expected_exception:

--- a/test/fixtures/generated/multiplatform/osx12-ARM64c-debian8-64-osx12-ARM64d
+++ b/test/fixtures/generated/multiplatform/osx12-ARM64c-debian8-64-osx12-ARM64d
@@ -1,0 +1,30 @@
+---
+arguments_string: osx12-ARM64c-debian8-64-osx12-ARM64d
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    osx12-ARM64-1:
+      platform: osx-12-arm64
+      template: macos-12-arm64
+      hypervisor: vmpooler
+      roles:
+      - agent
+      - dashboard
+    debian8-64-1:
+      platform: debian-8-amd64
+      template: debian-8-x86_64
+      hypervisor: vmpooler
+      roles:
+      - agent
+    osx12-ARM64-2:
+      platform: osx-12-arm64
+      template: macos-12-arm64
+      hypervisor: vmpooler
+      roles:
+      - agent
+      - database
+  CONFIG:
+    nfs_server: none
+    consoleport: 443
+    pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
+expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/osx11-ARM64u
+++ b/test/fixtures/generated/osinfo-version-0/osx11-ARM64u
@@ -1,0 +1,17 @@
+---
+arguments_string: "--osinfo-version 0 osx11-ARM64u"
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    osx11-ARM64-1:
+      platform: osx-11-arm64
+      template: macos-11-arm64
+      hypervisor: vmpooler
+      roles:
+      - agent
+      - ca
+  CONFIG:
+    nfs_server: none
+    consoleport: 443
+    pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
+expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/osx12-ARM64c
+++ b/test/fixtures/generated/osinfo-version-0/osx12-ARM64c
@@ -1,0 +1,17 @@
+---
+arguments_string: "--osinfo-version 0 osx12-ARM64c"
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    osx12-ARM64-1:
+      platform: osx-12-arm64
+      template: macos-12-arm64
+      hypervisor: vmpooler
+      roles:
+      - agent
+      - dashboard
+  CONFIG:
+    nfs_server: none
+    consoleport: 443
+    pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
+expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/osx11-ARM64u
+++ b/test/fixtures/generated/osinfo-version-1/osx11-ARM64u
@@ -1,0 +1,17 @@
+---
+arguments_string: "--osinfo-version 1 osx11-ARM64u"
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    osx11-ARM64-1:
+      platform: osx-11-arm64
+      template: macos-11-arm64
+      hypervisor: vmpooler
+      roles:
+      - agent
+      - ca
+  CONFIG:
+    nfs_server: none
+    consoleport: 443
+    pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
+expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/osx12-ARM64c
+++ b/test/fixtures/generated/osinfo-version-1/osx12-ARM64c
@@ -1,0 +1,17 @@
+---
+arguments_string: "--osinfo-version 1 osx12-ARM64c"
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    osx12-ARM64-1:
+      platform: osx-12-arm64
+      template: macos-12-arm64
+      hypervisor: vmpooler
+      roles:
+      - agent
+      - dashboard
+  CONFIG:
+    nfs_server: none
+    consoleport: 443
+    pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
+expected_exception:


### PR DESCRIPTION
For both IMAGES-1297 and IMAGES-1378, adds support for macOS 11
(Big Sur) and 12 (Monterey) M1 (ARM64) platforms.