### PR TITLE
Drop nfs_server and consoleport defaults

### DIFF
--- a/lib/beaker-hostgenerator/data.rb
+++ b/lib/beaker-hostgenerator/data.rb
@@ -56,10 +56,7 @@ module BeakerHostGenerator
 
     BASE_CONFIG = {
       'HOSTS' => {},
-      'CONFIG' => {
-        'nfs_server' => 'none',
-        'consoleport' => 443,
-      }
+      'CONFIG' => {},
     }
 
     def base_host_config(options)

--- a/test/fixtures/generated/default/aix53-POWERa
+++ b/test/fixtures/generated/default/aix53-POWERa
@@ -9,7 +9,5 @@ expected_hash:
       roles:
       - agent
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/default/aix61-POWERu
+++ b/test/fixtures/generated/default/aix61-POWERu
@@ -10,7 +10,5 @@ expected_hash:
       - agent
       - ca
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/default/aix71-POWERl
+++ b/test/fixtures/generated/default/aix71-POWERl
@@ -10,7 +10,5 @@ expected_hash:
       - agent
       - classifier
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/default/aix72-POWERc
+++ b/test/fixtures/generated/default/aix72-POWERc
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - dashboard
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/default/almalinux8-64u
+++ b/test/fixtures/generated/default/almalinux8-64u
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - ca
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/default/amazon6-64d
+++ b/test/fixtures/generated/default/amazon6-64d
@@ -10,7 +10,5 @@ expected_hash:
       - agent
       - database
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/default/amazon7-64f
+++ b/test/fixtures/generated/default/amazon7-64f
@@ -10,7 +10,5 @@ expected_hash:
       - agent
       - frictionless
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/default/amazon7-ARM64m
+++ b/test/fixtures/generated/default/amazon7-ARM64m
@@ -10,7 +10,5 @@ expected_hash:
       - agent
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/default/archlinuxrolling-64a
+++ b/test/fixtures/generated/default/archlinuxrolling-64a
@@ -9,6 +9,4 @@ expected_hash:
       roles:
       - agent
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/

--- a/test/fixtures/generated/default/archlinuxrolling-64c
+++ b/test/fixtures/generated/default/archlinuxrolling-64c
@@ -10,6 +10,4 @@ expected_hash:
       - agent
       - dashboard
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/

--- a/test/fixtures/generated/default/archlinuxrolling-64l
+++ b/test/fixtures/generated/default/archlinuxrolling-64l
@@ -10,6 +10,4 @@ expected_hash:
       - agent
       - classifier
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/

--- a/test/fixtures/generated/default/archlinuxrolling-64u
+++ b/test/fixtures/generated/default/archlinuxrolling-64u
@@ -10,6 +10,4 @@ expected_hash:
       - agent
       - ca
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/

--- a/test/fixtures/generated/default/arista4-32d
+++ b/test/fixtures/generated/default/arista4-32d
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - database
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/default/centos4-32f
+++ b/test/fixtures/generated/default/centos4-32f
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - frictionless
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/default/centos4-64m
+++ b/test/fixtures/generated/default/centos4-64m
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/default/centos5-32aulcdfm
+++ b/test/fixtures/generated/default/centos5-32aulcdfm
@@ -16,7 +16,5 @@ expected_hash:
       - frictionless
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/default/centos5-64a
+++ b/test/fixtures/generated/default/centos5-64a
@@ -10,7 +10,5 @@ expected_hash:
       roles:
       - agent
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/default/centos6-32u
+++ b/test/fixtures/generated/default/centos6-32u
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - ca
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/default/centos6-64l
+++ b/test/fixtures/generated/default/centos6-64l
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - classifier
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/default/centos7-64c
+++ b/test/fixtures/generated/default/centos7-64c
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - dashboard
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/default/centos8-64aulcdfm
+++ b/test/fixtures/generated/default/centos8-64aulcdfm
@@ -16,7 +16,5 @@ expected_hash:
       - frictionless
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/default/cisco_ios_c2960-HWm
+++ b/test/fixtures/generated/default/cisco_ios_c2960-HWm
@@ -12,7 +12,5 @@ expected_hash:
       - agent
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/default/cisco_ios_c3560-HWaulcdfm
+++ b/test/fixtures/generated/default/cisco_ios_c3560-HWaulcdfm
@@ -17,7 +17,5 @@ expected_hash:
       - frictionless
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/default/cisco_ios_c3750-HWa
+++ b/test/fixtures/generated/default/cisco_ios_c3750-HWa
@@ -11,7 +11,5 @@ expected_hash:
       roles:
       - agent
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/default/cisco_ios_c4507r-HWu
+++ b/test/fixtures/generated/default/cisco_ios_c4507r-HWu
@@ -12,7 +12,5 @@ expected_hash:
       - agent
       - ca
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/default/cisco_ios_c4948-HWl
+++ b/test/fixtures/generated/default/cisco_ios_c4948-HWl
@@ -12,7 +12,5 @@ expected_hash:
       - agent
       - classifier
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/default/cisco_ios_c6503-HWc
+++ b/test/fixtures/generated/default/cisco_ios_c6503-HWc
@@ -12,7 +12,5 @@ expected_hash:
       - agent
       - dashboard
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/default/cisco_iosxe_c3650-HWd
+++ b/test/fixtures/generated/default/cisco_iosxe_c3650-HWd
@@ -12,7 +12,5 @@ expected_hash:
       - agent
       - database
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/default/cisco_iosxe_c4503-HWf
+++ b/test/fixtures/generated/default/cisco_iosxe_c4503-HWf
@@ -12,7 +12,5 @@ expected_hash:
       - agent
       - frictionless
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/default/cisco_n7k-HWc
+++ b/test/fixtures/generated/default/cisco_n7k-HWc
@@ -14,7 +14,5 @@ expected_hash:
       - agent
       - dashboard
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/default/cisco_n7k_vdc-HWd
+++ b/test/fixtures/generated/default/cisco_n7k_vdc-HWd
@@ -14,7 +14,5 @@ expected_hash:
       - agent
       - database
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/default/cisco_n9k-HWf
+++ b/test/fixtures/generated/default/cisco_n9k-HWf
@@ -14,7 +14,5 @@ expected_hash:
       - agent
       - frictionless
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/default/cisco_n9k-VMl
+++ b/test/fixtures/generated/default/cisco_n9k-VMl
@@ -15,7 +15,5 @@ expected_hash:
       - agent
       - classifier
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/default/cisco_xr_9k-VMm
+++ b/test/fixtures/generated/default/cisco_xr_9k-VMm
@@ -12,7 +12,5 @@ expected_hash:
       - agent
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/default/ciscon7k-64a
+++ b/test/fixtures/generated/default/ciscon7k-64a
@@ -13,7 +13,5 @@ expected_hash:
       roles:
       - agent
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/default/cisconx-64aulcdfm
+++ b/test/fixtures/generated/default/cisconx-64aulcdfm
@@ -20,7 +20,5 @@ expected_hash:
       - frictionless
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/default/cisconx-64d
+++ b/test/fixtures/generated/default/cisconx-64d
@@ -15,7 +15,5 @@ expected_hash:
       - agent
       - database
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/default/cisconxhw-64f
+++ b/test/fixtures/generated/default/cisconxhw-64f
@@ -14,7 +14,5 @@ expected_hash:
       - agent
       - frictionless
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/default/cisconxhw-64u
+++ b/test/fixtures/generated/default/cisconxhw-64u
@@ -14,7 +14,5 @@ expected_hash:
       - agent
       - ca
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/default/cumulus25-64m
+++ b/test/fixtures/generated/default/cumulus25-64m
@@ -12,7 +12,5 @@ expected_hash:
       - agent
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/default/debian10-32d
+++ b/test/fixtures/generated/default/debian10-32d
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - database
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/default/debian10-64c
+++ b/test/fixtures/generated/default/debian10-64c
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - dashboard
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/default/debian11-64m
+++ b/test/fixtures/generated/default/debian11-64m
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/default/debian6-32aulcdfm
+++ b/test/fixtures/generated/default/debian6-32aulcdfm
@@ -16,7 +16,5 @@ expected_hash:
       - frictionless
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/default/debian6-64a
+++ b/test/fixtures/generated/default/debian6-64a
@@ -10,7 +10,5 @@ expected_hash:
       roles:
       - agent
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/default/debian7-32u
+++ b/test/fixtures/generated/default/debian7-32u
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - ca
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/default/debian7-64l
+++ b/test/fixtures/generated/default/debian7-64l
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - classifier
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/default/debian8-32c
+++ b/test/fixtures/generated/default/debian8-32c
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - dashboard
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/default/debian8-64d
+++ b/test/fixtures/generated/default/debian8-64d
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - database
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/default/debian9-32f
+++ b/test/fixtures/generated/default/debian9-32f
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - frictionless
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/default/debian9-64m
+++ b/test/fixtures/generated/default/debian9-64m
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/default/fedora14-32aulcdfm
+++ b/test/fixtures/generated/default/fedora14-32aulcdfm
@@ -16,7 +16,5 @@ expected_hash:
       - frictionless
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/default/fedora19-32a
+++ b/test/fixtures/generated/default/fedora19-32a
@@ -10,7 +10,5 @@ expected_hash:
       roles:
       - agent
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/default/fedora19-64u
+++ b/test/fixtures/generated/default/fedora19-64u
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - ca
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/default/fedora20-32l
+++ b/test/fixtures/generated/default/fedora20-32l
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - classifier
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/default/fedora20-64c
+++ b/test/fixtures/generated/default/fedora20-64c
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - dashboard
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/default/fedora21-32d
+++ b/test/fixtures/generated/default/fedora21-32d
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - database
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/default/fedora21-64f
+++ b/test/fixtures/generated/default/fedora21-64f
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - frictionless
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/default/fedora22-32m
+++ b/test/fixtures/generated/default/fedora22-32m
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/default/fedora22-64aulcdfm
+++ b/test/fixtures/generated/default/fedora22-64aulcdfm
@@ -16,7 +16,5 @@ expected_hash:
       - frictionless
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/default/fedora23-32a
+++ b/test/fixtures/generated/default/fedora23-32a
@@ -10,7 +10,5 @@ expected_hash:
       roles:
       - agent
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/default/fedora23-64u
+++ b/test/fixtures/generated/default/fedora23-64u
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - ca
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/default/fedora24-32l
+++ b/test/fixtures/generated/default/fedora24-32l
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - classifier
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/default/fedora24-64c
+++ b/test/fixtures/generated/default/fedora24-64c
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - dashboard
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/default/fedora25-32d
+++ b/test/fixtures/generated/default/fedora25-32d
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - database
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/default/fedora25-64f
+++ b/test/fixtures/generated/default/fedora25-64f
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - frictionless
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/default/fedora26-64m
+++ b/test/fixtures/generated/default/fedora26-64m
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/default/fedora27-64l
+++ b/test/fixtures/generated/default/fedora27-64l
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - classifier
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/default/fedora28-64d
+++ b/test/fixtures/generated/default/fedora28-64d
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - database
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/default/fedora29-64d
+++ b/test/fixtures/generated/default/fedora29-64d
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - database
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/default/fedora30-64aulcdfm
+++ b/test/fixtures/generated/default/fedora30-64aulcdfm
@@ -16,7 +16,5 @@ expected_hash:
       - frictionless
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/default/fedora31-64aulcdfm
+++ b/test/fixtures/generated/default/fedora31-64aulcdfm
@@ -16,7 +16,5 @@ expected_hash:
       - frictionless
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/default/fedora32-64a
+++ b/test/fixtures/generated/default/fedora32-64a
@@ -10,7 +10,5 @@ expected_hash:
       roles:
       - agent
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/default/fedora32-64aulcdfm-vagrant
+++ b/test/fixtures/generated/default/fedora32-64aulcdfm-vagrant
@@ -16,7 +16,5 @@ expected_hash:
       - database
       - frictionless
       - master
-  CONFIG:
-    nfs_server: none
-    consoleport: 443
+  CONFIG: {}
 expected_exception:

