### PR TITLE
Debian: Install iproute2

### DIFF
--- a/lib/beaker-hostgenerator/hypervisor/docker.rb
+++ b/lib/beaker-hostgenerator/hypervisor/docker.rb
@@ -58,7 +58,7 @@ module BeakerHostGenerator
           [
             'cp /bin/true /sbin/agetty',
             'rm -f /usr/sbin/policy-rc.d',
-            'apt-get update && apt-get install -y cron locales-all net-tools wget gnupg',
+            'apt-get update && apt-get install -y cron locales-all net-tools wget gnupg iproute2',
           ]
         when /^opensuse/
           [

--- a/test/fixtures/per-host-settings/every-hypervisor.yaml
+++ b/test/fixtures/per-host-settings/every-hypervisor.yaml
@@ -31,7 +31,7 @@ expected_hash:
       docker_image_commands:
       - cp /bin/true /sbin/agetty
       - rm -f /usr/sbin/policy-rc.d
-      - apt-get update && apt-get install -y cron locales-all net-tools wget gnupg
+      - apt-get update && apt-get install -y cron locales-all net-tools wget gnupg iproute2
       roles:
       - agent
     ubuntu1804-64-1:


### PR DESCRIPTION
Install iproute2. This provides `ss`:
https://packages.debian.org/bookworm/amd64/iproute2/filelist This is used by serverspec to check for open ports. This is probably not the best space because it's docker specific, but it will fix our tests.