### PR TITLE
(RE-15156) Add redhat-9-arm64 support

### DIFF
--- a/lib/beaker-hostgenerator/data.rb
+++ b/lib/beaker-hostgenerator/data.rb
@@ -361,6 +361,17 @@ module BeakerHostGenerator
                           'platform' => 'el-9-x86_64',
                         },
                       },
+                      'redhat9-AARCH64' => {
+                        general: {
+                          'platform' => 'el-9-aarch64',
+                        },
+                        abs: {
+                          'template' => 'redhat-9-arm64',
+                        },
+                        vmpooler: {
+                          'template' => 'redhat-9-arm64',
+                        },
+                      },
                       'sles11-32' => {
                         general: {
                           'platform' => 'sles-11-i386',

--- a/test/fixtures/generated/default/redhat9-AARCH64m
+++ b/test/fixtures/generated/default/redhat9-AARCH64m
@@ -1,0 +1,15 @@
+---
+arguments_string: redhat9-AARCH64m
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    redhat9-AARCH64-1:
+      platform: el-9-aarch64
+      template: redhat-9-arm64
+      hypervisor: vmpooler
+      roles:
+      - agent
+      - master
+  CONFIG:
+    pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
+expected_exception:

--- a/test/fixtures/generated/multiplatform/centos7-64a-redhat9-AARCH64-centos7-64aulcdfm
+++ b/test/fixtures/generated/multiplatform/centos7-64a-redhat9-AARCH64-centos7-64aulcdfm
@@ -1,0 +1,32 @@
+---
+arguments_string: centos7-64a-redhat9-AARCH64-centos7-64aulcdfm
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    centos7-64-1:
+      platform: el-7-x86_64
+      hypervisor: vmpooler
+      template: centos-7-x86_64
+      roles:
+      - agent
+    redhat9-AARCH64-1:
+      platform: el-9-aarch64
+      template: redhat-9-arm64
+      hypervisor: vmpooler
+      roles:
+      - agent
+    centos7-64-2:
+      platform: el-7-x86_64
+      hypervisor: vmpooler
+      template: centos-7-x86_64
+      roles:
+      - agent
+      - ca
+      - classifier
+      - dashboard
+      - database
+      - frictionless
+      - master
+  CONFIG:
+    pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
+expected_exception:

--- a/test/fixtures/generated/multiplatform/redhat9-AARCH64m-centos7-64-redhat9-AARCH64u
+++ b/test/fixtures/generated/multiplatform/redhat9-AARCH64m-centos7-64-redhat9-AARCH64u
@@ -1,0 +1,28 @@
+---
+arguments_string: redhat9-AARCH64m-centos7-64-redhat9-AARCH64u
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    redhat9-AARCH64-1:
+      platform: el-9-aarch64
+      template: redhat-9-arm64
+      hypervisor: vmpooler
+      roles:
+      - agent
+      - master
+    centos7-64-1:
+      platform: el-7-x86_64
+      hypervisor: vmpooler
+      template: centos-7-x86_64
+      roles:
+      - agent
+    redhat9-AARCH64-2:
+      platform: el-9-aarch64
+      template: redhat-9-arm64
+      hypervisor: vmpooler
+      roles:
+      - agent
+      - ca
+  CONFIG:
+    pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
+expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/redhat9-AARCH64m
+++ b/test/fixtures/generated/osinfo-version-0/redhat9-AARCH64m
@@ -1,0 +1,15 @@
+---
+arguments_string: "--osinfo-version 0 redhat9-AARCH64m"
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    redhat9-AARCH64-1:
+      platform: el-9-aarch64
+      template: redhat-9-arm64
+      hypervisor: vmpooler
+      roles:
+      - agent
+      - master
+  CONFIG:
+    pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
+expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/redhat9-AARCH64m
+++ b/test/fixtures/generated/osinfo-version-1/redhat9-AARCH64m
@@ -1,0 +1,15 @@
+---
+arguments_string: "--osinfo-version 1 redhat9-AARCH64m"
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    redhat9-AARCH64-1:
+      platform: el-9-aarch64
+      template: redhat-9-arm64
+      hypervisor: vmpooler
+      roles:
+      - agent
+      - master
+  CONFIG:
+    pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
+expected_exception:


### PR DESCRIPTION
I'm not sure about all the places that the `abs` and `vmpooler` platform data keys are used, but was a bit confused because the `redhat8-AARCH64` specifies the x86 template name `redhat-8-x86_64`, is that a mistake? https://github.com/voxpupuli/beaker-hostgenerator/blob/da8ac9a25030480925b79a84a34444d7f9d14970/lib/beaker-hostgenerator/data.rb#L348

So for the new platform's `vmpooler` key I used the expected name that we would use in vmpooler for that platform, is that correct? Or should that key just be omitted?


**EDIT**: Ah it looks like those keys related to the hypervisor gem. The above definitely seems like a bug per:
```
> beaker-hostgenerator redhat8-AARCH64 --hypervisor vmpooler
---
HOSTS:
  redhat8-AARCH64-1:
    platform: el-8-aarch64
    template: redhat-8-x86_64
    hypervisor: vmpooler
    roles:
    - agent
CONFIG:
  pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
```