--- a/test/fixtures/generated/default/fedora34-64c
+++ b/test/fixtures/generated/default/fedora34-64c
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - dashboard
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/default/fedora36-64f
+++ b/test/fixtures/generated/default/fedora36-64f
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - frictionless
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/default/huaweios6-POWERaulcdfm
+++ b/test/fixtures/generated/default/huaweios6-POWERaulcdfm
@@ -15,7 +15,5 @@ expected_hash:
       - frictionless
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/default/opensuse11-32a
+++ b/test/fixtures/generated/default/opensuse11-32a
@@ -10,7 +10,5 @@ expected_hash:
       roles:
       - agent
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/default/opensuse11-64u
+++ b/test/fixtures/generated/default/opensuse11-64u
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - ca
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/default/oracle5-32l
+++ b/test/fixtures/generated/default/oracle5-32l
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - classifier
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/default/oracle5-64c
+++ b/test/fixtures/generated/default/oracle5-64c
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - dashboard
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/default/oracle6-32d
+++ b/test/fixtures/generated/default/oracle6-32d
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - database
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/default/oracle6-64f
+++ b/test/fixtures/generated/default/oracle6-64f
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - frictionless
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/default/oracle7-64m
+++ b/test/fixtures/generated/default/oracle7-64m
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/default/osx1010-64a
+++ b/test/fixtures/generated/default/osx1010-64a
@@ -10,7 +10,5 @@ expected_hash:
       roles:
       - agent
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/default/osx1011-64u
+++ b/test/fixtures/generated/default/osx1011-64u
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - ca
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/default/osx1012-64l
+++ b/test/fixtures/generated/default/osx1012-64l
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - classifier
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/default/osx1013-64f
+++ b/test/fixtures/generated/default/osx1013-64f
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - frictionless
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/default/osx1014-64f
+++ b/test/fixtures/generated/default/osx1014-64f
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - frictionless
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/default/osx1015-64u
+++ b/test/fixtures/generated/default/osx1015-64u
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - ca
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/default/osx109-64aulcdfm
+++ b/test/fixtures/generated/default/osx109-64aulcdfm
@@ -16,7 +16,5 @@ expected_hash:
       - frictionless
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/default/osx11-64f
+++ b/test/fixtures/generated/default/osx11-64f
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - frictionless
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/default/osx11-ARM64u
+++ b/test/fixtures/generated/default/osx11-ARM64u
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - ca
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/default/osx12-64d
+++ b/test/fixtures/generated/default/osx12-64d
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - database
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/default/osx12-ARM64c
+++ b/test/fixtures/generated/default/osx12-ARM64c
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - dashboard
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/default/panos61-64f
+++ b/test/fixtures/generated/default/panos61-64f
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - frictionless
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/default/panos71-64m
+++ b/test/fixtures/generated/default/panos71-64m
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/default/panos81-64aulcdfm
+++ b/test/fixtures/generated/default/panos81-64aulcdfm
@@ -16,7 +16,5 @@ expected_hash:
       - frictionless
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/default/redhat4-32c
+++ b/test/fixtures/generated/default/redhat4-32c
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - dashboard
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/default/redhat4-64d
+++ b/test/fixtures/generated/default/redhat4-64d
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - database
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/default/redhat5-32f
+++ b/test/fixtures/generated/default/redhat5-32f
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - frictionless
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/default/redhat5-64m
+++ b/test/fixtures/generated/default/redhat5-64m
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/default/redhat6-32aulcdfm
+++ b/test/fixtures/generated/default/redhat6-32aulcdfm
@@ -16,7 +16,5 @@ expected_hash:
       - frictionless
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/default/redhat6-64a
+++ b/test/fixtures/generated/default/redhat6-64a
@@ -10,7 +10,5 @@ expected_hash:
       roles:
       - agent
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/default/redhat7-64l
+++ b/test/fixtures/generated/default/redhat7-64l
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - classifier
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/default/redhat7-AARCH64a
+++ b/test/fixtures/generated/default/redhat7-AARCH64a
@@ -10,7 +10,5 @@ expected_hash:
       roles:
       - agent
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/default/redhat7-AARCH64aulcdfm
+++ b/test/fixtures/generated/default/redhat7-AARCH64aulcdfm
@@ -16,7 +16,5 @@ expected_hash:
       - frictionless
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/default/redhat7-POWERc
+++ b/test/fixtures/generated/default/redhat7-POWERc
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - dashboard
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/default/redhat7-S390Xd
+++ b/test/fixtures/generated/default/redhat7-S390Xd
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - database
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/default/redhat8-64u
+++ b/test/fixtures/generated/default/redhat8-64u
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - ca
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/default/redhat8-AARCH64a
+++ b/test/fixtures/generated/default/redhat8-AARCH64a
@@ -10,7 +10,5 @@ expected_hash:
       roles:
       - agent
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/default/redhat9-64l
+++ b/test/fixtures/generated/default/redhat9-64l
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - classifier
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/default/redhatfips7-64aulcdfm
+++ b/test/fixtures/generated/default/redhatfips7-64aulcdfm
@@ -17,7 +17,5 @@ expected_hash:
       - frictionless
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/default/redhatfips8-64m
+++ b/test/fixtures/generated/default/redhatfips8-64m
@@ -12,7 +12,5 @@ expected_hash:
       - agent
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/default/rocky8-64l
+++ b/test/fixtures/generated/default/rocky8-64l
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - classifier
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/default/scientific5-32f
+++ b/test/fixtures/generated/default/scientific5-32f
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - frictionless
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/default/scientific5-64m
+++ b/test/fixtures/generated/default/scientific5-64m
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/default/scientific6-32aulcdfm
+++ b/test/fixtures/generated/default/scientific6-32aulcdfm
@@ -16,7 +16,5 @@ expected_hash:
       - frictionless
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/default/scientific6-64a
+++ b/test/fixtures/generated/default/scientific6-64a
@@ -10,7 +10,5 @@ expected_hash:
       roles:
       - agent
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/default/scientific7-64u
+++ b/test/fixtures/generated/default/scientific7-64u
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - ca
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/default/sles10-32l
+++ b/test/fixtures/generated/default/sles10-32l
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - classifier
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/default/sles10-64c
+++ b/test/fixtures/generated/default/sles10-64c
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - dashboard
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/default/sles11-32d
+++ b/test/fixtures/generated/default/sles11-32d
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - database
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/default/sles11-64f
+++ b/test/fixtures/generated/default/sles11-64f
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - frictionless
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/default/sles11-S390Xm
+++ b/test/fixtures/generated/default/sles11-S390Xm
@@ -10,7 +10,5 @@ expected_hash:
       - agent
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/default/sles12-64aulcdfm
+++ b/test/fixtures/generated/default/sles12-64aulcdfm
@@ -16,7 +16,5 @@ expected_hash:
       - frictionless
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/default/sles12-POWERu
+++ b/test/fixtures/generated/default/sles12-POWERu
@@ -10,7 +10,5 @@ expected_hash:
       - agent
       - ca
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/default/sles12-S390Xa
+++ b/test/fixtures/generated/default/sles12-S390Xa
@@ -9,7 +9,5 @@ expected_hash:
       roles:
       - agent
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/default/sles15-64l
+++ b/test/fixtures/generated/default/sles15-64l
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - classifier
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/default/solaris10-32l
+++ b/test/fixtures/generated/default/solaris10-32l
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - classifier
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/default/solaris10-64c
+++ b/test/fixtures/generated/default/solaris10-64c
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - dashboard
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/default/solaris10-SPARCd
+++ b/test/fixtures/generated/default/solaris10-SPARCd
@@ -10,7 +10,5 @@ expected_hash:
       - agent
       - database
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/default/solaris11-32f
+++ b/test/fixtures/generated/default/solaris11-32f
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - frictionless
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/default/solaris11-64m
+++ b/test/fixtures/generated/default/solaris11-64m
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/default/solaris11-SPARCaulcdfm
+++ b/test/fixtures/generated/default/solaris11-SPARCaulcdfm
@@ -15,7 +15,5 @@ expected_hash:
       - frictionless
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/default/solaris112-32a
+++ b/test/fixtures/generated/default/solaris112-32a
@@ -11,7 +11,5 @@ expected_hash:
       roles:
       - agent
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/default/solaris112-64u
+++ b/test/fixtures/generated/default/solaris112-64u
@@ -12,7 +12,5 @@ expected_hash:
       - agent
       - ca
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/default/ubuntu1404-32d
+++ b/test/fixtures/generated/default/ubuntu1404-32d
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - database
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/default/ubuntu1404-32m
+++ b/test/fixtures/generated/default/ubuntu1404-32m
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/default/ubuntu1404-64aulcdfm
+++ b/test/fixtures/generated/default/ubuntu1404-64aulcdfm
@@ -16,7 +16,5 @@ expected_hash:
       - frictionless
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/default/ubuntu1404-64f
+++ b/test/fixtures/generated/default/ubuntu1404-64f
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - frictionless
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/default/ubuntu1404-AARCH64aulcdfm
+++ b/test/fixtures/generated/default/ubuntu1404-AARCH64aulcdfm
@@ -15,7 +15,5 @@ expected_hash:
       - frictionless
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/default/ubuntu1404-POWERm
+++ b/test/fixtures/generated/default/ubuntu1404-POWERm
@@ -10,7 +10,5 @@ expected_hash:
       - agent
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/default/ubuntu1604-32a
+++ b/test/fixtures/generated/default/ubuntu1604-32a
@@ -10,7 +10,5 @@ expected_hash:
       roles:
       - agent
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/default/ubuntu1604-32d
+++ b/test/fixtures/generated/default/ubuntu1604-32d
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - database
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/default/ubuntu1604-64f
+++ b/test/fixtures/generated/default/ubuntu1604-64f
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - frictionless
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/default/ubuntu1604-64u
+++ b/test/fixtures/generated/default/ubuntu1604-64u
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - ca
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/default/ubuntu1604-AARCH64c
+++ b/test/fixtures/generated/default/ubuntu1604-AARCH64c
@@ -10,7 +10,5 @@ expected_hash:
       - agent
       - dashboard
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/default/ubuntu1604-POWERl
+++ b/test/fixtures/generated/default/ubuntu1604-POWERl
@@ -10,7 +10,5 @@ expected_hash:
       - agent
       - classifier
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/default/ubuntu1604-POWERm
+++ b/test/fixtures/generated/default/ubuntu1604-POWERm
@@ -10,7 +10,5 @@ expected_hash:
       - agent
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/default/ubuntu1804-64a
+++ b/test/fixtures/generated/default/ubuntu1804-64a
@@ -10,7 +10,5 @@ expected_hash:
       roles:
       - agent
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/default/ubuntu1804-64d
+++ b/test/fixtures/generated/default/ubuntu1804-64d
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - database
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/default/ubuntu1804-AARCH64m
+++ b/test/fixtures/generated/default/ubuntu1804-AARCH64m
@@ -10,7 +10,5 @@ expected_hash:
       - agent
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/default/ubuntu1804-POWERf
+++ b/test/fixtures/generated/default/ubuntu1804-POWERf
@@ -10,7 +10,5 @@ expected_hash:
       - agent
       - frictionless
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/default/ubuntu2004-64a
+++ b/test/fixtures/generated/default/ubuntu2004-64a
@@ -10,7 +10,5 @@ expected_hash:
       roles:
       - agent
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/default/ubuntu2004-64aulcdfm
+++ b/test/fixtures/generated/default/ubuntu2004-64aulcdfm
@@ -16,7 +16,5 @@ expected_hash:
       - frictionless
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/default/ubuntu2004-AARCH64c
+++ b/test/fixtures/generated/default/ubuntu2004-AARCH64c
@@ -10,7 +10,5 @@ expected_hash:
       - agent
       - dashboard
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/default/ubuntu2004-AARCH64u
+++ b/test/fixtures/generated/default/ubuntu2004-AARCH64u
@@ -10,7 +10,5 @@ expected_hash:
       - agent
       - ca
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/default/ubuntu2004-POWERa
+++ b/test/fixtures/generated/default/ubuntu2004-POWERa
@@ -9,7 +9,5 @@ expected_hash:
       roles:
       - agent
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/default/ubuntu2010-64l
+++ b/test/fixtures/generated/default/ubuntu2010-64l
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - classifier
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/default/ubuntu2104-64c
+++ b/test/fixtures/generated/default/ubuntu2104-64c
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - dashboard
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/default/ubuntu2110-64d
+++ b/test/fixtures/generated/default/ubuntu2110-64d
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - database
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/default/ubuntu2204-64l
+++ b/test/fixtures/generated/default/ubuntu2204-64l
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - classifier
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/default/ubuntu2204-AARCH64d
+++ b/test/fixtures/generated/default/ubuntu2204-AARCH64d
@@ -10,7 +10,5 @@ expected_hash:
       - agent
       - database
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/default/ubuntu2204-POWERc
+++ b/test/fixtures/generated/default/ubuntu2204-POWERc
@@ -10,7 +10,5 @@ expected_hash:
       - agent
       - dashboard
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/default/vro6-64u
+++ b/test/fixtures/generated/default/vro6-64u
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - ca
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/default/vro7-64l
+++ b/test/fixtures/generated/default/vro7-64l
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - classifier
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/default/vro71-64d
+++ b/test/fixtures/generated/default/vro71-64d
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - database
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/default/vro73-64l
+++ b/test/fixtures/generated/default/vro73-64l
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - classifier
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/default/vro74-64m
+++ b/test/fixtures/generated/default/vro74-64m
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/default/windows10_1511-64a
+++ b/test/fixtures/generated/default/windows10_1511-64a
@@ -12,7 +12,5 @@ expected_hash:
       roles:
       - agent
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/default/windows10_1607-64a
+++ b/test/fixtures/generated/default/windows10_1607-64a
@@ -12,7 +12,5 @@ expected_hash:
       roles:
       - agent
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/default/windows10_1809-64a
+++ b/test/fixtures/generated/default/windows10_1809-64a
@@ -12,7 +12,5 @@ expected_hash:
       roles:
       - agent
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/default/windows10ent-32u
+++ b/test/fixtures/generated/default/windows10ent-32u
@@ -13,7 +13,5 @@ expected_hash:
       - agent
       - ca
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/default/windows10ent-64l
+++ b/test/fixtures/generated/default/windows10ent-64l
@@ -13,7 +13,5 @@ expected_hash:
       - agent
       - classifier
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/default/windows10next-32a
+++ b/test/fixtures/generated/default/windows10next-32a
@@ -12,7 +12,5 @@ expected_hash:
       roles:
       - agent
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/default/windows10next-64a
+++ b/test/fixtures/generated/default/windows10next-64a
@@ -12,7 +12,5 @@ expected_hash:
       roles:
       - agent
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/default/windows10pro-64c
+++ b/test/fixtures/generated/default/windows10pro-64c
@@ -13,7 +13,5 @@ expected_hash:
       - agent
       - dashboard
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/default/windows11ent-64c
+++ b/test/fixtures/generated/default/windows11ent-64c
@@ -13,7 +13,5 @@ expected_hash:
       - agent
       - dashboard
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/default/windows2008-6432u
+++ b/test/fixtures/generated/default/windows2008-6432u
@@ -13,7 +13,5 @@ expected_hash:
       - agent
       - ca
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/default/windows2008-64a
+++ b/test/fixtures/generated/default/windows2008-64a
@@ -12,7 +12,5 @@ expected_hash:
       roles:
       - agent
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/default/windows2008r2-6432c
+++ b/test/fixtures/generated/default/windows2008r2-6432c
@@ -13,7 +13,5 @@ expected_hash:
       - agent
       - dashboard
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/default/windows2008r2-64l
+++ b/test/fixtures/generated/default/windows2008r2-64l
@@ -13,7 +13,5 @@ expected_hash:
       - agent
       - classifier
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/default/windows2012-6432f
+++ b/test/fixtures/generated/default/windows2012-6432f
@@ -13,7 +13,5 @@ expected_hash:
       - agent
       - frictionless
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/default/windows2012-64d
+++ b/test/fixtures/generated/default/windows2012-64d
@@ -13,7 +13,5 @@ expected_hash:
       - agent
       - database
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/default/windows2012r2-6432aulcdfm
+++ b/test/fixtures/generated/default/windows2012r2-6432aulcdfm
@@ -18,7 +18,5 @@ expected_hash:
       - frictionless
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/default/windows2012r2-64m
+++ b/test/fixtures/generated/default/windows2012r2-64m
@@ -13,7 +13,5 @@ expected_hash:
       - agent
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/default/windows2012r2_ja-6432l
+++ b/test/fixtures/generated/default/windows2012r2_ja-6432l
@@ -14,7 +14,5 @@ expected_hash:
       - agent
       - classifier
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/default/windows2012r2_ja-64u
+++ b/test/fixtures/generated/default/windows2012r2_ja-64u
@@ -14,7 +14,5 @@ expected_hash:
       - agent
       - ca
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/default/windows2012r2_wmf5-64a
+++ b/test/fixtures/generated/default/windows2012r2_wmf5-64a
@@ -12,7 +12,5 @@ expected_hash:
       roles:
       - agent
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/default/windows2016-6432d
+++ b/test/fixtures/generated/default/windows2016-6432d
@@ -13,7 +13,5 @@ expected_hash:
       - agent
       - database
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/default/windows2016-64c
+++ b/test/fixtures/generated/default/windows2016-64c
@@ -13,7 +13,5 @@ expected_hash:
       - agent
       - dashboard
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/default/windows2016_fr-6432f
+++ b/test/fixtures/generated/default/windows2016_fr-6432f
@@ -15,7 +15,5 @@ expected_hash:
       - agent
       - frictionless
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/default/windows2016_fr-64d
+++ b/test/fixtures/generated/default/windows2016_fr-64d
@@ -15,7 +15,5 @@ expected_hash:
       - agent
       - database
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/default/windows2019_fr-6432f
+++ b/test/fixtures/generated/default/windows2019_fr-6432f
@@ -15,7 +15,5 @@ expected_hash:
       - agent
       - frictionless
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/default/windows2019_fr-64c
+++ b/test/fixtures/generated/default/windows2019_fr-64c
@@ -15,7 +15,5 @@ expected_hash:
       - agent
       - dashboard
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/default/windows2019_ja-6432f
+++ b/test/fixtures/generated/default/windows2019_ja-6432f
@@ -14,7 +14,5 @@ expected_hash:
       - agent
       - frictionless
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/default/windows2019_ja-64c
+++ b/test/fixtures/generated/default/windows2019_ja-64c
@@ -14,7 +14,5 @@ expected_hash:
       - agent
       - dashboard
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/default/windows2022-64aulcdfm
+++ b/test/fixtures/generated/default/windows2022-64aulcdfm
@@ -18,7 +18,5 @@ expected_hash:
       - frictionless
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/default/windows7-64f
+++ b/test/fixtures/generated/default/windows7-64f
@@ -13,7 +13,5 @@ expected_hash:
       - agent
       - frictionless
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/default/windows81-64aulcdfm
+++ b/test/fixtures/generated/default/windows81-64aulcdfm
@@ -18,7 +18,5 @@ expected_hash:
       - frictionless
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/default/windows81-64m
+++ b/test/fixtures/generated/default/windows81-64m
@@ -13,7 +13,5 @@ expected_hash:
       - agent
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/default/windowsfips2012r2-6432f
+++ b/test/fixtures/generated/default/windowsfips2012r2-6432f
@@ -13,7 +13,5 @@ expected_hash:
       - agent
       - frictionless
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/default/windowsfips2012r2-64d
+++ b/test/fixtures/generated/default/windowsfips2012r2-64d
@@ -13,7 +13,5 @@ expected_hash:
       - agent
       - database
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/environment_variable_tests/pe_version_and_pe_family/centos6-32a
+++ b/test/fixtures/generated/environment_variable_tests/pe_version_and_pe_family/centos6-32a
@@ -18,7 +18,5 @@ expected_hash:
       roles:
       - agent
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/environment_variable_tests/pe_version_and_pe_family_no_upgrade/centos6-32a
+++ b/test/fixtures/generated/environment_variable_tests/pe_version_and_pe_family_no_upgrade/centos6-32a
@@ -14,7 +14,5 @@ expected_hash:
       roles:
       - agent
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/environment_variable_tests/pe_version_and_pe_family_upgrade_only/centos6-32a
+++ b/test/fixtures/generated/environment_variable_tests/pe_version_and_pe_family_upgrade_only/centos6-32a
@@ -14,7 +14,5 @@ expected_hash:
       roles:
       - agent
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/multiplatform/aix53-POWERa-windows10pro-64-aix53-POWERaulcdfm
+++ b/test/fixtures/generated/multiplatform/aix53-POWERa-windows10pro-64-aix53-POWERaulcdfm
@@ -28,7 +28,5 @@ expected_hash:
       - frictionless
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/aix61-POWERu-windows10ent-64-aix61-POWERm
+++ b/test/fixtures/generated/multiplatform/aix61-POWERu-windows10ent-64-aix61-POWERm
@@ -24,7 +24,5 @@ expected_hash:
       - agent
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/aix71-POWERl-windows10ent-32-aix71-POWERf
+++ b/test/fixtures/generated/multiplatform/aix71-POWERl-windows10ent-32-aix71-POWERf
@@ -24,7 +24,5 @@ expected_hash:
       - agent
       - frictionless
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/almalinux8-64u-solaris112-32-almalinux8-64m
+++ b/test/fixtures/generated/multiplatform/almalinux8-64u-solaris112-32-almalinux8-64m
@@ -25,7 +25,5 @@ expected_hash:
       - agent
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/multiplatform/amazon6-64d-windows81-64-amazon6-64c
+++ b/test/fixtures/generated/multiplatform/amazon6-64d-windows81-64-amazon6-64c
@@ -24,7 +24,5 @@ expected_hash:
       - agent
       - dashboard
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/amazon7-ARM64m-windows7-64-amazon7-ARM64u
+++ b/test/fixtures/generated/multiplatform/amazon7-ARM64m-windows7-64-amazon7-ARM64u
@@ -24,7 +24,5 @@ expected_hash:
       - agent
       - ca
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/arista4-32d-windows81-64-arista4-32c
+++ b/test/fixtures/generated/multiplatform/arista4-32d-windows81-64-arista4-32c
@@ -26,7 +26,5 @@ expected_hash:
       - agent
       - dashboard
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/centos4-64m-windows7-64-centos4-64u
+++ b/test/fixtures/generated/multiplatform/centos4-64m-windows7-64-centos4-64u
@@ -26,7 +26,5 @@ expected_hash:
       - agent
       - ca
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/centos5-32aulcdfm-windows2016-6432-centos5-32a
+++ b/test/fixtures/generated/multiplatform/centos5-32aulcdfm-windows2016-6432-centos5-32a
@@ -30,7 +30,5 @@ expected_hash:
       roles:
       - agent
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/centos5-64a-windows2016-64-centos5-64aulcdfm
+++ b/test/fixtures/generated/multiplatform/centos5-64a-windows2016-64-centos5-64aulcdfm
@@ -30,7 +30,5 @@ expected_hash:
       - frictionless
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/centos5-64c-windows2016_fr-6432-centos5-64d
+++ b/test/fixtures/generated/multiplatform/centos5-64c-windows2016_fr-6432-centos5-64d
@@ -28,7 +28,5 @@ expected_hash:
       - agent
       - database
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/centos6-32d-windows2016_fr-64-centos6-32c
+++ b/test/fixtures/generated/multiplatform/centos6-32d-windows2016_fr-64-centos6-32c
@@ -28,7 +28,5 @@ expected_hash:
       - agent
       - dashboard
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/centos6-32u-windows2012r2_ja-6432-centos6-32m
+++ b/test/fixtures/generated/multiplatform/centos6-32u-windows2012r2_ja-6432-centos6-32m
@@ -27,7 +27,5 @@ expected_hash:
       - agent
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/centos6-64l-windows2012r2_ja-64-centos6-64f
+++ b/test/fixtures/generated/multiplatform/centos6-64l-windows2012r2_ja-64-centos6-64f
@@ -27,7 +27,5 @@ expected_hash:
       - agent
       - frictionless
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/centos7-64c-windows2012r2_wmf5-64-centos7-64d
+++ b/test/fixtures/generated/multiplatform/centos7-64c-windows2012r2_wmf5-64-centos7-64d
@@ -26,7 +26,5 @@ expected_hash:
       - agent
       - database
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/centos8-64aulcdfm-windows2019_ja-64-centos8-64a
+++ b/test/fixtures/generated/multiplatform/centos8-64aulcdfm-windows2019_ja-64-centos8-64a
@@ -31,7 +31,5 @@ expected_hash:
       roles:
       - agent
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/cisco_ios_c2960-HWm-windows2016-6432-cisco_ios_c2960-HWu
+++ b/test/fixtures/generated/multiplatform/cisco_ios_c2960-HWm-windows2016-6432-cisco_ios_c2960-HWu
@@ -28,7 +28,5 @@ expected_hash:
       - agent
       - ca
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/cisco_ios_c3560-HWaulcdfm-windows2016-64-cisco_ios_c3560-HWa
+++ b/test/fixtures/generated/multiplatform/cisco_ios_c3560-HWaulcdfm-windows2016-64-cisco_ios_c3560-HWa
@@ -32,7 +32,5 @@ expected_hash:
       roles:
       - agent
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/cisco_ios_c3560-HWm-rocky8-64-cisco_ios_c3560-HWu
+++ b/test/fixtures/generated/multiplatform/cisco_ios_c3560-HWm-rocky8-64-cisco_ios_c3560-HWu
@@ -26,7 +26,5 @@ expected_hash:
       - agent
       - ca
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/multiplatform/cisco_ios_c3750-HWa-windows2012r2_core-6432-cisco_ios_c3750-HWaulcdfm
+++ b/test/fixtures/generated/multiplatform/cisco_ios_c3750-HWa-windows2012r2_core-6432-cisco_ios_c3750-HWaulcdfm
@@ -32,7 +32,5 @@ expected_hash:
       - frictionless
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/cisco_ios_c4507r-HWa-redhat9-64-cisco_ios_c4507r-HWaulcdfm
+++ b/test/fixtures/generated/multiplatform/cisco_ios_c4507r-HWa-redhat9-64-cisco_ios_c4507r-HWaulcdfm
@@ -30,7 +30,5 @@ expected_hash:
       - frictionless
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/multiplatform/cisco_ios_c4507r-HWu-windows2012r2_core-64-cisco_ios_c4507r-HWm
+++ b/test/fixtures/generated/multiplatform/cisco_ios_c4507r-HWu-windows2012r2_core-64-cisco_ios_c4507r-HWm
@@ -28,7 +28,5 @@ expected_hash:
       - agent
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/cisco_ios_c4948-HWa-redhatfips8-64-cisco_ios_c4948-HWaulcdfm
+++ b/test/fixtures/generated/multiplatform/cisco_ios_c4948-HWa-redhatfips8-64-cisco_ios_c4948-HWaulcdfm
@@ -31,7 +31,5 @@ expected_hash:
       - frictionless
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/multiplatform/cisco_ios_c4948-HWl-windows2012r2_fr-6432-cisco_ios_c4948-HWf
+++ b/test/fixtures/generated/multiplatform/cisco_ios_c4948-HWl-windows2012r2_fr-6432-cisco_ios_c4948-HWf
@@ -30,7 +30,5 @@ expected_hash:
       - agent
       - frictionless
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/cisco_ios_c6503-HWc-windows2012r2_fr-64-cisco_ios_c6503-HWd
+++ b/test/fixtures/generated/multiplatform/cisco_ios_c6503-HWc-windows2012r2_fr-64-cisco_ios_c6503-HWd
@@ -30,7 +30,5 @@ expected_hash:
       - agent
       - database
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/cisco_iosxe_c3650-HWd-windows2012r2_ja-6432-cisco_iosxe_c3650-HWc
+++ b/test/fixtures/generated/multiplatform/cisco_iosxe_c3650-HWd-windows2012r2_ja-6432-cisco_iosxe_c3650-HWc
@@ -29,7 +29,5 @@ expected_hash:
       - agent
       - dashboard
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/cisco_iosxe_c4503-HWf-windows2012r2_ja-64-cisco_iosxe_c4503-HWl
+++ b/test/fixtures/generated/multiplatform/cisco_iosxe_c4503-HWf-windows2012r2_ja-64-cisco_iosxe_c4503-HWl
@@ -29,7 +29,5 @@ expected_hash:
       - agent
       - classifier
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/cisco_n7k-HWc-windows2016_fr-64-cisco_n7k-HWd
+++ b/test/fixtures/generated/multiplatform/cisco_n7k-HWc-windows2016_fr-64-cisco_n7k-HWd
@@ -34,7 +34,5 @@ expected_hash:
       - agent
       - database
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/cisco_n7k_vdc-HWd-windows2016_core-6432-cisco_n7k_vdc-HWc
+++ b/test/fixtures/generated/multiplatform/cisco_n7k_vdc-HWd-windows2016_core-6432-cisco_n7k_vdc-HWc
@@ -32,7 +32,5 @@ expected_hash:
       - agent
       - dashboard
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/cisco_n9k-HWf-windows2016_core-64-cisco_n9k-HWl
+++ b/test/fixtures/generated/multiplatform/cisco_n9k-HWf-windows2016_core-64-cisco_n9k-HWl
@@ -32,7 +32,5 @@ expected_hash:
       - agent
       - classifier
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/cisco_n9k-VMl-windows2016_fr-6432-cisco_n9k-VMf
+++ b/test/fixtures/generated/multiplatform/cisco_n9k-VMl-windows2016_fr-6432-cisco_n9k-VMf
@@ -36,7 +36,5 @@ expected_hash:
       - agent
       - frictionless
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/cisco_xr_9k-VMm-windows2012r2_wmf5-64-cisco_xr_9k-VMu
+++ b/test/fixtures/generated/multiplatform/cisco_xr_9k-VMm-windows2012r2_wmf5-64-cisco_xr_9k-VMu
@@ -28,7 +28,5 @@ expected_hash:
       - agent
       - ca
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/ciscon7k-64a-windows2019-6432-ciscon7k-64aulcdfm
+++ b/test/fixtures/generated/multiplatform/ciscon7k-64a-windows2019-6432-ciscon7k-64aulcdfm
@@ -36,7 +36,5 @@ expected_hash:
       - frictionless
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/cisconx-64aulcdfm-windows2019_ja-64-cisconx-64a
+++ b/test/fixtures/generated/multiplatform/cisconx-64aulcdfm-windows2019_ja-64-cisconx-64a
@@ -39,7 +39,5 @@ expected_hash:
       roles:
       - agent
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/cisconx-64d-windows2012r2-6432-cisconx-64c
+++ b/test/fixtures/generated/multiplatform/cisconx-64d-windows2012r2-6432-cisconx-64c
@@ -34,7 +34,5 @@ expected_hash:
       - agent
       - dashboard
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/cisconxhw-64f-windows2012r2-64-cisconxhw-64l
+++ b/test/fixtures/generated/multiplatform/cisconxhw-64f-windows2012r2-64-cisconxhw-64l
@@ -32,7 +32,5 @@ expected_hash:
       - agent
       - classifier
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/multiplatform/cisconxhw-64u-windows2019-64-cisconxhw-64m
+++ b/test/fixtures/generated/multiplatform/cisconxhw-64u-windows2019-64-cisconxhw-64m
@@ -32,7 +32,5 @@ expected_hash:
       - agent
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/cumulus25-64m-windows2012-6432-cumulus25-64u
+++ b/test/fixtures/generated/multiplatform/cumulus25-64m-windows2012-6432-cumulus25-64u
@@ -28,7 +28,5 @@ expected_hash:
       - agent
       - ca
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/debian10-32d-windows2008-6432-debian10-32c
+++ b/test/fixtures/generated/multiplatform/debian10-32d-windows2008-6432-debian10-32c
@@ -26,7 +26,5 @@ expected_hash:
       - agent
       - dashboard
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/debian10-32l-osx12-64-debian10-32f
+++ b/test/fixtures/generated/multiplatform/debian10-32l-osx12-64-debian10-32f
@@ -24,7 +24,5 @@ expected_hash:
       - agent
       - frictionless
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/debian10-64c-windows2008r2-64-debian10-64d
+++ b/test/fixtures/generated/multiplatform/debian10-64c-windows2008r2-64-debian10-64d
@@ -26,7 +26,5 @@ expected_hash:
       - agent
       - database
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/debian11-64m-solaris11-64-debian11-64u
+++ b/test/fixtures/generated/multiplatform/debian11-64m-solaris11-64-debian11-64u
@@ -24,7 +24,5 @@ expected_hash:
       - agent
       - ca
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/debian6-32aulcdfm-windows2012-64-debian6-32a
+++ b/test/fixtures/generated/multiplatform/debian6-32aulcdfm-windows2012-64-debian6-32a
@@ -30,7 +30,5 @@ expected_hash:
       roles:
       - agent
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/debian6-64a-windows2008r2-6432-debian6-64aulcdfm
+++ b/test/fixtures/generated/multiplatform/debian6-64a-windows2008r2-6432-debian6-64aulcdfm
@@ -30,7 +30,5 @@ expected_hash:
       - frictionless
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/debian7-32u-windows2008r2-64-debian7-32m
+++ b/test/fixtures/generated/multiplatform/debian7-32u-windows2008r2-64-debian7-32m
@@ -26,7 +26,5 @@ expected_hash:
       - agent
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/debian7-64l-windows2008-6432-debian7-64f
+++ b/test/fixtures/generated/multiplatform/debian7-64l-windows2008-6432-debian7-64f
@@ -26,7 +26,5 @@ expected_hash:
       - agent
       - frictionless
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/debian8-32c-windows2008-64-debian8-32d
+++ b/test/fixtures/generated/multiplatform/debian8-32c-windows2008-64-debian8-32d
@@ -26,7 +26,5 @@ expected_hash:
       - agent
       - database
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/debian8-64a-windowsfips2012r2-6432-debian8-64aulcdfm
+++ b/test/fixtures/generated/multiplatform/debian8-64a-windowsfips2012r2-6432-debian8-64aulcdfm
@@ -30,7 +30,5 @@ expected_hash:
       - frictionless
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/debian8-64c-osx12-ARM64-debian8-64d
+++ b/test/fixtures/generated/multiplatform/debian8-64c-osx12-ARM64-debian8-64d
@@ -24,7 +24,5 @@ expected_hash:
       - agent
       - database
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/multiplatform/debian9-32u-windowsfips2012r2-64-debian9-32m
+++ b/test/fixtures/generated/multiplatform/debian9-32u-windowsfips2012r2-64-debian9-32m
@@ -26,7 +26,5 @@ expected_hash:
       - agent
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/debian9-64f-osx11-ARM64-debian9-64l
+++ b/test/fixtures/generated/multiplatform/debian9-64f-osx11-ARM64-debian9-64l
@@ -24,7 +24,5 @@ expected_hash:
       - agent
       - classifier
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/multiplatform/fedora19-64u-vro7-64-fedora19-64m
+++ b/test/fixtures/generated/multiplatform/fedora19-64u-vro7-64-fedora19-64m
@@ -24,7 +24,5 @@ expected_hash:
       - agent
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/fedora19-64u-vro73-64-fedora19-64m
+++ b/test/fixtures/generated/multiplatform/fedora19-64u-vro73-64-fedora19-64m
@@ -24,7 +24,5 @@ expected_hash:
       - agent
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/fedora19-64u-windows11ent-64-fedora19-64m
+++ b/test/fixtures/generated/multiplatform/fedora19-64u-windows11ent-64-fedora19-64m
@@ -26,7 +26,5 @@ expected_hash:
       - agent
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/multiplatform/fedora20-32l-vro6-64-fedora20-32f
+++ b/test/fixtures/generated/multiplatform/fedora20-32l-vro6-64-fedora20-32f
@@ -24,7 +24,5 @@ expected_hash:
       - agent
       - frictionless
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/fedora20-32m-ubuntu2004-64-fedora20-32u
+++ b/test/fixtures/generated/multiplatform/fedora20-32m-ubuntu2004-64-fedora20-32u
@@ -24,7 +24,5 @@ expected_hash:
       - agent
       - ca
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/fedora20-32m-ubuntu2004-AARCH64-fedora20-32u
+++ b/test/fixtures/generated/multiplatform/fedora20-32m-ubuntu2004-AARCH64-fedora20-32u
@@ -23,7 +23,5 @@ expected_hash:
       - agent
       - ca
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/fedora21-32aulcdfm-vro74-64-fedora21-32a
+++ b/test/fixtures/generated/multiplatform/fedora21-32aulcdfm-vro74-64-fedora21-32a
@@ -28,7 +28,5 @@ expected_hash:
       roles:
       - agent
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/fedora21-64f-ubuntu1604-POWER-fedora21-64l
+++ b/test/fixtures/generated/multiplatform/fedora21-64f-ubuntu1604-POWER-fedora21-64l
@@ -23,7 +23,5 @@ expected_hash:
       - agent
       - classifier
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/fedora22-32m-ubuntu1604-64-fedora22-32u
+++ b/test/fixtures/generated/multiplatform/fedora22-32m-ubuntu1604-64-fedora22-32u
@@ -24,7 +24,5 @@ expected_hash:
       - agent
       - ca
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/fedora22-32u-ubuntu1804-64-fedora22-32m
+++ b/test/fixtures/generated/multiplatform/fedora22-32u-ubuntu1804-64-fedora22-32m
@@ -24,7 +24,5 @@ expected_hash:
       - agent
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/fedora22-32u-vro71-64-fedora22-32m
+++ b/test/fixtures/generated/multiplatform/fedora22-32u-vro71-64-fedora22-32m
@@ -24,7 +24,5 @@ expected_hash:
       - agent
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/fedora22-64aulcdfm-ubuntu1604-32-fedora22-64a
+++ b/test/fixtures/generated/multiplatform/fedora22-64aulcdfm-ubuntu1604-32-fedora22-64a
@@ -28,7 +28,5 @@ expected_hash:
       roles:
       - agent
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/fedora24-32l-windows2022-64-fedora24-32f
+++ b/test/fixtures/generated/multiplatform/fedora24-32l-windows2022-64-fedora24-32f
@@ -26,7 +26,5 @@ expected_hash:
       - agent
       - frictionless
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/multiplatform/fedora25-32d-ubuntu1404-64-fedora25-32c
+++ b/test/fixtures/generated/multiplatform/fedora25-32d-ubuntu1404-64-fedora25-32c
@@ -24,7 +24,5 @@ expected_hash:
       - agent
       - dashboard
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/fedora25-64f-ubuntu1404-32-fedora25-64l
+++ b/test/fixtures/generated/multiplatform/fedora25-64f-ubuntu1404-32-fedora25-64l
@@ -24,7 +24,5 @@ expected_hash:
       - agent
       - classifier
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/fedora27-64l-ubuntu1404-64-fedora27-64f
+++ b/test/fixtures/generated/multiplatform/fedora27-64l-ubuntu1404-64-fedora27-64f
@@ -24,7 +24,5 @@ expected_hash:
       - agent
       - frictionless
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/fedora28-64d-ubuntu1404-64-fedora28-64c
+++ b/test/fixtures/generated/multiplatform/fedora28-64d-ubuntu1404-64-fedora28-64c
@@ -24,7 +24,5 @@ expected_hash:
       - agent
       - dashboard
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/fedora29-64d-ubuntu1604-POWER-fedora29-64c
+++ b/test/fixtures/generated/multiplatform/fedora29-64d-ubuntu1604-POWER-fedora29-64c
@@ -23,7 +23,5 @@ expected_hash:
       - agent
       - dashboard
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/fedora31-64aulcdfm-solaris114-64-fedora31-64a
+++ b/test/fixtures/generated/multiplatform/fedora31-64aulcdfm-solaris114-64-fedora31-64a
@@ -29,7 +29,5 @@ expected_hash:
       roles:
       - agent
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/fedora32-64a-solaris114-64-fedora32-64aulcdfm
+++ b/test/fixtures/generated/multiplatform/fedora32-64a-solaris114-64-fedora32-64aulcdfm
@@ -29,7 +29,5 @@ expected_hash:
       - frictionless
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/fedora34-64c-windows2012r2_fr-64-fedora34-64d
+++ b/test/fixtures/generated/multiplatform/fedora34-64c-windows2012r2_fr-64-fedora34-64d
@@ -28,7 +28,5 @@ expected_hash:
       - agent
       - database
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/multiplatform/fedora36-64f-windows2012r2_fr-6432-fedora36-64l
+++ b/test/fixtures/generated/multiplatform/fedora36-64f-windows2012r2_fr-6432-fedora36-64l
@@ -28,7 +28,5 @@ expected_hash:
       - agent
       - classifier
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/multiplatform/oracle5-32l-solaris112-64-oracle5-32f
+++ b/test/fixtures/generated/multiplatform/oracle5-32l-solaris112-64-oracle5-32f
@@ -25,7 +25,5 @@ expected_hash:
       - agent
       - frictionless
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/oracle5-64c-solaris112-32-oracle5-64d
+++ b/test/fixtures/generated/multiplatform/oracle5-64c-solaris112-32-oracle5-64d
@@ -25,7 +25,5 @@ expected_hash:
       - agent
       - database
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/oracle6-32d-solaris11-SPARC-oracle6-32c
+++ b/test/fixtures/generated/multiplatform/oracle6-32d-solaris11-SPARC-oracle6-32c
@@ -23,7 +23,5 @@ expected_hash:
       - agent
       - dashboard
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/oracle6-64f-solaris11-64-oracle6-64l
+++ b/test/fixtures/generated/multiplatform/oracle6-64f-solaris11-64-oracle6-64l
@@ -24,7 +24,5 @@ expected_hash:
       - agent
       - classifier
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/oracle7-64m-solaris11-32-oracle7-64u
+++ b/test/fixtures/generated/multiplatform/oracle7-64m-solaris11-32-oracle7-64u
@@ -24,7 +24,5 @@ expected_hash:
       - agent
       - ca
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/osx1010-64a-solaris10-64-osx1010-64aulcdfm
+++ b/test/fixtures/generated/multiplatform/osx1010-64a-solaris10-64-osx1010-64aulcdfm
@@ -28,7 +28,5 @@ expected_hash:
       - frictionless
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/osx1011-64u-solaris10-32-osx1011-64m
+++ b/test/fixtures/generated/multiplatform/osx1011-64u-solaris10-32-osx1011-64m
@@ -24,7 +24,5 @@ expected_hash:
       - agent
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/osx1012-64l-sles12-POWER-osx1012-64f
+++ b/test/fixtures/generated/multiplatform/osx1012-64l-sles12-POWER-osx1012-64f
@@ -23,7 +23,5 @@ expected_hash:
       - agent
       - frictionless
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/osx1013-64f-sles11-S390X-osx1013-64l
+++ b/test/fixtures/generated/multiplatform/osx1013-64f-sles11-S390X-osx1013-64l
@@ -23,7 +23,5 @@ expected_hash:
       - agent
       - classifier
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/osx1014-64f-solaris11-SPARC-osx1014-64l
+++ b/test/fixtures/generated/multiplatform/osx1014-64f-solaris11-SPARC-osx1014-64l
@@ -23,7 +23,5 @@ expected_hash:
       - agent
       - classifier
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/osx1015-64u-sles10-32-osx1015-64m
+++ b/test/fixtures/generated/multiplatform/osx1015-64u-sles10-32-osx1015-64m
@@ -24,7 +24,5 @@ expected_hash:
       - agent
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/osx109-64aulcdfm-solaris10-SPARC-osx109-64a
+++ b/test/fixtures/generated/multiplatform/osx109-64aulcdfm-solaris10-SPARC-osx109-64a
@@ -27,7 +27,5 @@ expected_hash:
       roles:
       - agent
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/osx11-64f-redhat7-POWER-osx11-64l
+++ b/test/fixtures/generated/multiplatform/osx11-64f-redhat7-POWER-osx11-64l
@@ -24,7 +24,5 @@ expected_hash:
       - agent
       - classifier
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/osx11-ARM64u-debian9-64-osx11-ARM64m
+++ b/test/fixtures/generated/multiplatform/osx11-ARM64u-debian9-64-osx11-ARM64m
@@ -24,7 +24,5 @@ expected_hash:
       - agent
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/multiplatform/osx12-64d-debian10-32-osx12-64c
+++ b/test/fixtures/generated/multiplatform/osx12-64d-debian10-32-osx12-64c
@@ -24,7 +24,5 @@ expected_hash:
       - agent
       - dashboard
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/osx12-ARM64c-debian8-64-osx12-ARM64d
+++ b/test/fixtures/generated/multiplatform/osx12-ARM64c-debian8-64-osx12-ARM64d
@@ -24,7 +24,5 @@ expected_hash:
       - agent
       - database
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/multiplatform/redhat4-32c-sles12-S390X-redhat4-32d
+++ b/test/fixtures/generated/multiplatform/redhat4-32c-sles12-S390X-redhat4-32d
@@ -23,7 +23,5 @@ expected_hash:
       - agent
       - database
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/redhat4-64d-sles12-64-redhat4-64c
+++ b/test/fixtures/generated/multiplatform/redhat4-64d-sles12-64-redhat4-64c
@@ -24,7 +24,5 @@ expected_hash:
       - agent
       - dashboard
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/redhat5-32f-sles11-S390X-redhat5-32l
+++ b/test/fixtures/generated/multiplatform/redhat5-32f-sles11-S390X-redhat5-32l
@@ -23,7 +23,5 @@ expected_hash:
       - agent
       - classifier
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/redhat5-64m-sles11-64-redhat5-64u
+++ b/test/fixtures/generated/multiplatform/redhat5-64m-sles11-64-redhat5-64u
@@ -24,7 +24,5 @@ expected_hash:
       - agent
       - ca
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/redhat6-32aulcdfm-sles11-32-redhat6-32a
+++ b/test/fixtures/generated/multiplatform/redhat6-32aulcdfm-sles11-32-redhat6-32a
@@ -28,7 +28,5 @@ expected_hash:
       roles:
       - agent
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/redhat6-64a-redhat8-AARCH64-redhat6-64aulcdfm
+++ b/test/fixtures/generated/multiplatform/redhat6-64a-redhat8-AARCH64-redhat6-64aulcdfm
@@ -28,7 +28,5 @@ expected_hash:
       - frictionless
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/multiplatform/redhat6-64a-sles10-64-redhat6-64aulcdfm
+++ b/test/fixtures/generated/multiplatform/redhat6-64a-sles10-64-redhat6-64aulcdfm
@@ -28,7 +28,5 @@ expected_hash:
       - frictionless
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/redhat6-64m-sles15-64-redhat6-64u
+++ b/test/fixtures/generated/multiplatform/redhat6-64m-sles15-64-redhat6-64u
@@ -24,7 +24,5 @@ expected_hash:
       - agent
       - ca
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/redhat7-64l-scientific7-64-redhat7-64f
+++ b/test/fixtures/generated/multiplatform/redhat7-64l-scientific7-64-redhat7-64f
@@ -24,7 +24,5 @@ expected_hash:
       - agent
       - frictionless
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/redhat7-AARCH64aulcdfm-redhat7-AARCH64-redhat7-AARCH64a
+++ b/test/fixtures/generated/multiplatform/redhat7-AARCH64aulcdfm-redhat7-AARCH64-redhat7-AARCH64a
@@ -28,7 +28,5 @@ expected_hash:
       roles:
       - agent
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/redhat7-POWERaulcdfm-osx11-64-redhat7-POWERa
+++ b/test/fixtures/generated/multiplatform/redhat7-POWERaulcdfm-osx11-64-redhat7-POWERa
@@ -28,7 +28,5 @@ expected_hash:
       roles:
       - agent
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/redhat7-POWERc-scientific6-64-redhat7-POWERd
+++ b/test/fixtures/generated/multiplatform/redhat7-POWERc-scientific6-64-redhat7-POWERd
@@ -24,7 +24,5 @@ expected_hash:
       - agent
       - database
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/redhat8-64u-sles11-32-redhat8-64m
+++ b/test/fixtures/generated/multiplatform/redhat8-64u-sles11-32-redhat8-64m
@@ -24,7 +24,5 @@ expected_hash:
       - agent
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/redhat8-AARCH64a-redhat6-64-redhat8-AARCH64aulcdfm
+++ b/test/fixtures/generated/multiplatform/redhat8-AARCH64a-redhat6-64-redhat8-AARCH64aulcdfm
@@ -28,7 +28,5 @@ expected_hash:
       - frictionless
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/multiplatform/redhat9-64l-cisco_ios_c4507r-HW-redhat9-64f
+++ b/test/fixtures/generated/multiplatform/redhat9-64l-cisco_ios_c4507r-HW-redhat9-64f
@@ -25,7 +25,5 @@ expected_hash:
       - agent
       - frictionless
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/multiplatform/redhatfips7-64aulcdfm-sles10-32-redhatfips7-64a
+++ b/test/fixtures/generated/multiplatform/redhatfips7-64aulcdfm-sles10-32-redhatfips7-64a
@@ -30,7 +30,5 @@ expected_hash:
       roles:
       - agent
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/redhatfips8-64m-cisco_ios_c4948-HW-redhatfips8-64u
+++ b/test/fixtures/generated/multiplatform/redhatfips8-64m-cisco_ios_c4948-HW-redhatfips8-64u
@@ -27,7 +27,5 @@ expected_hash:
       - agent
       - ca
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/multiplatform/rocky8-64l-cisco_ios_c3560-HW-rocky8-64f
+++ b/test/fixtures/generated/multiplatform/rocky8-64l-cisco_ios_c3560-HW-rocky8-64f
@@ -25,7 +25,5 @@ expected_hash:
       - agent
       - frictionless
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/multiplatform/scientific5-32f-scientific5-64-scientific5-32l
+++ b/test/fixtures/generated/multiplatform/scientific5-32f-scientific5-64-scientific5-32l
@@ -24,7 +24,5 @@ expected_hash:
       - agent
       - classifier
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/scientific5-64m-scientific5-32-scientific5-64u
+++ b/test/fixtures/generated/multiplatform/scientific5-64m-scientific5-32-scientific5-64u
@@ -24,7 +24,5 @@ expected_hash:
       - agent
       - ca
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/scientific6-64a-redhat7-POWER-scientific6-64aulcdfm
+++ b/test/fixtures/generated/multiplatform/scientific6-64a-redhat7-POWER-scientific6-64aulcdfm
@@ -28,7 +28,5 @@ expected_hash:
       - frictionless
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/scientific7-64u-redhat7-64-scientific7-64m
+++ b/test/fixtures/generated/multiplatform/scientific7-64u-redhat7-64-scientific7-64m
@@ -24,7 +24,5 @@ expected_hash:
       - agent
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/sles10-32a-redhatfips7-64-sles10-32aulcdfm
+++ b/test/fixtures/generated/multiplatform/sles10-32a-redhatfips7-64-sles10-32aulcdfm
@@ -29,7 +29,5 @@ expected_hash:
       - frictionless
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/sles10-32d-osx1015-64-sles10-32c
+++ b/test/fixtures/generated/multiplatform/sles10-32d-osx1015-64-sles10-32c
@@ -24,7 +24,5 @@ expected_hash:
       - agent
       - dashboard
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/sles10-64c-redhat6-64-sles10-64d
+++ b/test/fixtures/generated/multiplatform/sles10-64c-redhat6-64-sles10-64d
@@ -24,7 +24,5 @@ expected_hash:
       - agent
       - database
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/sles11-32d-redhat6-32-sles11-32c
+++ b/test/fixtures/generated/multiplatform/sles11-32d-redhat6-32-sles11-32c
@@ -24,7 +24,5 @@ expected_hash:
       - agent
       - dashboard
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/sles11-32u-redhat8-64-sles11-32m
+++ b/test/fixtures/generated/multiplatform/sles11-32u-redhat8-64-sles11-32m
@@ -24,7 +24,5 @@ expected_hash:
       - agent
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/sles11-64f-redhat5-64-sles11-64l
+++ b/test/fixtures/generated/multiplatform/sles11-64f-redhat5-64-sles11-64l
@@ -24,7 +24,5 @@ expected_hash:
       - agent
       - classifier
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/sles11-S390Xm-redhat5-32-sles11-S390Xu
+++ b/test/fixtures/generated/multiplatform/sles11-S390Xm-redhat5-32-sles11-S390Xu
@@ -22,7 +22,5 @@ expected_hash:
       - agent
       - ca
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/sles11-S390Xu-osx1013-64-sles11-S390Xm
+++ b/test/fixtures/generated/multiplatform/sles11-S390Xu-osx1013-64-sles11-S390Xm
@@ -22,7 +22,5 @@ expected_hash:
       - agent
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/sles12-64aulcdfm-redhat4-64-sles12-64a
+++ b/test/fixtures/generated/multiplatform/sles12-64aulcdfm-redhat4-64-sles12-64a
@@ -28,7 +28,5 @@ expected_hash:
       roles:
       - agent
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/sles12-POWERu-osx1012-64-sles12-POWERm
+++ b/test/fixtures/generated/multiplatform/sles12-POWERu-osx1012-64-sles12-POWERm
@@ -22,7 +22,5 @@ expected_hash:
       - agent
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/sles12-S390Xa-redhat4-32-sles12-S390Xaulcdfm
+++ b/test/fixtures/generated/multiplatform/sles12-S390Xa-redhat4-32-sles12-S390Xaulcdfm
@@ -26,7 +26,5 @@ expected_hash:
       - frictionless
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/sles15-64l-redhat6-64-sles15-64f
+++ b/test/fixtures/generated/multiplatform/sles15-64l-redhat6-64-sles15-64f
@@ -24,7 +24,5 @@ expected_hash:
       - agent
       - frictionless
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/solaris10-32l-osx1011-64-solaris10-32f
+++ b/test/fixtures/generated/multiplatform/solaris10-32l-osx1011-64-solaris10-32f
@@ -24,7 +24,5 @@ expected_hash:
       - agent
       - frictionless
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/solaris10-64c-osx1010-64-solaris10-64d
+++ b/test/fixtures/generated/multiplatform/solaris10-64c-osx1010-64-solaris10-64d
@@ -24,7 +24,5 @@ expected_hash:
       - agent
       - database
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/solaris10-SPARCd-osx109-64-solaris10-SPARCc
+++ b/test/fixtures/generated/multiplatform/solaris10-SPARCd-osx109-64-solaris10-SPARCc
@@ -22,7 +22,5 @@ expected_hash:
       - agent
       - dashboard
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/solaris11-32f-oracle7-64-solaris11-32l
+++ b/test/fixtures/generated/multiplatform/solaris11-32f-oracle7-64-solaris11-32l
@@ -24,7 +24,5 @@ expected_hash:
       - agent
       - classifier
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/solaris11-64a-debian11-64-solaris11-64aulcdfm
+++ b/test/fixtures/generated/multiplatform/solaris11-64a-debian11-64-solaris11-64aulcdfm
@@ -28,7 +28,5 @@ expected_hash:
       - frictionless
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/solaris11-64m-oracle6-64-solaris11-64u
+++ b/test/fixtures/generated/multiplatform/solaris11-64m-oracle6-64-solaris11-64u
@@ -24,7 +24,5 @@ expected_hash:
       - agent
       - ca
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/solaris11-SPARCaulcdfm-oracle6-32-solaris11-SPARCa
+++ b/test/fixtures/generated/multiplatform/solaris11-SPARCaulcdfm-oracle6-32-solaris11-SPARCa
@@ -26,7 +26,5 @@ expected_hash:
       roles:
       - agent
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/solaris112-32a-oracle5-64-solaris112-32aulcdfm
+++ b/test/fixtures/generated/multiplatform/solaris112-32a-oracle5-64-solaris112-32aulcdfm
@@ -30,7 +30,5 @@ expected_hash:
       - frictionless
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/solaris112-32aulcdfm-almalinux8-64-solaris112-32a
+++ b/test/fixtures/generated/multiplatform/solaris112-32aulcdfm-almalinux8-64-solaris112-32a
@@ -30,7 +30,5 @@ expected_hash:
       roles:
       - agent
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/multiplatform/solaris112-64u-oracle5-32-solaris112-64m
+++ b/test/fixtures/generated/multiplatform/solaris112-64u-oracle5-32-solaris112-64m
@@ -26,7 +26,5 @@ expected_hash:
       - agent
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/solaris114-64aulcdfm-fedora32-64-solaris114-64a
+++ b/test/fixtures/generated/multiplatform/solaris114-64aulcdfm-fedora32-64-solaris114-64a
@@ -30,7 +30,5 @@ expected_hash:
       roles:
       - agent
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/solaris114-64f-fedora31-64-solaris114-64l
+++ b/test/fixtures/generated/multiplatform/solaris114-64f-fedora31-64-solaris114-64l
@@ -26,7 +26,5 @@ expected_hash:
       - agent
       - classifier
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/ubuntu1404-32d-windows2012r2_ja-6432-ubuntu1404-32c
+++ b/test/fixtures/generated/multiplatform/ubuntu1404-32d-windows2012r2_ja-6432-ubuntu1404-32c
@@ -27,7 +27,5 @@ expected_hash:
       - agent
       - dashboard
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/multiplatform/ubuntu1404-32m-fedora25-64-ubuntu1404-32u
+++ b/test/fixtures/generated/multiplatform/ubuntu1404-32m-fedora25-64-ubuntu1404-32u
@@ -24,7 +24,5 @@ expected_hash:
       - agent
       - ca
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/ubuntu1404-64a-fedora28-64-ubuntu1404-64aulcdfm
+++ b/test/fixtures/generated/multiplatform/ubuntu1404-64a-fedora28-64-ubuntu1404-64aulcdfm
@@ -28,7 +28,5 @@ expected_hash:
       - frictionless
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/ubuntu1404-64aulcdfm-fedora25-32-ubuntu1404-64a
+++ b/test/fixtures/generated/multiplatform/ubuntu1404-64aulcdfm-fedora25-32-ubuntu1404-64a
@@ -28,7 +28,5 @@ expected_hash:
       roles:
       - agent
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/ubuntu1404-64f-windows2012r2_ja-64-ubuntu1404-64l
+++ b/test/fixtures/generated/multiplatform/ubuntu1404-64f-windows2012r2_ja-64-ubuntu1404-64l
@@ -27,7 +27,5 @@ expected_hash:
       - agent
       - classifier
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/multiplatform/ubuntu1404-64m-fedora27-64-ubuntu1404-64u
+++ b/test/fixtures/generated/multiplatform/ubuntu1404-64m-fedora27-64-ubuntu1404-64u
@@ -24,7 +24,5 @@ expected_hash:
       - agent
       - ca
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/ubuntu1404-AARCH64aulcdfm-windows2012r2-6432-ubuntu1404-AARCH64a
+++ b/test/fixtures/generated/multiplatform/ubuntu1404-AARCH64aulcdfm-windows2012r2-6432-ubuntu1404-AARCH64a
@@ -28,7 +28,5 @@ expected_hash:
       roles:
       - agent
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/multiplatform/ubuntu1404-POWERm-windows2012r2_wmf5-64-ubuntu1404-POWERu
+++ b/test/fixtures/generated/multiplatform/ubuntu1404-POWERm-windows2012r2_wmf5-64-ubuntu1404-POWERu
@@ -24,7 +24,5 @@ expected_hash:
       - agent
       - ca
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/multiplatform/ubuntu1604-32a-windowsfips2012r2-6432-ubuntu1604-32aulcdfm
+++ b/test/fixtures/generated/multiplatform/ubuntu1604-32a-windowsfips2012r2-6432-ubuntu1604-32aulcdfm
@@ -30,7 +30,5 @@ expected_hash:
       - frictionless
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/multiplatform/ubuntu1604-32d-fedora22-64-ubuntu1604-32c
+++ b/test/fixtures/generated/multiplatform/ubuntu1604-32d-fedora22-64-ubuntu1604-32c
@@ -24,7 +24,5 @@ expected_hash:
       - agent
       - dashboard
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/ubuntu1604-64f-fedora22-32-ubuntu1604-64l
+++ b/test/fixtures/generated/multiplatform/ubuntu1604-64f-fedora22-32-ubuntu1604-64l
@@ -24,7 +24,5 @@ expected_hash:
       - agent
       - classifier
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/ubuntu1604-64u-windowsfips2012r2-64-ubuntu1604-64m
+++ b/test/fixtures/generated/multiplatform/ubuntu1604-64u-windowsfips2012r2-64-ubuntu1604-64m
@@ -26,7 +26,5 @@ expected_hash:
       - agent
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/multiplatform/ubuntu1604-AARCH64c-windows2012-6432-ubuntu1604-AARCH64d
+++ b/test/fixtures/generated/multiplatform/ubuntu1604-AARCH64c-windows2012-6432-ubuntu1604-AARCH64d
@@ -24,7 +24,5 @@ expected_hash:
       - agent
       - database
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/multiplatform/ubuntu1604-POWERf-fedora29-64-ubuntu1604-POWERl
+++ b/test/fixtures/generated/multiplatform/ubuntu1604-POWERf-fedora29-64-ubuntu1604-POWERl
@@ -22,7 +22,5 @@ expected_hash:
       - agent
       - classifier
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/ubuntu1604-POWERl-windows2012r2-64-ubuntu1604-POWERf
+++ b/test/fixtures/generated/multiplatform/ubuntu1604-POWERl-windows2012r2-64-ubuntu1604-POWERf
@@ -24,7 +24,5 @@ expected_hash:
       - agent
       - frictionless
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/multiplatform/ubuntu1604-POWERm-fedora21-64-ubuntu1604-POWERu
+++ b/test/fixtures/generated/multiplatform/ubuntu1604-POWERm-fedora21-64-ubuntu1604-POWERu
@@ -22,7 +22,5 @@ expected_hash:
       - agent
       - ca
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/ubuntu1804-64a-fedora22-32-ubuntu1804-64aulcdfm
+++ b/test/fixtures/generated/multiplatform/ubuntu1804-64a-fedora22-32-ubuntu1804-64aulcdfm
@@ -28,7 +28,5 @@ expected_hash:
       - frictionless
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/ubuntu1804-64d-windows2012-64-ubuntu1804-64c
+++ b/test/fixtures/generated/multiplatform/ubuntu1804-64d-windows2012-64-ubuntu1804-64c
@@ -26,7 +26,5 @@ expected_hash:
       - agent
       - dashboard
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/multiplatform/ubuntu1804-AARCH64m-windows2008r2-64-ubuntu1804-AARCH64u
+++ b/test/fixtures/generated/multiplatform/ubuntu1804-AARCH64m-windows2008r2-64-ubuntu1804-AARCH64u
@@ -24,7 +24,5 @@ expected_hash:
       - agent
       - ca
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/multiplatform/ubuntu1804-POWERf-windows2008r2-6432-ubuntu1804-POWERl
+++ b/test/fixtures/generated/multiplatform/ubuntu1804-POWERf-windows2008r2-6432-ubuntu1804-POWERl
@@ -24,7 +24,5 @@ expected_hash:
       - agent
       - classifier
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/multiplatform/ubuntu2004-64a-fedora20-32-ubuntu2004-64aulcdfm
+++ b/test/fixtures/generated/multiplatform/ubuntu2004-64a-fedora20-32-ubuntu2004-64aulcdfm
@@ -28,7 +28,5 @@ expected_hash:
       - frictionless
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/ubuntu2004-64aulcdfm-windows2008-6432-ubuntu2004-64a
+++ b/test/fixtures/generated/multiplatform/ubuntu2004-64aulcdfm-windows2008-6432-ubuntu2004-64a
@@ -30,7 +30,5 @@ expected_hash:
       roles:
       - agent
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/multiplatform/ubuntu2004-AARCH64c-fedora20-32-ubuntu2004-AARCH64d
+++ b/test/fixtures/generated/multiplatform/ubuntu2004-AARCH64c-fedora20-32-ubuntu2004-AARCH64d
@@ -22,7 +22,5 @@ expected_hash:
       - agent
       - database
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/ubuntu2004-AARCH64u-vro74-64-ubuntu2004-AARCH64m
+++ b/test/fixtures/generated/multiplatform/ubuntu2004-AARCH64u-vro74-64-ubuntu2004-AARCH64m
@@ -22,7 +22,5 @@ expected_hash:
       - agent
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/multiplatform/ubuntu2004-POWERa-windows2008-64-ubuntu2004-POWERaulcdfm
+++ b/test/fixtures/generated/multiplatform/ubuntu2004-POWERa-windows2008-64-ubuntu2004-POWERaulcdfm
@@ -28,7 +28,5 @@ expected_hash:
       - frictionless
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/multiplatform/ubuntu2010-64l-vro73-64-ubuntu2010-64f
+++ b/test/fixtures/generated/multiplatform/ubuntu2010-64l-vro73-64-ubuntu2010-64f
@@ -24,7 +24,5 @@ expected_hash:
       - agent
       - frictionless
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/multiplatform/ubuntu2104-64c-vro71-64-ubuntu2104-64d
+++ b/test/fixtures/generated/multiplatform/ubuntu2104-64c-vro71-64-ubuntu2104-64d
@@ -24,7 +24,5 @@ expected_hash:
       - agent
       - database
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/multiplatform/ubuntu2110-64d-vro7-64-ubuntu2110-64c
+++ b/test/fixtures/generated/multiplatform/ubuntu2110-64d-vro7-64-ubuntu2110-64c
@@ -24,7 +24,5 @@ expected_hash:
       - agent
       - dashboard
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/multiplatform/ubuntu2204-64l-windows2008-64-ubuntu2204-64f
+++ b/test/fixtures/generated/multiplatform/ubuntu2204-64l-windows2008-64-ubuntu2204-64f
@@ -26,7 +26,5 @@ expected_hash:
       - agent
       - frictionless
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/ubuntu2204-AARCH64d-vro73-64-ubuntu2204-AARCH64c
+++ b/test/fixtures/generated/multiplatform/ubuntu2204-AARCH64d-vro73-64-ubuntu2204-AARCH64c
@@ -22,7 +22,5 @@ expected_hash:
       - agent
       - dashboard
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/ubuntu2204-POWERc-vro74-64-ubuntu2204-POWERd
+++ b/test/fixtures/generated/multiplatform/ubuntu2204-POWERc-vro74-64-ubuntu2204-POWERd
@@ -22,7 +22,5 @@ expected_hash:
       - agent
       - database
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/vro6-64u-fedora20-32-vro6-64m
+++ b/test/fixtures/generated/multiplatform/vro6-64u-fedora20-32-vro6-64m
@@ -24,7 +24,5 @@ expected_hash:
       - agent
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/vro7-64l-fedora19-64-vro7-64f
+++ b/test/fixtures/generated/multiplatform/vro7-64l-fedora19-64-vro7-64f
@@ -24,7 +24,5 @@ expected_hash:
       - agent
       - frictionless
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/vro7-64u-ubuntu2110-64-vro7-64m
+++ b/test/fixtures/generated/multiplatform/vro7-64u-ubuntu2110-64-vro7-64m
@@ -24,7 +24,5 @@ expected_hash:
       - agent
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/multiplatform/vro71-64d-fedora22-32-vro71-64c
+++ b/test/fixtures/generated/multiplatform/vro71-64d-fedora22-32-vro71-64c
@@ -24,7 +24,5 @@ expected_hash:
       - agent
       - dashboard
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/vro71-64l-ubuntu2104-64-vro71-64f
+++ b/test/fixtures/generated/multiplatform/vro71-64l-ubuntu2104-64-vro71-64f
@@ -24,7 +24,5 @@ expected_hash:
       - agent
       - frictionless
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/multiplatform/vro73-64c-ubuntu2010-64-vro73-64d
+++ b/test/fixtures/generated/multiplatform/vro73-64c-ubuntu2010-64-vro73-64d
@@ -24,7 +24,5 @@ expected_hash:
       - agent
       - database
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/multiplatform/vro73-64l-fedora19-64-vro73-64f
+++ b/test/fixtures/generated/multiplatform/vro73-64l-fedora19-64-vro73-64f
@@ -24,7 +24,5 @@ expected_hash:
       - agent
       - frictionless
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/vro74-64d-ubuntu2004-AARCH64-vro74-64c
+++ b/test/fixtures/generated/multiplatform/vro74-64d-ubuntu2004-AARCH64-vro74-64c
@@ -23,7 +23,5 @@ expected_hash:
       - agent
       - dashboard
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/multiplatform/vro74-64m-fedora21-32-vro74-64u
+++ b/test/fixtures/generated/multiplatform/vro74-64m-fedora21-32-vro74-64u
@@ -24,7 +24,5 @@ expected_hash:
       - agent
       - ca
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/windows10ent-32u-aix71-POWER-windows10ent-32m
+++ b/test/fixtures/generated/multiplatform/windows10ent-32u-aix71-POWER-windows10ent-32m
@@ -27,7 +27,5 @@ expected_hash:
       - agent
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/windows10ent-64l-aix61-POWER-windows10ent-64f
+++ b/test/fixtures/generated/multiplatform/windows10ent-64l-aix61-POWER-windows10ent-64f
@@ -27,7 +27,5 @@ expected_hash:
       - agent
       - frictionless
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/windows10pro-64c-aix53-POWER-windows10pro-64d
+++ b/test/fixtures/generated/multiplatform/windows10pro-64c-aix53-POWER-windows10pro-64d
@@ -27,7 +27,5 @@ expected_hash:
       - agent
       - database
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/windows11ent-64c-fedora19-64-windows11ent-64d
+++ b/test/fixtures/generated/multiplatform/windows11ent-64c-fedora19-64-windows11ent-64d
@@ -28,7 +28,5 @@ expected_hash:
       - agent
       - database
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/multiplatform/windows2008-6432l-debian10-32-windows2008-6432f
+++ b/test/fixtures/generated/multiplatform/windows2008-6432l-debian10-32-windows2008-6432f
@@ -28,7 +28,5 @@ expected_hash:
       - agent
       - frictionless
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/windows2008-6432m-ubuntu2004-64-windows2008-6432u
+++ b/test/fixtures/generated/multiplatform/windows2008-6432m-ubuntu2004-64-windows2008-6432u
@@ -28,7 +28,5 @@ expected_hash:
       - agent
       - ca
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/multiplatform/windows2008-6432u-debian7-64-windows2008-6432m
+++ b/test/fixtures/generated/multiplatform/windows2008-6432u-debian7-64-windows2008-6432m
@@ -28,7 +28,5 @@ expected_hash:
       - agent
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/windows2008-64a-debian8-32-windows2008-64aulcdfm
+++ b/test/fixtures/generated/multiplatform/windows2008-64a-debian8-32-windows2008-64aulcdfm
@@ -32,7 +32,5 @@ expected_hash:
       - frictionless
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/windows2008-64f-ubuntu2004-POWER-windows2008-64l
+++ b/test/fixtures/generated/multiplatform/windows2008-64f-ubuntu2004-POWER-windows2008-64l
@@ -27,7 +27,5 @@ expected_hash:
       - agent
       - classifier
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/multiplatform/windows2008r2-6432a-ubuntu1804-POWER-windows2008r2-6432aulcdfm
+++ b/test/fixtures/generated/multiplatform/windows2008r2-6432a-ubuntu1804-POWER-windows2008r2-6432aulcdfm
@@ -31,7 +31,5 @@ expected_hash:
       - frictionless
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/multiplatform/windows2008r2-6432c-debian6-64-windows2008r2-6432d
+++ b/test/fixtures/generated/multiplatform/windows2008r2-6432c-debian6-64-windows2008r2-6432d
@@ -28,7 +28,5 @@ expected_hash:
       - agent
       - database
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/windows2008r2-64aulcdfm-ubuntu1804-AARCH64-windows2008r2-64a
+++ b/test/fixtures/generated/multiplatform/windows2008r2-64aulcdfm-ubuntu1804-AARCH64-windows2008r2-64a
@@ -31,7 +31,5 @@ expected_hash:
       roles:
       - agent
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/multiplatform/windows2008r2-64c-debian10-64-windows2008r2-64d
+++ b/test/fixtures/generated/multiplatform/windows2008r2-64c-debian10-64-windows2008r2-64d
@@ -28,7 +28,5 @@ expected_hash:
       - agent
       - database
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/windows2008r2-64l-debian7-32-windows2008r2-64f
+++ b/test/fixtures/generated/multiplatform/windows2008r2-64l-debian7-32-windows2008r2-64f
@@ -28,7 +28,5 @@ expected_hash:
       - agent
       - frictionless
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/windows2012-6432f-cumulus25-64-windows2012-6432l
+++ b/test/fixtures/generated/multiplatform/windows2012-6432f-cumulus25-64-windows2012-6432l
@@ -29,7 +29,5 @@ expected_hash:
       - agent
       - classifier
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/windows2012-6432l-ubuntu1604-AARCH64-windows2012-6432f
+++ b/test/fixtures/generated/multiplatform/windows2012-6432l-ubuntu1604-AARCH64-windows2012-6432f
@@ -27,7 +27,5 @@ expected_hash:
       - agent
       - frictionless
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/multiplatform/windows2012-64d-debian6-32-windows2012-64c
+++ b/test/fixtures/generated/multiplatform/windows2012-64d-debian6-32-windows2012-64c
@@ -28,7 +28,5 @@ expected_hash:
       - agent
       - dashboard
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/windows2012-64u-ubuntu1804-64-windows2012-64m
+++ b/test/fixtures/generated/multiplatform/windows2012-64u-ubuntu1804-64-windows2012-64m
@@ -28,7 +28,5 @@ expected_hash:
       - agent
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/multiplatform/windows2012r2-6432aulcdfm-cisconx-64-windows2012r2-6432a
+++ b/test/fixtures/generated/multiplatform/windows2012r2-6432aulcdfm-cisconx-64-windows2012r2-6432a
@@ -36,7 +36,5 @@ expected_hash:
       roles:
       - agent
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/windows2012r2-6432m-ubuntu1404-AARCH64-windows2012r2-6432u
+++ b/test/fixtures/generated/multiplatform/windows2012r2-6432m-ubuntu1404-AARCH64-windows2012r2-6432u
@@ -27,7 +27,5 @@ expected_hash:
       - agent
       - ca
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/multiplatform/windows2012r2-64c-ubuntu1604-POWER-windows2012r2-64d
+++ b/test/fixtures/generated/multiplatform/windows2012r2-64c-ubuntu1604-POWER-windows2012r2-64d
@@ -27,7 +27,5 @@ expected_hash:
       - agent
       - database
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/multiplatform/windows2012r2_fr-6432aulcdfm-fedora36-64-windows2012r2_fr-6432a
+++ b/test/fixtures/generated/multiplatform/windows2012r2_fr-6432aulcdfm-fedora36-64-windows2012r2_fr-6432a
@@ -36,7 +36,5 @@ expected_hash:
       roles:
       - agent
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/multiplatform/windows2012r2_fr-64d-fedora34-64-windows2012r2_fr-64c
+++ b/test/fixtures/generated/multiplatform/windows2012r2_fr-64d-fedora34-64-windows2012r2_fr-64c
@@ -32,7 +32,5 @@ expected_hash:
       - agent
       - dashboard
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/multiplatform/windows2012r2_ja-6432l-centos6-32-windows2012r2_ja-6432f
+++ b/test/fixtures/generated/multiplatform/windows2012r2_ja-6432l-centos6-32-windows2012r2_ja-6432f
@@ -30,7 +30,5 @@ expected_hash:
       - agent
       - frictionless
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/windows2012r2_ja-6432u-ubuntu1404-32-windows2012r2_ja-6432m
+++ b/test/fixtures/generated/multiplatform/windows2012r2_ja-6432u-ubuntu1404-32-windows2012r2_ja-6432m
@@ -30,7 +30,5 @@ expected_hash:
       - agent
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/multiplatform/windows2012r2_ja-64a-ubuntu1404-64-windows2012r2_ja-64aulcdfm
+++ b/test/fixtures/generated/multiplatform/windows2012r2_ja-64a-ubuntu1404-64-windows2012r2_ja-64aulcdfm
@@ -34,7 +34,5 @@ expected_hash:
       - frictionless
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/multiplatform/windows2012r2_ja-64u-centos6-64-windows2012r2_ja-64m
+++ b/test/fixtures/generated/multiplatform/windows2012r2_ja-64u-centos6-64-windows2012r2_ja-64m
@@ -30,7 +30,5 @@ expected_hash:
       - agent
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/windows2012r2_wmf5-64a-centos7-64-windows2012r2_wmf5-64aulcdfm
+++ b/test/fixtures/generated/multiplatform/windows2012r2_wmf5-64a-centos7-64-windows2012r2_wmf5-64aulcdfm
@@ -32,7 +32,5 @@ expected_hash:
       - frictionless
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/windows2012r2_wmf5-64aulcdfm-ubuntu1404-POWER-windows2012r2_wmf5-64a
+++ b/test/fixtures/generated/multiplatform/windows2012r2_wmf5-64aulcdfm-ubuntu1404-POWER-windows2012r2_wmf5-64a
@@ -31,7 +31,5 @@ expected_hash:
       roles:
       - agent
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/multiplatform/windows2016-6432d-centos5-32-windows2016-6432c
+++ b/test/fixtures/generated/multiplatform/windows2016-6432d-centos5-32-windows2016-6432c
@@ -28,7 +28,5 @@ expected_hash:
       - agent
       - dashboard
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/windows2016-64c-centos5-64-windows2016-64d
+++ b/test/fixtures/generated/multiplatform/windows2016-64c-centos5-64-windows2016-64d
@@ -28,7 +28,5 @@ expected_hash:
       - agent
       - database
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/windows2016_fr-6432f-centos5-64-windows2016_fr-6432l
+++ b/test/fixtures/generated/multiplatform/windows2016_fr-6432f-centos5-64-windows2016_fr-6432l
@@ -32,7 +32,5 @@ expected_hash:
       - agent
       - classifier
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/windows2016_fr-64d-centos6-32-windows2016_fr-64c
+++ b/test/fixtures/generated/multiplatform/windows2016_fr-64d-centos6-32-windows2016_fr-64c
@@ -32,7 +32,5 @@ expected_hash:
       - agent
       - dashboard
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/windows2019_ja-64aulcdfm-centos8-64-windows2019_ja-64a
+++ b/test/fixtures/generated/multiplatform/windows2019_ja-64aulcdfm-centos8-64-windows2019_ja-64a
@@ -34,7 +34,5 @@ expected_hash:
       roles:
       - agent
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/windows2022-64aulcdfm-fedora24-32-windows2022-64a
+++ b/test/fixtures/generated/multiplatform/windows2022-64aulcdfm-fedora24-32-windows2022-64a
@@ -32,7 +32,5 @@ expected_hash:
       roles:
       - agent
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/multiplatform/windows7-64f-centos4-64-windows7-64l
+++ b/test/fixtures/generated/multiplatform/windows7-64f-centos4-64-windows7-64l
@@ -28,7 +28,5 @@ expected_hash:
       - agent
       - classifier
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/windows81-64aulcdfm-arista4-32-windows81-64a
+++ b/test/fixtures/generated/multiplatform/windows81-64aulcdfm-arista4-32-windows81-64a
@@ -32,7 +32,5 @@ expected_hash:
       roles:
       - agent
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/windowsfips2012r2-6432f-debian8-64-windowsfips2012r2-6432l
+++ b/test/fixtures/generated/multiplatform/windowsfips2012r2-6432f-debian8-64-windowsfips2012r2-6432l
@@ -28,7 +28,5 @@ expected_hash:
       - agent
       - classifier
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/windowsfips2012r2-6432f-ubuntu1604-32-windowsfips2012r2-6432l
+++ b/test/fixtures/generated/multiplatform/windowsfips2012r2-6432f-ubuntu1604-32-windowsfips2012r2-6432l
@@ -28,7 +28,5 @@ expected_hash:
       - agent
       - classifier
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/multiplatform/windowsfips2012r2-64d-debian9-32-windowsfips2012r2-64c
+++ b/test/fixtures/generated/multiplatform/windowsfips2012r2-64d-debian9-32-windowsfips2012r2-64c
@@ -28,7 +28,5 @@ expected_hash:
       - agent
       - dashboard
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/multiplatform/windowsfips2012r2-64d-ubuntu1604-64-windowsfips2012r2-64c
+++ b/test/fixtures/generated/multiplatform/windowsfips2012r2-64d-ubuntu1604-64-windowsfips2012r2-64c
@@ -28,7 +28,5 @@ expected_hash:
       - agent
       - dashboard
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/aix53-POWERa
+++ b/test/fixtures/generated/osinfo-version-0/aix53-POWERa
@@ -9,7 +9,5 @@ expected_hash:
       roles:
       - agent
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/osinfo-version-0/aix61-POWERu
+++ b/test/fixtures/generated/osinfo-version-0/aix61-POWERu
@@ -10,7 +10,5 @@ expected_hash:
       - agent
       - ca
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/osinfo-version-0/aix71-POWERl
+++ b/test/fixtures/generated/osinfo-version-0/aix71-POWERl
@@ -10,7 +10,5 @@ expected_hash:
       - agent
       - classifier
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/osinfo-version-0/aix72-POWERc
+++ b/test/fixtures/generated/osinfo-version-0/aix72-POWERc
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - dashboard
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/osinfo-version-0/almalinux8-64u
+++ b/test/fixtures/generated/osinfo-version-0/almalinux8-64u
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - ca
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/amazon6-64d
+++ b/test/fixtures/generated/osinfo-version-0/amazon6-64d
@@ -10,7 +10,5 @@ expected_hash:
       - agent
       - database
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/osinfo-version-0/amazon7-64f
+++ b/test/fixtures/generated/osinfo-version-0/amazon7-64f
@@ -10,7 +10,5 @@ expected_hash:
       - agent
       - frictionless
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/osinfo-version-0/amazon7-ARM64m
+++ b/test/fixtures/generated/osinfo-version-0/amazon7-ARM64m
@@ -10,7 +10,5 @@ expected_hash:
       - agent
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/osinfo-version-0/arista4-32d
+++ b/test/fixtures/generated/osinfo-version-0/arista4-32d
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - database
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/centos4-32f
+++ b/test/fixtures/generated/osinfo-version-0/centos4-32f
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - frictionless
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/centos4-64m
+++ b/test/fixtures/generated/osinfo-version-0/centos4-64m
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/centos5-32aulcdfm
+++ b/test/fixtures/generated/osinfo-version-0/centos5-32aulcdfm
@@ -16,7 +16,5 @@ expected_hash:
       - frictionless
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/centos5-64a
+++ b/test/fixtures/generated/osinfo-version-0/centos5-64a
@@ -10,7 +10,5 @@ expected_hash:
       roles:
       - agent
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/centos6-32u
+++ b/test/fixtures/generated/osinfo-version-0/centos6-32u
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - ca
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/centos6-64l
+++ b/test/fixtures/generated/osinfo-version-0/centos6-64l
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - classifier
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/centos7-64c
+++ b/test/fixtures/generated/osinfo-version-0/centos7-64c
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - dashboard
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/centos8-64aulcdfm
+++ b/test/fixtures/generated/osinfo-version-0/centos8-64aulcdfm
@@ -16,7 +16,5 @@ expected_hash:
       - frictionless
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/osinfo-version-0/cisco_ios_c2960-HWm
+++ b/test/fixtures/generated/osinfo-version-0/cisco_ios_c2960-HWm
@@ -12,7 +12,5 @@ expected_hash:
       - agent
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/cisco_ios_c3560-HWaulcdfm
+++ b/test/fixtures/generated/osinfo-version-0/cisco_ios_c3560-HWaulcdfm
@@ -17,7 +17,5 @@ expected_hash:
       - frictionless
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/cisco_ios_c3750-HWa
+++ b/test/fixtures/generated/osinfo-version-0/cisco_ios_c3750-HWa
@@ -11,7 +11,5 @@ expected_hash:
       roles:
       - agent
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/cisco_ios_c4507r-HWu
+++ b/test/fixtures/generated/osinfo-version-0/cisco_ios_c4507r-HWu
@@ -12,7 +12,5 @@ expected_hash:
       - agent
       - ca
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/cisco_ios_c4948-HWl
+++ b/test/fixtures/generated/osinfo-version-0/cisco_ios_c4948-HWl
@@ -12,7 +12,5 @@ expected_hash:
       - agent
       - classifier
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/cisco_ios_c6503-HWc
+++ b/test/fixtures/generated/osinfo-version-0/cisco_ios_c6503-HWc
@@ -12,7 +12,5 @@ expected_hash:
       - agent
       - dashboard
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/cisco_iosxe_c3650-HWd
+++ b/test/fixtures/generated/osinfo-version-0/cisco_iosxe_c3650-HWd
@@ -12,7 +12,5 @@ expected_hash:
       - agent
       - database
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/cisco_iosxe_c4503-HWf
+++ b/test/fixtures/generated/osinfo-version-0/cisco_iosxe_c4503-HWf
@@ -12,7 +12,5 @@ expected_hash:
       - agent
       - frictionless
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/cisco_n7k-HWc
+++ b/test/fixtures/generated/osinfo-version-0/cisco_n7k-HWc
@@ -14,7 +14,5 @@ expected_hash:
       - agent
       - dashboard
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/cisco_n7k_vdc-HWd
+++ b/test/fixtures/generated/osinfo-version-0/cisco_n7k_vdc-HWd
@@ -14,7 +14,5 @@ expected_hash:
       - agent
       - database
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/cisco_n9k-HWf
+++ b/test/fixtures/generated/osinfo-version-0/cisco_n9k-HWf
@@ -14,7 +14,5 @@ expected_hash:
       - agent
       - frictionless
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/cisco_n9k-VMl
+++ b/test/fixtures/generated/osinfo-version-0/cisco_n9k-VMl
@@ -15,7 +15,5 @@ expected_hash:
       - agent
       - classifier
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/cisco_xr_9k-VMm
+++ b/test/fixtures/generated/osinfo-version-0/cisco_xr_9k-VMm
@@ -12,7 +12,5 @@ expected_hash:
       - agent
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/ciscon7k-64a
+++ b/test/fixtures/generated/osinfo-version-0/ciscon7k-64a
@@ -13,7 +13,5 @@ expected_hash:
       roles:
       - agent
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/cisconx-64aulcdfm
+++ b/test/fixtures/generated/osinfo-version-0/cisconx-64aulcdfm
@@ -20,7 +20,5 @@ expected_hash:
       - frictionless
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/cisconx-64d
+++ b/test/fixtures/generated/osinfo-version-0/cisconx-64d
@@ -15,7 +15,5 @@ expected_hash:
       - agent
       - database
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/osinfo-version-0/cisconxhw-64f
+++ b/test/fixtures/generated/osinfo-version-0/cisconxhw-64f
@@ -14,7 +14,5 @@ expected_hash:
       - agent
       - frictionless
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/cisconxhw-64u
+++ b/test/fixtures/generated/osinfo-version-0/cisconxhw-64u
@@ -14,7 +14,5 @@ expected_hash:
       - agent
       - ca
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/cumulus25-64m
+++ b/test/fixtures/generated/osinfo-version-0/cumulus25-64m
@@ -12,7 +12,5 @@ expected_hash:
       - agent
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/debian10-32d
+++ b/test/fixtures/generated/osinfo-version-0/debian10-32d
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - database
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/osinfo-version-0/debian10-64c
+++ b/test/fixtures/generated/osinfo-version-0/debian10-64c
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - dashboard
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/osinfo-version-0/debian11-64m
+++ b/test/fixtures/generated/osinfo-version-0/debian11-64m
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/osinfo-version-0/debian6-32aulcdfm
+++ b/test/fixtures/generated/osinfo-version-0/debian6-32aulcdfm
@@ -16,7 +16,5 @@ expected_hash:
       - frictionless
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/debian6-64a
+++ b/test/fixtures/generated/osinfo-version-0/debian6-64a
@@ -10,7 +10,5 @@ expected_hash:
       roles:
       - agent
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/debian7-32u
+++ b/test/fixtures/generated/osinfo-version-0/debian7-32u
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - ca
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/debian7-64l
+++ b/test/fixtures/generated/osinfo-version-0/debian7-64l
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - classifier
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/debian8-32c
+++ b/test/fixtures/generated/osinfo-version-0/debian8-32c
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - dashboard
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/debian8-64d
+++ b/test/fixtures/generated/osinfo-version-0/debian8-64d
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - database
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/debian9-32f
+++ b/test/fixtures/generated/osinfo-version-0/debian9-32f
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - frictionless
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/debian9-64m
+++ b/test/fixtures/generated/osinfo-version-0/debian9-64m
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/fedora14-32aulcdfm
+++ b/test/fixtures/generated/osinfo-version-0/fedora14-32aulcdfm
@@ -16,7 +16,5 @@ expected_hash:
       - frictionless
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/osinfo-version-0/fedora19-32a
+++ b/test/fixtures/generated/osinfo-version-0/fedora19-32a
@@ -10,7 +10,5 @@ expected_hash:
       roles:
       - agent
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/fedora19-64u
+++ b/test/fixtures/generated/osinfo-version-0/fedora19-64u
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - ca
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/fedora20-32l
+++ b/test/fixtures/generated/osinfo-version-0/fedora20-32l
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - classifier
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/fedora20-64c
+++ b/test/fixtures/generated/osinfo-version-0/fedora20-64c
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - dashboard
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/fedora21-32d
+++ b/test/fixtures/generated/osinfo-version-0/fedora21-32d
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - database
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/fedora21-64f
+++ b/test/fixtures/generated/osinfo-version-0/fedora21-64f
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - frictionless
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/fedora22-32m
+++ b/test/fixtures/generated/osinfo-version-0/fedora22-32m
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/fedora22-64aulcdfm
+++ b/test/fixtures/generated/osinfo-version-0/fedora22-64aulcdfm
@@ -16,7 +16,5 @@ expected_hash:
       - frictionless
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/fedora23-32a
+++ b/test/fixtures/generated/osinfo-version-0/fedora23-32a
@@ -10,7 +10,5 @@ expected_hash:
       roles:
       - agent
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/fedora23-64u
+++ b/test/fixtures/generated/osinfo-version-0/fedora23-64u
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - ca
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/fedora24-32l
+++ b/test/fixtures/generated/osinfo-version-0/fedora24-32l
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - classifier
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/fedora24-64c
+++ b/test/fixtures/generated/osinfo-version-0/fedora24-64c
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - dashboard
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/fedora25-32d
+++ b/test/fixtures/generated/osinfo-version-0/fedora25-32d
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - database
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/fedora25-64f
+++ b/test/fixtures/generated/osinfo-version-0/fedora25-64f
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - frictionless
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/fedora26-64m
+++ b/test/fixtures/generated/osinfo-version-0/fedora26-64m
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/osinfo-version-0/fedora27-64l
+++ b/test/fixtures/generated/osinfo-version-0/fedora27-64l
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - classifier
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/osinfo-version-0/fedora28-64d
+++ b/test/fixtures/generated/osinfo-version-0/fedora28-64d
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - database
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/osinfo-version-0/fedora29-64d
+++ b/test/fixtures/generated/osinfo-version-0/fedora29-64d
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - database
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/osinfo-version-0/fedora30-64aulcdfm
+++ b/test/fixtures/generated/osinfo-version-0/fedora30-64aulcdfm
@@ -16,7 +16,5 @@ expected_hash:
       - frictionless
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/fedora31-64aulcdfm
+++ b/test/fixtures/generated/osinfo-version-0/fedora31-64aulcdfm
@@ -16,7 +16,5 @@ expected_hash:
       - frictionless
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/osinfo-version-0/fedora32-64a
+++ b/test/fixtures/generated/osinfo-version-0/fedora32-64a
@@ -10,7 +10,5 @@ expected_hash:
       roles:
       - agent
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/osinfo-version-0/fedora34-64c
+++ b/test/fixtures/generated/osinfo-version-0/fedora34-64c
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - dashboard
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/fedora36-64f
+++ b/test/fixtures/generated/osinfo-version-0/fedora36-64f
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - frictionless
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/huaweios6-POWERaulcdfm
+++ b/test/fixtures/generated/osinfo-version-0/huaweios6-POWERaulcdfm
@@ -15,7 +15,5 @@ expected_hash:
       - frictionless
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/osinfo-version-0/opensuse11-32a
+++ b/test/fixtures/generated/osinfo-version-0/opensuse11-32a
@@ -10,7 +10,5 @@ expected_hash:
       roles:
       - agent
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/opensuse11-64u
+++ b/test/fixtures/generated/osinfo-version-0/opensuse11-64u
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - ca
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/oracle5-32l
+++ b/test/fixtures/generated/osinfo-version-0/oracle5-32l
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - classifier
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/osinfo-version-0/oracle5-64c
+++ b/test/fixtures/generated/osinfo-version-0/oracle5-64c
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - dashboard
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/osinfo-version-0/oracle6-32d
+++ b/test/fixtures/generated/osinfo-version-0/oracle6-32d
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - database
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/osinfo-version-0/oracle6-64f
+++ b/test/fixtures/generated/osinfo-version-0/oracle6-64f
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - frictionless
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/osinfo-version-0/oracle7-64m
+++ b/test/fixtures/generated/osinfo-version-0/oracle7-64m
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/osinfo-version-0/osx1010-64a
+++ b/test/fixtures/generated/osinfo-version-0/osx1010-64a
@@ -10,7 +10,5 @@ expected_hash:
       roles:
       - agent
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/osinfo-version-0/osx1011-64u
+++ b/test/fixtures/generated/osinfo-version-0/osx1011-64u
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - ca
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/osinfo-version-0/osx1012-64l
+++ b/test/fixtures/generated/osinfo-version-0/osx1012-64l
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - classifier
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/osinfo-version-0/osx1013-64f
+++ b/test/fixtures/generated/osinfo-version-0/osx1013-64f
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - frictionless
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/osx1014-64f
+++ b/test/fixtures/generated/osinfo-version-0/osx1014-64f
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - frictionless
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/osinfo-version-0/osx1015-64u
+++ b/test/fixtures/generated/osinfo-version-0/osx1015-64u
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - ca
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/osx109-64aulcdfm
+++ b/test/fixtures/generated/osinfo-version-0/osx109-64aulcdfm
@@ -16,7 +16,5 @@ expected_hash:
       - frictionless
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/osinfo-version-0/osx11-64f
+++ b/test/fixtures/generated/osinfo-version-0/osx11-64f
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - frictionless
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/osinfo-version-0/osx11-ARM64u
+++ b/test/fixtures/generated/osinfo-version-0/osx11-ARM64u
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - ca
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/osx12-64d
+++ b/test/fixtures/generated/osinfo-version-0/osx12-64d
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - database
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/osinfo-version-0/osx12-ARM64c
+++ b/test/fixtures/generated/osinfo-version-0/osx12-ARM64c
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - dashboard
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/panos61-64f
+++ b/test/fixtures/generated/osinfo-version-0/panos61-64f
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - frictionless
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/panos71-64m
+++ b/test/fixtures/generated/osinfo-version-0/panos71-64m
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/panos81-64aulcdfm
+++ b/test/fixtures/generated/osinfo-version-0/panos81-64aulcdfm
@@ -16,7 +16,5 @@ expected_hash:
       - frictionless
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/redhat4-32c
+++ b/test/fixtures/generated/osinfo-version-0/redhat4-32c
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - dashboard
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/redhat4-64d
+++ b/test/fixtures/generated/osinfo-version-0/redhat4-64d
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - database
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/redhat5-32f
+++ b/test/fixtures/generated/osinfo-version-0/redhat5-32f
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - frictionless
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/redhat5-64m
+++ b/test/fixtures/generated/osinfo-version-0/redhat5-64m
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/redhat6-32aulcdfm
+++ b/test/fixtures/generated/osinfo-version-0/redhat6-32aulcdfm
@@ -16,7 +16,5 @@ expected_hash:
       - frictionless
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/redhat6-64a
+++ b/test/fixtures/generated/osinfo-version-0/redhat6-64a
@@ -10,7 +10,5 @@ expected_hash:
       roles:
       - agent
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/redhat7-64l
+++ b/test/fixtures/generated/osinfo-version-0/redhat7-64l
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - classifier
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/redhat7-AARCH64a
+++ b/test/fixtures/generated/osinfo-version-0/redhat7-AARCH64a
@@ -10,7 +10,5 @@ expected_hash:
       roles:
       - agent
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/osinfo-version-0/redhat7-AARCH64aulcdfm
+++ b/test/fixtures/generated/osinfo-version-0/redhat7-AARCH64aulcdfm
@@ -16,7 +16,5 @@ expected_hash:
       - frictionless
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/osinfo-version-0/redhat7-POWERc
+++ b/test/fixtures/generated/osinfo-version-0/redhat7-POWERc
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - dashboard
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/redhat7-S390Xd
+++ b/test/fixtures/generated/osinfo-version-0/redhat7-S390Xd
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - database
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/redhat8-64u
+++ b/test/fixtures/generated/osinfo-version-0/redhat8-64u
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - ca
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/osinfo-version-0/redhat8-AARCH64a
+++ b/test/fixtures/generated/osinfo-version-0/redhat8-AARCH64a
@@ -10,7 +10,5 @@ expected_hash:
       roles:
       - agent
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/redhat9-64l
+++ b/test/fixtures/generated/osinfo-version-0/redhat9-64l
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - classifier
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/redhatfips7-64aulcdfm
+++ b/test/fixtures/generated/osinfo-version-0/redhatfips7-64aulcdfm
@@ -17,7 +17,5 @@ expected_hash:
       - frictionless
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/osinfo-version-0/redhatfips8-64m
+++ b/test/fixtures/generated/osinfo-version-0/redhatfips8-64m
@@ -12,7 +12,5 @@ expected_hash:
       - agent
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/rocky8-64l
+++ b/test/fixtures/generated/osinfo-version-0/rocky8-64l
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - classifier
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/scientific5-32f
+++ b/test/fixtures/generated/osinfo-version-0/scientific5-32f
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - frictionless
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/scientific5-64m
+++ b/test/fixtures/generated/osinfo-version-0/scientific5-64m
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/scientific6-32aulcdfm
+++ b/test/fixtures/generated/osinfo-version-0/scientific6-32aulcdfm
@@ -16,7 +16,5 @@ expected_hash:
       - frictionless
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/scientific6-64a
+++ b/test/fixtures/generated/osinfo-version-0/scientific6-64a
@@ -10,7 +10,5 @@ expected_hash:
       roles:
       - agent
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/scientific7-64u
+++ b/test/fixtures/generated/osinfo-version-0/scientific7-64u
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - ca
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/sles10-32l
+++ b/test/fixtures/generated/osinfo-version-0/sles10-32l
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - classifier
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/sles10-64c
+++ b/test/fixtures/generated/osinfo-version-0/sles10-64c
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - dashboard
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/sles11-32d
+++ b/test/fixtures/generated/osinfo-version-0/sles11-32d
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - database
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/sles11-64f
+++ b/test/fixtures/generated/osinfo-version-0/sles11-64f
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - frictionless
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/sles11-S390Xm
+++ b/test/fixtures/generated/osinfo-version-0/sles11-S390Xm
@@ -10,7 +10,5 @@ expected_hash:
       - agent
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/sles12-64aulcdfm
+++ b/test/fixtures/generated/osinfo-version-0/sles12-64aulcdfm
@@ -16,7 +16,5 @@ expected_hash:
       - frictionless
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/sles12-POWERu
+++ b/test/fixtures/generated/osinfo-version-0/sles12-POWERu
@@ -10,7 +10,5 @@ expected_hash:
       - agent
       - ca
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/sles12-S390Xa
+++ b/test/fixtures/generated/osinfo-version-0/sles12-S390Xa
@@ -9,7 +9,5 @@ expected_hash:
       roles:
       - agent
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/sles15-64l
+++ b/test/fixtures/generated/osinfo-version-0/sles15-64l
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - classifier
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/solaris10-32l
+++ b/test/fixtures/generated/osinfo-version-0/solaris10-32l
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - classifier
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/osinfo-version-0/solaris10-64c
+++ b/test/fixtures/generated/osinfo-version-0/solaris10-64c
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - dashboard
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/osinfo-version-0/solaris10-SPARCd
+++ b/test/fixtures/generated/osinfo-version-0/solaris10-SPARCd
@@ -10,7 +10,5 @@ expected_hash:
       - agent
       - database
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/osinfo-version-0/solaris11-32f
+++ b/test/fixtures/generated/osinfo-version-0/solaris11-32f
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - frictionless
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/osinfo-version-0/solaris11-64m
+++ b/test/fixtures/generated/osinfo-version-0/solaris11-64m
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/osinfo-version-0/solaris11-SPARCaulcdfm
+++ b/test/fixtures/generated/osinfo-version-0/solaris11-SPARCaulcdfm
@@ -15,7 +15,5 @@ expected_hash:
       - frictionless
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/osinfo-version-0/solaris112-32a
+++ b/test/fixtures/generated/osinfo-version-0/solaris112-32a
@@ -11,7 +11,5 @@ expected_hash:
       roles:
       - agent
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/osinfo-version-0/solaris112-64u
+++ b/test/fixtures/generated/osinfo-version-0/solaris112-64u
@@ -12,7 +12,5 @@ expected_hash:
       - agent
       - ca
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/osinfo-version-0/ubuntu1404-32d
+++ b/test/fixtures/generated/osinfo-version-0/ubuntu1404-32d
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - database
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/ubuntu1404-32m
+++ b/test/fixtures/generated/osinfo-version-0/ubuntu1404-32m
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/osinfo-version-0/ubuntu1404-64aulcdfm
+++ b/test/fixtures/generated/osinfo-version-0/ubuntu1404-64aulcdfm
@@ -16,7 +16,5 @@ expected_hash:
       - frictionless
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/osinfo-version-0/ubuntu1404-64f
+++ b/test/fixtures/generated/osinfo-version-0/ubuntu1404-64f
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - frictionless
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/ubuntu1404-AARCH64aulcdfm
+++ b/test/fixtures/generated/osinfo-version-0/ubuntu1404-AARCH64aulcdfm
@@ -15,7 +15,5 @@ expected_hash:
       - frictionless
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/ubuntu1404-POWERm
+++ b/test/fixtures/generated/osinfo-version-0/ubuntu1404-POWERm
@@ -10,7 +10,5 @@ expected_hash:
       - agent
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/ubuntu1604-32a
+++ b/test/fixtures/generated/osinfo-version-0/ubuntu1604-32a
@@ -10,7 +10,5 @@ expected_hash:
       roles:
       - agent
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/ubuntu1604-32d
+++ b/test/fixtures/generated/osinfo-version-0/ubuntu1604-32d
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - database
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/osinfo-version-0/ubuntu1604-64f
+++ b/test/fixtures/generated/osinfo-version-0/ubuntu1604-64f
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - frictionless
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/osinfo-version-0/ubuntu1604-64u
+++ b/test/fixtures/generated/osinfo-version-0/ubuntu1604-64u
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - ca
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/ubuntu1604-AARCH64c
+++ b/test/fixtures/generated/osinfo-version-0/ubuntu1604-AARCH64c
@@ -10,7 +10,5 @@ expected_hash:
       - agent
       - dashboard
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/ubuntu1604-POWERl
+++ b/test/fixtures/generated/osinfo-version-0/ubuntu1604-POWERl
@@ -10,7 +10,5 @@ expected_hash:
       - agent
       - classifier
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/ubuntu1604-POWERm
+++ b/test/fixtures/generated/osinfo-version-0/ubuntu1604-POWERm
@@ -10,7 +10,5 @@ expected_hash:
       - agent
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/osinfo-version-0/ubuntu1804-64a
+++ b/test/fixtures/generated/osinfo-version-0/ubuntu1804-64a
@@ -10,7 +10,5 @@ expected_hash:
       roles:
       - agent
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/osinfo-version-0/ubuntu1804-64d
+++ b/test/fixtures/generated/osinfo-version-0/ubuntu1804-64d
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - database
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/ubuntu1804-AARCH64m
+++ b/test/fixtures/generated/osinfo-version-0/ubuntu1804-AARCH64m
@@ -10,7 +10,5 @@ expected_hash:
       - agent
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/ubuntu1804-POWERf
+++ b/test/fixtures/generated/osinfo-version-0/ubuntu1804-POWERf
@@ -10,7 +10,5 @@ expected_hash:
       - agent
       - frictionless
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/ubuntu2004-64a
+++ b/test/fixtures/generated/osinfo-version-0/ubuntu2004-64a
@@ -10,7 +10,5 @@ expected_hash:
       roles:
       - agent
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/osinfo-version-0/ubuntu2004-64aulcdfm
+++ b/test/fixtures/generated/osinfo-version-0/ubuntu2004-64aulcdfm
@@ -16,7 +16,5 @@ expected_hash:
       - frictionless
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/ubuntu2004-AARCH64c
+++ b/test/fixtures/generated/osinfo-version-0/ubuntu2004-AARCH64c
@@ -10,7 +10,5 @@ expected_hash:
       - agent
       - dashboard
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/osinfo-version-0/ubuntu2004-AARCH64u
+++ b/test/fixtures/generated/osinfo-version-0/ubuntu2004-AARCH64u
@@ -10,7 +10,5 @@ expected_hash:
       - agent
       - ca
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/ubuntu2004-POWERa
+++ b/test/fixtures/generated/osinfo-version-0/ubuntu2004-POWERa
@@ -9,7 +9,5 @@ expected_hash:
       roles:
       - agent
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/ubuntu2010-64l
+++ b/test/fixtures/generated/osinfo-version-0/ubuntu2010-64l
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - classifier
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/ubuntu2104-64c
+++ b/test/fixtures/generated/osinfo-version-0/ubuntu2104-64c
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - dashboard
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/ubuntu2110-64d
+++ b/test/fixtures/generated/osinfo-version-0/ubuntu2110-64d
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - database
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/ubuntu2204-64l
+++ b/test/fixtures/generated/osinfo-version-0/ubuntu2204-64l
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - classifier
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/osinfo-version-0/ubuntu2204-AARCH64d
+++ b/test/fixtures/generated/osinfo-version-0/ubuntu2204-AARCH64d
@@ -10,7 +10,5 @@ expected_hash:
       - agent
       - database
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/osinfo-version-0/ubuntu2204-POWERc
+++ b/test/fixtures/generated/osinfo-version-0/ubuntu2204-POWERc
@@ -10,7 +10,5 @@ expected_hash:
       - agent
       - dashboard
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/osinfo-version-0/vro6-64u
+++ b/test/fixtures/generated/osinfo-version-0/vro6-64u
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - ca
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/vro7-64l
+++ b/test/fixtures/generated/osinfo-version-0/vro7-64l
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - classifier
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/vro71-64d
+++ b/test/fixtures/generated/osinfo-version-0/vro71-64d
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - database
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/osinfo-version-0/vro73-64l
+++ b/test/fixtures/generated/osinfo-version-0/vro73-64l
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - classifier
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/osinfo-version-0/vro74-64m
+++ b/test/fixtures/generated/osinfo-version-0/vro74-64m
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/osinfo-version-0/windows10ent-32u
+++ b/test/fixtures/generated/osinfo-version-0/windows10ent-32u
@@ -13,7 +13,5 @@ expected_hash:
       - agent
       - ca
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/windows10ent-64l
+++ b/test/fixtures/generated/osinfo-version-0/windows10ent-64l
@@ -13,7 +13,5 @@ expected_hash:
       - agent
       - classifier
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/windows10pro-64c
+++ b/test/fixtures/generated/osinfo-version-0/windows10pro-64c
@@ -13,7 +13,5 @@ expected_hash:
       - agent
       - dashboard
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/windows11ent-64c
+++ b/test/fixtures/generated/osinfo-version-0/windows11ent-64c
@@ -13,7 +13,5 @@ expected_hash:
       - agent
       - dashboard
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/windows2008-6432u
+++ b/test/fixtures/generated/osinfo-version-0/windows2008-6432u
@@ -13,7 +13,5 @@ expected_hash:
       - agent
       - ca
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/windows2008-64a
+++ b/test/fixtures/generated/osinfo-version-0/windows2008-64a
@@ -12,7 +12,5 @@ expected_hash:
       roles:
       - agent
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/windows2008r2-6432c
+++ b/test/fixtures/generated/osinfo-version-0/windows2008r2-6432c
@@ -13,7 +13,5 @@ expected_hash:
       - agent
       - dashboard
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/windows2008r2-64l
+++ b/test/fixtures/generated/osinfo-version-0/windows2008r2-64l
@@ -13,7 +13,5 @@ expected_hash:
       - agent
       - classifier
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/windows2012-6432f
+++ b/test/fixtures/generated/osinfo-version-0/windows2012-6432f
@@ -13,7 +13,5 @@ expected_hash:
       - agent
       - frictionless
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/windows2012-64d
+++ b/test/fixtures/generated/osinfo-version-0/windows2012-64d
@@ -13,7 +13,5 @@ expected_hash:
       - agent
       - database
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/windows2012r2-6432aulcdfm
+++ b/test/fixtures/generated/osinfo-version-0/windows2012r2-6432aulcdfm
@@ -18,7 +18,5 @@ expected_hash:
       - frictionless
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/windows2012r2-64m
+++ b/test/fixtures/generated/osinfo-version-0/windows2012r2-64m
@@ -13,7 +13,5 @@ expected_hash:
       - agent
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/windows2012r2_ja-6432l
+++ b/test/fixtures/generated/osinfo-version-0/windows2012r2_ja-6432l
@@ -14,7 +14,5 @@ expected_hash:
       - agent
       - classifier
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/windows2012r2_ja-64u
+++ b/test/fixtures/generated/osinfo-version-0/windows2012r2_ja-64u
@@ -14,7 +14,5 @@ expected_hash:
       - agent
       - ca
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/windows2012r2_wmf5-64a
+++ b/test/fixtures/generated/osinfo-version-0/windows2012r2_wmf5-64a
@@ -12,7 +12,5 @@ expected_hash:
       roles:
       - agent
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/windows2016-6432d
+++ b/test/fixtures/generated/osinfo-version-0/windows2016-6432d
@@ -13,7 +13,5 @@ expected_hash:
       - agent
       - database
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/windows2016-64c
+++ b/test/fixtures/generated/osinfo-version-0/windows2016-64c
@@ -13,7 +13,5 @@ expected_hash:
       - agent
       - dashboard
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/windows2016_fr-6432f
+++ b/test/fixtures/generated/osinfo-version-0/windows2016_fr-6432f
@@ -15,7 +15,5 @@ expected_hash:
       - agent
       - frictionless
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/osinfo-version-0/windows2016_fr-64d
+++ b/test/fixtures/generated/osinfo-version-0/windows2016_fr-64d
@@ -15,7 +15,5 @@ expected_hash:
       - agent
       - database
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/osinfo-version-0/windows2022-64aulcdfm
+++ b/test/fixtures/generated/osinfo-version-0/windows2022-64aulcdfm
@@ -18,7 +18,5 @@ expected_hash:
       - frictionless
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/windows7-64f
+++ b/test/fixtures/generated/osinfo-version-0/windows7-64f
@@ -13,7 +13,5 @@ expected_hash:
       - agent
       - frictionless
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/windows81-64aulcdfm
+++ b/test/fixtures/generated/osinfo-version-0/windows81-64aulcdfm
@@ -18,7 +18,5 @@ expected_hash:
       - frictionless
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/osinfo-version-0/windowsfips2012r2-6432f
+++ b/test/fixtures/generated/osinfo-version-0/windowsfips2012r2-6432f
@@ -13,7 +13,5 @@ expected_hash:
       - agent
       - frictionless
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/osinfo-version-0/windowsfips2012r2-64d
+++ b/test/fixtures/generated/osinfo-version-0/windowsfips2012r2-64d
@@ -13,7 +13,5 @@ expected_hash:
       - agent
       - database
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/osinfo-version-1/aix53-POWERa
+++ b/test/fixtures/generated/osinfo-version-1/aix53-POWERa
@@ -9,7 +9,5 @@ expected_hash:
       roles:
       - agent
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/osinfo-version-1/aix61-POWERu
+++ b/test/fixtures/generated/osinfo-version-1/aix61-POWERu
@@ -10,7 +10,5 @@ expected_hash:
       - agent
       - ca
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/osinfo-version-1/aix71-POWERl
+++ b/test/fixtures/generated/osinfo-version-1/aix71-POWERl
@@ -10,7 +10,5 @@ expected_hash:
       - agent
       - classifier
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/osinfo-version-1/aix72-POWERc
+++ b/test/fixtures/generated/osinfo-version-1/aix72-POWERc
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - dashboard
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/osinfo-version-1/almalinux8-64u
+++ b/test/fixtures/generated/osinfo-version-1/almalinux8-64u
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - ca
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/amazon6-64d
+++ b/test/fixtures/generated/osinfo-version-1/amazon6-64d
@@ -10,7 +10,5 @@ expected_hash:
       - agent
       - database
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/osinfo-version-1/amazon7-64f
+++ b/test/fixtures/generated/osinfo-version-1/amazon7-64f
@@ -10,7 +10,5 @@ expected_hash:
       - agent
       - frictionless
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/osinfo-version-1/amazon7-ARM64m
+++ b/test/fixtures/generated/osinfo-version-1/amazon7-ARM64m
@@ -10,7 +10,5 @@ expected_hash:
       - agent
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/osinfo-version-1/arista4-32d
+++ b/test/fixtures/generated/osinfo-version-1/arista4-32d
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - database
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/centos4-32f
+++ b/test/fixtures/generated/osinfo-version-1/centos4-32f
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - frictionless
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/centos4-64m
+++ b/test/fixtures/generated/osinfo-version-1/centos4-64m
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/centos5-32aulcdfm
+++ b/test/fixtures/generated/osinfo-version-1/centos5-32aulcdfm
@@ -16,7 +16,5 @@ expected_hash:
       - frictionless
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/centos5-64a
+++ b/test/fixtures/generated/osinfo-version-1/centos5-64a
@@ -10,7 +10,5 @@ expected_hash:
       roles:
       - agent
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/centos6-32u
+++ b/test/fixtures/generated/osinfo-version-1/centos6-32u
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - ca
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/centos6-64l
+++ b/test/fixtures/generated/osinfo-version-1/centos6-64l
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - classifier
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/centos7-64c
+++ b/test/fixtures/generated/osinfo-version-1/centos7-64c
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - dashboard
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/centos8-64aulcdfm
+++ b/test/fixtures/generated/osinfo-version-1/centos8-64aulcdfm
@@ -16,7 +16,5 @@ expected_hash:
       - frictionless
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/osinfo-version-1/centos8-64m
+++ b/test/fixtures/generated/osinfo-version-1/centos8-64m
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/cisco_ios_c2960-HWm
+++ b/test/fixtures/generated/osinfo-version-1/cisco_ios_c2960-HWm
@@ -12,7 +12,5 @@ expected_hash:
       - agent
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/cisco_ios_c3560-HWaulcdfm
+++ b/test/fixtures/generated/osinfo-version-1/cisco_ios_c3560-HWaulcdfm
@@ -17,7 +17,5 @@ expected_hash:
       - frictionless
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/cisco_ios_c3750-HWa
+++ b/test/fixtures/generated/osinfo-version-1/cisco_ios_c3750-HWa
@@ -11,7 +11,5 @@ expected_hash:
       roles:
       - agent
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/cisco_ios_c4507r-HWu
+++ b/test/fixtures/generated/osinfo-version-1/cisco_ios_c4507r-HWu
@@ -12,7 +12,5 @@ expected_hash:
       - agent
       - ca
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/cisco_ios_c4948-HWl
+++ b/test/fixtures/generated/osinfo-version-1/cisco_ios_c4948-HWl
@@ -12,7 +12,5 @@ expected_hash:
       - agent
       - classifier
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/cisco_ios_c6503-HWc
+++ b/test/fixtures/generated/osinfo-version-1/cisco_ios_c6503-HWc
@@ -12,7 +12,5 @@ expected_hash:
       - agent
       - dashboard
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/cisco_iosxe_c3650-HWd
+++ b/test/fixtures/generated/osinfo-version-1/cisco_iosxe_c3650-HWd
@@ -12,7 +12,5 @@ expected_hash:
       - agent
       - database
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/cisco_iosxe_c4503-HWf
+++ b/test/fixtures/generated/osinfo-version-1/cisco_iosxe_c4503-HWf
@@ -12,7 +12,5 @@ expected_hash:
       - agent
       - frictionless
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/cisco_n7k-HWc
+++ b/test/fixtures/generated/osinfo-version-1/cisco_n7k-HWc
@@ -14,7 +14,5 @@ expected_hash:
       - agent
       - dashboard
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/cisco_n7k_vdc-HWd
+++ b/test/fixtures/generated/osinfo-version-1/cisco_n7k_vdc-HWd
@@ -14,7 +14,5 @@ expected_hash:
       - agent
       - database
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/cisco_n9k-HWf
+++ b/test/fixtures/generated/osinfo-version-1/cisco_n9k-HWf
@@ -14,7 +14,5 @@ expected_hash:
       - agent
       - frictionless
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/cisco_n9k-VMl
+++ b/test/fixtures/generated/osinfo-version-1/cisco_n9k-VMl
@@ -15,7 +15,5 @@ expected_hash:
       - agent
       - classifier
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/cisco_xr_9k-VMm
+++ b/test/fixtures/generated/osinfo-version-1/cisco_xr_9k-VMm
@@ -12,7 +12,5 @@ expected_hash:
       - agent
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/ciscon7k-64a
+++ b/test/fixtures/generated/osinfo-version-1/ciscon7k-64a
@@ -13,7 +13,5 @@ expected_hash:
       roles:
       - agent
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/cisconx-64aulcdfm
+++ b/test/fixtures/generated/osinfo-version-1/cisconx-64aulcdfm
@@ -20,7 +20,5 @@ expected_hash:
       - frictionless
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/cisconx-64d
+++ b/test/fixtures/generated/osinfo-version-1/cisconx-64d
@@ -15,7 +15,5 @@ expected_hash:
       - agent
       - database
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/osinfo-version-1/cisconxhw-64f
+++ b/test/fixtures/generated/osinfo-version-1/cisconxhw-64f
@@ -14,7 +14,5 @@ expected_hash:
       - agent
       - frictionless
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/cisconxhw-64u
+++ b/test/fixtures/generated/osinfo-version-1/cisconxhw-64u
@@ -14,7 +14,5 @@ expected_hash:
       - agent
       - ca
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/cumulus25-64m
+++ b/test/fixtures/generated/osinfo-version-1/cumulus25-64m
@@ -12,7 +12,5 @@ expected_hash:
       - agent
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/debian10-32d
+++ b/test/fixtures/generated/osinfo-version-1/debian10-32d
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - database
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/osinfo-version-1/debian10-64c
+++ b/test/fixtures/generated/osinfo-version-1/debian10-64c
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - dashboard
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/osinfo-version-1/debian11-64m
+++ b/test/fixtures/generated/osinfo-version-1/debian11-64m
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/osinfo-version-1/debian6-32aulcdfm
+++ b/test/fixtures/generated/osinfo-version-1/debian6-32aulcdfm
@@ -16,7 +16,5 @@ expected_hash:
       - frictionless
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/debian6-64a
+++ b/test/fixtures/generated/osinfo-version-1/debian6-64a
@@ -10,7 +10,5 @@ expected_hash:
       roles:
       - agent
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/debian7-32u
+++ b/test/fixtures/generated/osinfo-version-1/debian7-32u
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - ca
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/debian7-64l
+++ b/test/fixtures/generated/osinfo-version-1/debian7-64l
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - classifier
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/debian8-32c
+++ b/test/fixtures/generated/osinfo-version-1/debian8-32c
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - dashboard
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/debian8-64d
+++ b/test/fixtures/generated/osinfo-version-1/debian8-64d
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - database
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/debian9-32f
+++ b/test/fixtures/generated/osinfo-version-1/debian9-32f
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - frictionless
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/debian9-64m
+++ b/test/fixtures/generated/osinfo-version-1/debian9-64m
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/fedora14-32aulcdfm
+++ b/test/fixtures/generated/osinfo-version-1/fedora14-32aulcdfm
@@ -16,7 +16,5 @@ expected_hash:
       - frictionless
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/osinfo-version-1/fedora19-32a
+++ b/test/fixtures/generated/osinfo-version-1/fedora19-32a
@@ -10,7 +10,5 @@ expected_hash:
       roles:
       - agent
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/fedora19-64u
+++ b/test/fixtures/generated/osinfo-version-1/fedora19-64u
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - ca
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/fedora20-32l
+++ b/test/fixtures/generated/osinfo-version-1/fedora20-32l
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - classifier
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/fedora20-64c
+++ b/test/fixtures/generated/osinfo-version-1/fedora20-64c
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - dashboard
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/fedora21-32d
+++ b/test/fixtures/generated/osinfo-version-1/fedora21-32d
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - database
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/fedora21-64f
+++ b/test/fixtures/generated/osinfo-version-1/fedora21-64f
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - frictionless
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/fedora22-32m
+++ b/test/fixtures/generated/osinfo-version-1/fedora22-32m
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/fedora22-64aulcdfm
+++ b/test/fixtures/generated/osinfo-version-1/fedora22-64aulcdfm
@@ -16,7 +16,5 @@ expected_hash:
       - frictionless
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/fedora23-32a
+++ b/test/fixtures/generated/osinfo-version-1/fedora23-32a
@@ -10,7 +10,5 @@ expected_hash:
       roles:
       - agent
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/fedora23-64u
+++ b/test/fixtures/generated/osinfo-version-1/fedora23-64u
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - ca
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/fedora24-32l
+++ b/test/fixtures/generated/osinfo-version-1/fedora24-32l
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - classifier
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/fedora24-64c
+++ b/test/fixtures/generated/osinfo-version-1/fedora24-64c
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - dashboard
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/fedora25-32d
+++ b/test/fixtures/generated/osinfo-version-1/fedora25-32d
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - database
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/fedora25-64f
+++ b/test/fixtures/generated/osinfo-version-1/fedora25-64f
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - frictionless
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/fedora26-64m
+++ b/test/fixtures/generated/osinfo-version-1/fedora26-64m
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/osinfo-version-1/fedora27-64l
+++ b/test/fixtures/generated/osinfo-version-1/fedora27-64l
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - classifier
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/osinfo-version-1/fedora28-64d
+++ b/test/fixtures/generated/osinfo-version-1/fedora28-64d
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - database
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/osinfo-version-1/fedora29-64d
+++ b/test/fixtures/generated/osinfo-version-1/fedora29-64d
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - database
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/osinfo-version-1/fedora30-64aulcdfm
+++ b/test/fixtures/generated/osinfo-version-1/fedora30-64aulcdfm
@@ -16,7 +16,5 @@ expected_hash:
       - frictionless
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/fedora31-64aulcdfm
+++ b/test/fixtures/generated/osinfo-version-1/fedora31-64aulcdfm
@@ -16,7 +16,5 @@ expected_hash:
       - frictionless
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/osinfo-version-1/fedora32-64a
+++ b/test/fixtures/generated/osinfo-version-1/fedora32-64a
@@ -10,7 +10,5 @@ expected_hash:
       roles:
       - agent
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/osinfo-version-1/fedora34-64c
+++ b/test/fixtures/generated/osinfo-version-1/fedora34-64c
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - dashboard
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/fedora36-64f
+++ b/test/fixtures/generated/osinfo-version-1/fedora36-64f
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - frictionless
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/huaweios6-POWERaulcdfm
+++ b/test/fixtures/generated/osinfo-version-1/huaweios6-POWERaulcdfm
@@ -15,7 +15,5 @@ expected_hash:
       - frictionless
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/osinfo-version-1/opensuse11-32a
+++ b/test/fixtures/generated/osinfo-version-1/opensuse11-32a
@@ -10,7 +10,5 @@ expected_hash:
       roles:
       - agent
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/opensuse11-64u
+++ b/test/fixtures/generated/osinfo-version-1/opensuse11-64u
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - ca
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/oracle5-32l
+++ b/test/fixtures/generated/osinfo-version-1/oracle5-32l
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - classifier
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/osinfo-version-1/oracle5-64c
+++ b/test/fixtures/generated/osinfo-version-1/oracle5-64c
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - dashboard
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/osinfo-version-1/oracle6-32d
+++ b/test/fixtures/generated/osinfo-version-1/oracle6-32d
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - database
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/osinfo-version-1/oracle6-64f
+++ b/test/fixtures/generated/osinfo-version-1/oracle6-64f
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - frictionless
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/osinfo-version-1/oracle7-64m
+++ b/test/fixtures/generated/osinfo-version-1/oracle7-64m
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/osinfo-version-1/osx1010-64a
+++ b/test/fixtures/generated/osinfo-version-1/osx1010-64a
@@ -10,7 +10,5 @@ expected_hash:
       roles:
       - agent
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/osinfo-version-1/osx1011-64u
+++ b/test/fixtures/generated/osinfo-version-1/osx1011-64u
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - ca
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/osinfo-version-1/osx1012-64l
+++ b/test/fixtures/generated/osinfo-version-1/osx1012-64l
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - classifier
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/osinfo-version-1/osx1013-64f
+++ b/test/fixtures/generated/osinfo-version-1/osx1013-64f
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - frictionless
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/osx1014-64f
+++ b/test/fixtures/generated/osinfo-version-1/osx1014-64f
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - frictionless
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/osinfo-version-1/osx1015-64u
+++ b/test/fixtures/generated/osinfo-version-1/osx1015-64u
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - ca
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/osx109-64aulcdfm
+++ b/test/fixtures/generated/osinfo-version-1/osx109-64aulcdfm
@@ -16,7 +16,5 @@ expected_hash:
       - frictionless
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/osinfo-version-1/osx11-64f
+++ b/test/fixtures/generated/osinfo-version-1/osx11-64f
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - frictionless
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/osinfo-version-1/osx11-ARM64u
+++ b/test/fixtures/generated/osinfo-version-1/osx11-ARM64u
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - ca
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/osx12-64d
+++ b/test/fixtures/generated/osinfo-version-1/osx12-64d
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - database
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/osinfo-version-1/osx12-ARM64c
+++ b/test/fixtures/generated/osinfo-version-1/osx12-ARM64c
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - dashboard
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/panos61-64f
+++ b/test/fixtures/generated/osinfo-version-1/panos61-64f
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - frictionless
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/panos71-64m
+++ b/test/fixtures/generated/osinfo-version-1/panos71-64m
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/panos81-64aulcdfm
+++ b/test/fixtures/generated/osinfo-version-1/panos81-64aulcdfm
@@ -16,7 +16,5 @@ expected_hash:
       - frictionless
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/redhat4-32c
+++ b/test/fixtures/generated/osinfo-version-1/redhat4-32c
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - dashboard
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/redhat4-64d
+++ b/test/fixtures/generated/osinfo-version-1/redhat4-64d
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - database
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/redhat5-32f
+++ b/test/fixtures/generated/osinfo-version-1/redhat5-32f
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - frictionless
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/redhat5-64m
+++ b/test/fixtures/generated/osinfo-version-1/redhat5-64m
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/redhat6-32aulcdfm
+++ b/test/fixtures/generated/osinfo-version-1/redhat6-32aulcdfm
@@ -16,7 +16,5 @@ expected_hash:
       - frictionless
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/redhat6-64a
+++ b/test/fixtures/generated/osinfo-version-1/redhat6-64a
@@ -10,7 +10,5 @@ expected_hash:
       roles:
       - agent
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/redhat7-64l
+++ b/test/fixtures/generated/osinfo-version-1/redhat7-64l
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - classifier
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/redhat7-AARCH64a
+++ b/test/fixtures/generated/osinfo-version-1/redhat7-AARCH64a
@@ -10,7 +10,5 @@ expected_hash:
       roles:
       - agent
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/osinfo-version-1/redhat7-AARCH64aulcdfm
+++ b/test/fixtures/generated/osinfo-version-1/redhat7-AARCH64aulcdfm
@@ -16,7 +16,5 @@ expected_hash:
       - frictionless
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/osinfo-version-1/redhat7-POWERc
+++ b/test/fixtures/generated/osinfo-version-1/redhat7-POWERc
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - dashboard
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/redhat7-S390Xd
+++ b/test/fixtures/generated/osinfo-version-1/redhat7-S390Xd
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - database
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/redhat8-64u
+++ b/test/fixtures/generated/osinfo-version-1/redhat8-64u
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - ca
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/osinfo-version-1/redhat8-AARCH64a
+++ b/test/fixtures/generated/osinfo-version-1/redhat8-AARCH64a
@@ -10,7 +10,5 @@ expected_hash:
       roles:
       - agent
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/redhat9-64l
+++ b/test/fixtures/generated/osinfo-version-1/redhat9-64l
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - classifier
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/redhatfips7-64aulcdfm
+++ b/test/fixtures/generated/osinfo-version-1/redhatfips7-64aulcdfm
@@ -17,7 +17,5 @@ expected_hash:
       - frictionless
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/osinfo-version-1/redhatfips8-64m
+++ b/test/fixtures/generated/osinfo-version-1/redhatfips8-64m
@@ -12,7 +12,5 @@ expected_hash:
       - agent
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/rocky8-64l
+++ b/test/fixtures/generated/osinfo-version-1/rocky8-64l
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - classifier
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/scientific5-32f
+++ b/test/fixtures/generated/osinfo-version-1/scientific5-32f
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - frictionless
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/scientific5-64m
+++ b/test/fixtures/generated/osinfo-version-1/scientific5-64m
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/scientific6-32aulcdfm
+++ b/test/fixtures/generated/osinfo-version-1/scientific6-32aulcdfm
@@ -16,7 +16,5 @@ expected_hash:
       - frictionless
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/scientific6-64a
+++ b/test/fixtures/generated/osinfo-version-1/scientific6-64a
@@ -10,7 +10,5 @@ expected_hash:
       roles:
       - agent
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/scientific7-64u
+++ b/test/fixtures/generated/osinfo-version-1/scientific7-64u
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - ca
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/sles10-32l
+++ b/test/fixtures/generated/osinfo-version-1/sles10-32l
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - classifier
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/sles10-64c
+++ b/test/fixtures/generated/osinfo-version-1/sles10-64c
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - dashboard
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/sles11-32d
+++ b/test/fixtures/generated/osinfo-version-1/sles11-32d
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - database
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/sles11-64f
+++ b/test/fixtures/generated/osinfo-version-1/sles11-64f
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - frictionless
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/sles11-S390Xm
+++ b/test/fixtures/generated/osinfo-version-1/sles11-S390Xm
@@ -10,7 +10,5 @@ expected_hash:
       - agent
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/sles12-64aulcdfm
+++ b/test/fixtures/generated/osinfo-version-1/sles12-64aulcdfm
@@ -16,7 +16,5 @@ expected_hash:
       - frictionless
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/sles12-POWERu
+++ b/test/fixtures/generated/osinfo-version-1/sles12-POWERu
@@ -10,7 +10,5 @@ expected_hash:
       - agent
       - ca
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/sles12-S390Xa
+++ b/test/fixtures/generated/osinfo-version-1/sles12-S390Xa
@@ -9,7 +9,5 @@ expected_hash:
       roles:
       - agent
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/sles15-64l
+++ b/test/fixtures/generated/osinfo-version-1/sles15-64l
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - classifier
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/solaris10-32l
+++ b/test/fixtures/generated/osinfo-version-1/solaris10-32l
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - classifier
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/osinfo-version-1/solaris10-64c
+++ b/test/fixtures/generated/osinfo-version-1/solaris10-64c
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - dashboard
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/osinfo-version-1/solaris10-SPARCd
+++ b/test/fixtures/generated/osinfo-version-1/solaris10-SPARCd
@@ -10,7 +10,5 @@ expected_hash:
       - agent
       - database
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/osinfo-version-1/solaris11-32f
+++ b/test/fixtures/generated/osinfo-version-1/solaris11-32f
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - frictionless
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/osinfo-version-1/solaris11-64m
+++ b/test/fixtures/generated/osinfo-version-1/solaris11-64m
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/osinfo-version-1/solaris11-SPARCaulcdfm
+++ b/test/fixtures/generated/osinfo-version-1/solaris11-SPARCaulcdfm
@@ -15,7 +15,5 @@ expected_hash:
       - frictionless
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/osinfo-version-1/solaris112-32a
+++ b/test/fixtures/generated/osinfo-version-1/solaris112-32a
@@ -11,7 +11,5 @@ expected_hash:
       roles:
       - agent
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/osinfo-version-1/solaris112-64u
+++ b/test/fixtures/generated/osinfo-version-1/solaris112-64u
@@ -12,7 +12,5 @@ expected_hash:
       - agent
       - ca
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/osinfo-version-1/ubuntu1404-32d
+++ b/test/fixtures/generated/osinfo-version-1/ubuntu1404-32d
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - database
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/ubuntu1404-32m
+++ b/test/fixtures/generated/osinfo-version-1/ubuntu1404-32m
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/osinfo-version-1/ubuntu1404-64aulcdfm
+++ b/test/fixtures/generated/osinfo-version-1/ubuntu1404-64aulcdfm
@@ -16,7 +16,5 @@ expected_hash:
       - frictionless
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/osinfo-version-1/ubuntu1404-64f
+++ b/test/fixtures/generated/osinfo-version-1/ubuntu1404-64f
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - frictionless
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/ubuntu1404-AARCH64aulcdfm
+++ b/test/fixtures/generated/osinfo-version-1/ubuntu1404-AARCH64aulcdfm
@@ -15,7 +15,5 @@ expected_hash:
       - frictionless
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/ubuntu1404-POWERm
+++ b/test/fixtures/generated/osinfo-version-1/ubuntu1404-POWERm
@@ -10,7 +10,5 @@ expected_hash:
       - agent
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/ubuntu1604-32a
+++ b/test/fixtures/generated/osinfo-version-1/ubuntu1604-32a
@@ -10,7 +10,5 @@ expected_hash:
       roles:
       - agent
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/ubuntu1604-32d
+++ b/test/fixtures/generated/osinfo-version-1/ubuntu1604-32d
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - database
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/osinfo-version-1/ubuntu1604-64f
+++ b/test/fixtures/generated/osinfo-version-1/ubuntu1604-64f
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - frictionless
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/osinfo-version-1/ubuntu1604-64u
+++ b/test/fixtures/generated/osinfo-version-1/ubuntu1604-64u
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - ca
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/ubuntu1604-AARCH64c
+++ b/test/fixtures/generated/osinfo-version-1/ubuntu1604-AARCH64c
@@ -10,7 +10,5 @@ expected_hash:
       - agent
       - dashboard
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/ubuntu1604-POWERl
+++ b/test/fixtures/generated/osinfo-version-1/ubuntu1604-POWERl
@@ -10,7 +10,5 @@ expected_hash:
       - agent
       - classifier
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/ubuntu1604-POWERm
+++ b/test/fixtures/generated/osinfo-version-1/ubuntu1604-POWERm
@@ -10,7 +10,5 @@ expected_hash:
       - agent
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/osinfo-version-1/ubuntu1804-64a
+++ b/test/fixtures/generated/osinfo-version-1/ubuntu1804-64a
@@ -10,7 +10,5 @@ expected_hash:
       roles:
       - agent
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/osinfo-version-1/ubuntu1804-64d
+++ b/test/fixtures/generated/osinfo-version-1/ubuntu1804-64d
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - database
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/ubuntu1804-AARCH64m
+++ b/test/fixtures/generated/osinfo-version-1/ubuntu1804-AARCH64m
@@ -10,7 +10,5 @@ expected_hash:
       - agent
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/ubuntu1804-POWERf
+++ b/test/fixtures/generated/osinfo-version-1/ubuntu1804-POWERf
@@ -10,7 +10,5 @@ expected_hash:
       - agent
       - frictionless
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/ubuntu2004-64a
+++ b/test/fixtures/generated/osinfo-version-1/ubuntu2004-64a
@@ -10,7 +10,5 @@ expected_hash:
       roles:
       - agent
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/osinfo-version-1/ubuntu2004-64aulcdfm
+++ b/test/fixtures/generated/osinfo-version-1/ubuntu2004-64aulcdfm
@@ -16,7 +16,5 @@ expected_hash:
       - frictionless
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/ubuntu2004-AARCH64c
+++ b/test/fixtures/generated/osinfo-version-1/ubuntu2004-AARCH64c
@@ -10,7 +10,5 @@ expected_hash:
       - agent
       - dashboard
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/osinfo-version-1/ubuntu2004-AARCH64u
+++ b/test/fixtures/generated/osinfo-version-1/ubuntu2004-AARCH64u
@@ -10,7 +10,5 @@ expected_hash:
       - agent
       - ca
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/ubuntu2004-POWERa
+++ b/test/fixtures/generated/osinfo-version-1/ubuntu2004-POWERa
@@ -9,7 +9,5 @@ expected_hash:
       roles:
       - agent
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/ubuntu2010-64l
+++ b/test/fixtures/generated/osinfo-version-1/ubuntu2010-64l
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - classifier
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/ubuntu2104-64c
+++ b/test/fixtures/generated/osinfo-version-1/ubuntu2104-64c
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - dashboard
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/ubuntu2110-64d
+++ b/test/fixtures/generated/osinfo-version-1/ubuntu2110-64d
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - database
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/ubuntu2204-64l
+++ b/test/fixtures/generated/osinfo-version-1/ubuntu2204-64l
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - classifier
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/osinfo-version-1/ubuntu2204-AARCH64d
+++ b/test/fixtures/generated/osinfo-version-1/ubuntu2204-AARCH64d
@@ -10,7 +10,5 @@ expected_hash:
       - agent
       - database
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/osinfo-version-1/ubuntu2204-POWERc
+++ b/test/fixtures/generated/osinfo-version-1/ubuntu2204-POWERc
@@ -10,7 +10,5 @@ expected_hash:
       - agent
       - dashboard
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/osinfo-version-1/vro6-64u
+++ b/test/fixtures/generated/osinfo-version-1/vro6-64u
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - ca
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/vro7-64l
+++ b/test/fixtures/generated/osinfo-version-1/vro7-64l
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - classifier
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/vro71-64d
+++ b/test/fixtures/generated/osinfo-version-1/vro71-64d
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - database
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/osinfo-version-1/vro73-64l
+++ b/test/fixtures/generated/osinfo-version-1/vro73-64l
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - classifier
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/osinfo-version-1/vro74-64m
+++ b/test/fixtures/generated/osinfo-version-1/vro74-64m
@@ -11,7 +11,5 @@ expected_hash:
       - agent
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/osinfo-version-1/windows10ent-32u
+++ b/test/fixtures/generated/osinfo-version-1/windows10ent-32u
@@ -13,7 +13,5 @@ expected_hash:
       - agent
       - ca
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/windows10ent-64l
+++ b/test/fixtures/generated/osinfo-version-1/windows10ent-64l
@@ -13,7 +13,5 @@ expected_hash:
       - agent
       - classifier
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/windows10pro-64c
+++ b/test/fixtures/generated/osinfo-version-1/windows10pro-64c
@@ -13,7 +13,5 @@ expected_hash:
       - agent
       - dashboard
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/windows11ent-64c
+++ b/test/fixtures/generated/osinfo-version-1/windows11ent-64c
@@ -13,7 +13,5 @@ expected_hash:
       - agent
       - dashboard
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/windows2008-6432u
+++ b/test/fixtures/generated/osinfo-version-1/windows2008-6432u
@@ -13,7 +13,5 @@ expected_hash:
       - agent
       - ca
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/windows2008-64a
+++ b/test/fixtures/generated/osinfo-version-1/windows2008-64a
@@ -12,7 +12,5 @@ expected_hash:
       roles:
       - agent
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/windows2008r2-6432c
+++ b/test/fixtures/generated/osinfo-version-1/windows2008r2-6432c
@@ -13,7 +13,5 @@ expected_hash:
       - agent
       - dashboard
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/windows2008r2-64l
+++ b/test/fixtures/generated/osinfo-version-1/windows2008r2-64l
@@ -13,7 +13,5 @@ expected_hash:
       - agent
       - classifier
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/windows2012-6432f
+++ b/test/fixtures/generated/osinfo-version-1/windows2012-6432f
@@ -13,7 +13,5 @@ expected_hash:
       - agent
       - frictionless
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/windows2012-64d
+++ b/test/fixtures/generated/osinfo-version-1/windows2012-64d
@@ -13,7 +13,5 @@ expected_hash:
       - agent
       - database
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/windows2012r2-6432aulcdfm
+++ b/test/fixtures/generated/osinfo-version-1/windows2012r2-6432aulcdfm
@@ -18,7 +18,5 @@ expected_hash:
       - frictionless
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/windows2012r2-64m
+++ b/test/fixtures/generated/osinfo-version-1/windows2012r2-64m
@@ -13,7 +13,5 @@ expected_hash:
       - agent
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/windows2012r2_ja-6432l
+++ b/test/fixtures/generated/osinfo-version-1/windows2012r2_ja-6432l
@@ -14,7 +14,5 @@ expected_hash:
       - agent
       - classifier
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/windows2012r2_ja-64u
+++ b/test/fixtures/generated/osinfo-version-1/windows2012r2_ja-64u
@@ -14,7 +14,5 @@ expected_hash:
       - agent
       - ca
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/windows2012r2_wmf5-64a
+++ b/test/fixtures/generated/osinfo-version-1/windows2012r2_wmf5-64a
@@ -12,7 +12,5 @@ expected_hash:
       roles:
       - agent
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/windows2016-6432d
+++ b/test/fixtures/generated/osinfo-version-1/windows2016-6432d
@@ -13,7 +13,5 @@ expected_hash:
       - agent
       - database
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/windows2016-64c
+++ b/test/fixtures/generated/osinfo-version-1/windows2016-64c
@@ -13,7 +13,5 @@ expected_hash:
       - agent
       - dashboard
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/windows2016_fr-6432f
+++ b/test/fixtures/generated/osinfo-version-1/windows2016_fr-6432f
@@ -15,7 +15,5 @@ expected_hash:
       - agent
       - frictionless
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/osinfo-version-1/windows2016_fr-64d
+++ b/test/fixtures/generated/osinfo-version-1/windows2016_fr-64d
@@ -15,7 +15,5 @@ expected_hash:
       - agent
       - database
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/osinfo-version-1/windows2022-64aulcdfm
+++ b/test/fixtures/generated/osinfo-version-1/windows2022-64aulcdfm
@@ -18,7 +18,5 @@ expected_hash:
       - frictionless
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/windows7-64f
+++ b/test/fixtures/generated/osinfo-version-1/windows7-64f
@@ -13,7 +13,5 @@ expected_hash:
       - agent
       - frictionless
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/windows81-64aulcdfm
+++ b/test/fixtures/generated/osinfo-version-1/windows81-64aulcdfm
@@ -18,7 +18,5 @@ expected_hash:
       - frictionless
       - master
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/osinfo-version-1/windowsfips2012r2-6432f
+++ b/test/fixtures/generated/osinfo-version-1/windowsfips2012r2-6432f
@@ -13,7 +13,5 @@ expected_hash:
       - agent
       - frictionless
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/osinfo-version-1/windowsfips2012r2-64d
+++ b/test/fixtures/generated/osinfo-version-1/windowsfips2012r2-64d
@@ -13,7 +13,5 @@ expected_hash:
       - agent
       - database
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception: 

