### PR TITLE
Drop fixup_node implementation

### DIFF
--- a/lib/beaker-hostgenerator/data.rb
+++ b/lib/beaker-hostgenerator/data.rb
@@ -1882,19 +1882,5 @@ module BeakerHostGenerator
       info = get_osinfo(bhg_version)[platform]
       {}.deeper_merge!(info[:general]).deeper_merge!(info[hypervisor])
     end
-
-    # Perform any adjustments or modifications necessary to the given node
-    # configuration map, taking things like platform and PE version into
-    # account.
-    #
-    # This is intended to capture any oddities that are necessary for a node
-    # to be used in a particular context.
-    def fixup_node(cfg)
-      # PE 2.8 doesn't exist for EL 4. We use 2.0 instead.
-      if cfg['platform'] =~ /el-4/ and pe_version =~ /2\.8/
-        cfg['pe_ver'] = "2.0.3"
-      end
-    end
-
   end
 end

--- a/lib/beaker-hostgenerator/hypervisor/vmpooler.rb
+++ b/lib/beaker-hostgenerator/hypervisor/vmpooler.rb
@@ -35,10 +35,6 @@ module BeakerHostGenerator
           base_config['template'] ||= "#{node_info['ostype'].sub('ubuntu', 'ubuntu-')}-#{arch}" if arch
         end
 
-        # Some vmpooler/vsphere platforms have special requirements.
-        # We munge the node host config here if that is necessary.
-        fixup_node base_config
-
         return base_config
       end
     end

--- a/lib/beaker-hostgenerator/util.rb
+++ b/lib/beaker-hostgenerator/util.rb
@@ -11,10 +11,6 @@ module BeakerHostGenerator
       BeakerHostGenerator::Data.pe_dir(version)
     end
 
-    def fixup_node(cfg)
-      BeakerHostGenerator::Data.fixup_node(cfg)
-    end
-
     def dump_hosts(hosts, path)
       vmpooler_hypervisor = BeakerHostGenerator::Hypervisor::Vmpooler.new
       config = {}


### PR DESCRIPTION
This was only used for EL 4 and a specific platform version, which are EOL now.