### PR TITLE
Fix missing include for `strscan`

### DIFF
--- a/lib/beaker-hostgenerator/parser.rb
+++ b/lib/beaker-hostgenerator/parser.rb
@@ -1,6 +1,7 @@
 require 'beaker-hostgenerator/data'
 require 'beaker-hostgenerator/exceptions'
 require 'cgi'
+require 'strscan'
 
 module BeakerHostGenerator
   # Functions for parsing the raw user input host layout string and turning


### PR DESCRIPTION
StringScanner is used without a corresponding require.  The lack of this require breaks under Ruby 3.1 in some environments.