--- a/test/fixtures/generated/pe_dir/centos6-64mdc
+++ b/test/fixtures/generated/pe_dir/centos6-64mdc
@@ -14,7 +14,5 @@ expected_hash:
       - database
       - dashboard
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/pe_upgrade_dir/centos6-64mdc
+++ b/test/fixtures/generated/pe_upgrade_dir/centos6-64mdc
@@ -14,7 +14,5 @@ expected_hash:
       - database
       - dashboard
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/pe_upgrade_ver/centos6-64mdc
+++ b/test/fixtures/generated/pe_upgrade_ver/centos6-64mdc
@@ -14,7 +14,5 @@ expected_hash:
       - database
       - dashboard
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/generated/pe_ver/centos6-64mdc
+++ b/test/fixtures/generated/pe_ver/centos6-64mdc
@@ -14,7 +14,5 @@ expected_hash:
       - database
       - dashboard
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/per-host-settings/arbitrary-hypervisor.yaml
+++ b/test/fixtures/per-host-settings/arbitrary-hypervisor.yaml
@@ -21,7 +21,5 @@ expected_hash:
       roles:
       - agent
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/per-host-settings/arbitrary-settings.yaml
+++ b/test/fixtures/per-host-settings/arbitrary-settings.yaml
@@ -35,7 +35,5 @@ expected_hash:
       - database
       - dashboard
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/per-host-settings/docker-regex-validation.yaml
+++ b/test/fixtures/per-host-settings/docker-regex-validation.yaml
@@ -34,7 +34,5 @@ expected_hash:
       hypervisor: docker
       roles:
       - agent
