### PR TITLE
Fix typo in yum command

### DIFF
--- a/lib/beaker-hostgenerator/hypervisor/docker.rb
+++ b/lib/beaker-hostgenerator/hypervisor/docker.rb
@@ -79,7 +79,7 @@ module BeakerHostGenerator
         if version >= 8
           'dnf install -y crontabs initscripts iproute openssl wget which glibc-langpack-en hostname'
         else
-          'yum intall -y crontabs initscripts iproute openssl wget which sysvinit-tools tar ss'
+          'yum install -y crontabs initscripts iproute openssl wget which sysvinit-tools tar ss'
         end
       end
     end


### PR DESCRIPTION
Fixes:
```jsonl
{"stream":"Step 7/9 : RUN yum intall -y crontabs initscripts iproute openssl wget which sysvinit-tools tar ss"}
{"stream":"\n"}
{"stream":" ---\u003e Running in f1b3d7cc1eae\n"}
{"stream":"Loaded plugins: fastestmirror, ovl\n"}
{"stream":"\u001b[91mNo such command: intall. Please use /usr/bin/yum --help\n\u001b[0m"}
{"errorDetail":{"code":1,"message":"The command '/bin/sh -c yum intall -y crontabs initscripts iproute openssl wget which sysvinit-tools tar ss' returned a non-zero code: 1"},"error":"The command '/bin/sh -c yum intall -y crontabs initscripts iproute openssl wget which sysvinit-tools tar ss' returned a non-zero code: 1"}
```
