### PR TITLE
Use centos/stream9 vagrant box

### DIFF
--- a/lib/beaker-hostgenerator/data.rb
+++ b/lib/beaker-hostgenerator/data.rb
@@ -161,7 +161,6 @@ module BeakerHostGenerator
                         },
                         vagrant: {
                           'box' => 'centos/stream9',
-                          'box_url' => 'https://cloud.centos.org/centos/9-stream/x86_64/images/CentOS-Stream-Vagrant-9-20230410.0.x86_64.vagrant-libvirt.box',
                         },
                       },
                       'debian10-64' => {


### PR DESCRIPTION
These are finally published on Vagrant Cloud which means it can automatically retrieve the latest version.

When I just tested this elsewhere I couldn't get the latest image to boot, so perhaps this isn't ready yet. Marking as draft until I can verify it works.