### PR TITLE
Add hcloud support

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,10 @@ information.
 
 It currently provides built-in configuration for Puppets' internal
 [vmpooler][vmpooler] hypervisor, [always-be-scheduling][always-be-scheduling]
-hypervisor, static (non-provisioned) nodes, and is designed in a way that makes
-it possible to easily add support for additional hypervisors
-(any hypervisor type supported by [beaker][beaker]).
+hypervisor, Vagrant with Virtualbox and Libvirt backend,
+[Hetzner cloud](https://www.hetzner.com/cloud), static (non-provisioned) nodes,
+and is designed in a way that makes it possible to easily add support for
+additional hypervisors (any hypervisor type supported by [beaker][beaker]).
 
 To see the list of built-in hypervisors you can run:
 ```

--- a/lib/beaker-hostgenerator/hypervisor.rb
+++ b/lib/beaker-hostgenerator/hypervisor.rb
@@ -45,7 +45,8 @@ module BeakerHostGenerator
         'vagrant' => BeakerHostGenerator::Hypervisor::Vagrant,
         'vagrant_libvirt' => BeakerHostGenerator::Hypervisor::Vagrant,
         'docker' => BeakerHostGenerator::Hypervisor::Docker,
-        'abs' => BeakerHostGenerator::Hypervisor::ABS
+        'abs' => BeakerHostGenerator::Hypervisor::ABS,
+        'hcloud' => BeakerHostGenerator::Hypervisor::Hcloud,
       }
     end
 
@@ -114,3 +115,4 @@ require 'beaker-hostgenerator/hypervisor/vmpooler'
 require 'beaker-hostgenerator/hypervisor/vagrant'
 require 'beaker-hostgenerator/hypervisor/docker'
 require 'beaker-hostgenerator/hypervisor/abs'
+require 'beaker-hostgenerator/hypervisor/hcloud'

--- a/lib/beaker-hostgenerator/hypervisor/hcloud.rb
+++ b/lib/beaker-hostgenerator/hypervisor/hcloud.rb
@@ -1,0 +1,26 @@
+require 'beaker-hostgenerator/data'
+require 'beaker-hostgenerator/hypervisor'
+
+module BeakerHostGenerator
+  module Hypervisor
+
+    class Hcloud < BeakerHostGenerator::Hypervisor::Interface
+      include BeakerHostGenerator::Data
+
+      def generate_node(node_info, base_config, bhg_version)
+        # split ostype into string and array
+        # ostype is ubuntu2204, debian10, rocky9
+        os, version = node_info['ostype'].split(/(\D+)/).reject!(&:empty?)
+        base_config['image'] = case os
+        when 'ubuntu'
+          "#{os}-#{version[0, 2]}.#{version[2,2]}"
+        when 'centos'
+          version.to_i == 7 ? "#{os}-#{version}" : "#{os}-stream-#{version}"
+        else
+          "#{os}-#{version}"
+        end
+        return base_generate_node(node_info, base_config, bhg_version, :hcloud)
+      end
+    end
+  end
+end

--- a/test/fixtures/per-host-settings/hcloud-hypervisor.yaml
+++ b/test/fixtures/per-host-settings/hcloud-hypervisor.yaml
@@ -1,0 +1,35 @@
+---
+arguments_string: --hypervisor hcloud centos7-64m-centos9-64m-debian11-64a-ubuntu2204-64a{hypervisor=hcloud}
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    centos7-64-1:
+      image: centos-7
+      platform: el-7-x86_64
+      hypervisor: hcloud
+      roles:
+      - agent
+      - master
+    centos9-64-1:
+      image: centos-stream-9
+      platform: el-9-x86_64
+      hypervisor: hcloud
+      roles:
+      - agent
+      - master
+    debian11-64-1:
+      image: debian-11
+      platform: debian-11-amd64
+      hypervisor: hcloud
+      roles:
+      - agent
+    ubuntu2204-64-1:
+      image: ubuntu-22.04
+      platform: ubuntu-22.04-amd64
+      hypervisor: hcloud
+      roles:
+      - agent
+  CONFIG:
+    nfs_server: none
+    consoleport: 443
+expected_exception:


### PR DESCRIPTION
This adds support for the Hetzner Cloud platform. They currently support
(2022-12-07) the folling images:

```
bastelfreak@bastelfreak-nb ~ $ hcloud image list --type system
ID         TYPE     NAME              DESCRIPTION       IMAGE SIZE   DISK SIZE   CREATED                         DEPRECATED
3          system   centos-7          CentOS 7          -            5 GB        Mon Jan 15 12:34:45 CET 2018    -
168855     system   ubuntu-18.04      Ubuntu 18.04      -            5 GB        Wed May  2 13:02:30 CEST 2018   -
5924233    system   debian-10         Debian 10         -            5 GB        Mon Jul  8 08:35:48 CEST 2019   -
15512617   system   ubuntu-20.04      Ubuntu 20.04      -            5 GB        Thu Apr 23 19:55:14 CEST 2020   -
45557056   system   debian-11         Debian 11         -            5 GB        Mon Aug 16 13:12:01 CEST 2021   -
45778012   system   centos-stream-8   CentOS Stream 8   -            5 GB        Thu Aug  5 07:07:23 CEST 2021   -
45780948   system   rocky-8           Rocky Linux 8     -            5 GB        Thu Aug 19 08:30:23 CEST 2021   -
59752342   system   centos-stream-9   CentOS Stream 9   -            5 GB        Thu Jan 27 08:52:03 CET 2022    -
67794396   system   ubuntu-22.04      Ubuntu 22.04      -            5 GB        Thu Apr 21 15:32:38 CEST 2022   -
69726282   system   fedora-36         Fedora 36         -            5 GB        Wed May 11 07:50:00 CEST 2022   -
76766499   system   rocky-9           Rocky Linux 9     -            5 GB        Wed Jul 20 15:55:52 CEST 2022   -
bastelfreak@bastelfreak-nb ~ $
```