-  CONFIG:
-    nfs_server: none
-    consoleport: 443
+  CONFIG: {}
 expected_exception:

--- a/test/fixtures/per-host-settings/every-hypervisor.yaml
+++ b/test/fixtures/per-host-settings/every-hypervisor.yaml
@@ -50,7 +50,5 @@ expected_hash:
       - agent
 
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/per-host-settings/hcloud-hypervisor.yaml
+++ b/test/fixtures/per-host-settings/hcloud-hypervisor.yaml
@@ -29,7 +29,5 @@ expected_hash:
       hypervisor: hcloud
       roles:
       - agent
-  CONFIG:
-    nfs_server: none
-    consoleport: 443
+  CONFIG: {}
 expected_exception:

--- a/test/fixtures/per-host-settings/url-encoded.yaml
+++ b/test/fixtures/per-host-settings/url-encoded.yaml
@@ -26,7 +26,5 @@ expected_hash:
       roles:
       - agent
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
 expected_exception:

--- a/test/fixtures/per-host-settings/vagrant-hypervisor.yaml
+++ b/test/fixtures/per-host-settings/vagrant-hypervisor.yaml
@@ -25,7 +25,5 @@ expected_hash:
       hypervisor: vagrant
       roles:
       - agent
-  CONFIG:
-    nfs_server: none
-    consoleport: 443
+  CONFIG: {}
 expected_exception:

--- a/test/fixtures/per-host-settings/with-global-settings-overwrite.yaml
+++ b/test/fixtures/per-host-settings/with-global-settings-overwrite.yaml
@@ -11,7 +11,5 @@ expected_hash:
         - agent
         - dashboard
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     pooling_api: http://customvmpooler/
 expected_exception:

--- a/test/fixtures/per-host-settings/with-global-settings.yaml
+++ b/test/fixtures/per-host-settings/with-global-settings.yaml
@@ -12,8 +12,6 @@ expected_hash:
         - agent
         - dashboard
   CONFIG:
-    nfs_server: none
-    consoleport: 443
     masterless: true
     number: 1234
     key: url encoded  white space


### PR DESCRIPTION
Beaker defaults to consoleport 443, so specifying this is redundant and extremely noisy.

As for nfs_server, I could not find any code that uses it. It shows up in many markdown files and configs, but I've yet to find actual Ruby code that uses it.