### PR TITLE
Install hostname on CentOS 9 Stream in docker

### DIFF
--- a/lib/beaker-hostgenerator/data.rb
+++ b/lib/beaker-hostgenerator/data.rb
@@ -334,7 +334,7 @@ module BeakerHostGenerator
             'image'                 => 'quay.io/centos/centos:stream9',
             'docker_image_commands' => [
               'cp /bin/true /sbin/agetty',
-              'dnf install -y crontabs initscripts iproute openssl wget which glibc-langpack-en',
+              'dnf install -y crontabs initscripts iproute openssl wget which glibc-langpack-en hostname',
             ],
           },
         },


### PR DESCRIPTION
This is not available in the minimal CentOS 9 Stream containers and specinfra relies on this for the hostname -f command to determine the FQDN.

Fixes: b7fe509f83284e85875108a48603abdd13ff3434