### PR TITLE
(RE-15206) Add ubuntu-2204-arm64 fixtures

### DIFF
--- a/test/fixtures/generated/default/ubuntu2204-AARCH64m
+++ b/test/fixtures/generated/default/ubuntu2204-AARCH64m
@@ -1,0 +1,14 @@
+---
+arguments_string: ubuntu2204-AARCH64m
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    ubuntu2204-AARCH64-1:
+      platform: ubuntu-22.04-aarch64
+      hypervisor: vmpooler
+      roles:
+      - agent
+      - master
+  CONFIG:
+    pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
+expected_exception:

--- a/test/fixtures/generated/multiplatform/ubuntu2204-AARCH64m-windows2008r2-6432-ubuntu2204-AARCH64u
+++ b/test/fixtures/generated/multiplatform/ubuntu2204-AARCH64m-windows2008r2-6432-ubuntu2204-AARCH64u
@@ -1,0 +1,28 @@
+---
+arguments_string: ubuntu2204-AARCH64m-windows2008r2-6432-ubuntu2204-AARCH64u
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    ubuntu2204-AARCH64-1:
+      platform: ubuntu-22.04-aarch64
+      hypervisor: vmpooler
+      roles:
+      - agent
+      - master
+    windows2008r2-6432-1:
+      platform: windows-2008r2-64
+      packaging_platform: windows-2012-x64
+      ruby_arch: x86
+      template: win-2008r2-x86_64
+      hypervisor: vmpooler
+      roles:
+      - agent
+    ubuntu2204-AARCH64-2:
+      platform: ubuntu-22.04-aarch64
+      hypervisor: vmpooler
+      roles:
+      - agent
+      - ca
+  CONFIG:
+    pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
+expected_exception:

--- a/test/fixtures/generated/multiplatform/windows2008r2-6432aulcdfm-ubuntu2204-AARCH64-windows2008r2-6432a
+++ b/test/fixtures/generated/multiplatform/windows2008r2-6432aulcdfm-ubuntu2204-AARCH64-windows2008r2-6432a
@@ -1,0 +1,35 @@
+---
+arguments_string: windows2008r2-6432aulcdfm-ubuntu2204-AARCH64-windows2008r2-6432a
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    windows2008r2-6432-1:
+      platform: windows-2008r2-64
+      packaging_platform: windows-2012-x64
+      ruby_arch: x86
+      template: win-2008r2-x86_64
+      hypervisor: vmpooler
+      roles:
+      - agent
+      - ca
+      - classifier
+      - dashboard
+      - database
+      - frictionless
+      - master
+    ubuntu2204-AARCH64-1:
+      platform: ubuntu-22.04-aarch64
+      hypervisor: vmpooler
+      roles:
+      - agent
+    windows2008r2-6432-2:
+      platform: windows-2008r2-64
+      packaging_platform: windows-2012-x64
+      ruby_arch: x86
+      template: win-2008r2-x86_64
+      hypervisor: vmpooler
+      roles:
+      - agent
+  CONFIG:
+    pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
+expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/ubuntu2204-AARCH64m
+++ b/test/fixtures/generated/osinfo-version-0/ubuntu2204-AARCH64m
@@ -1,0 +1,14 @@
+---
+arguments_string: "--osinfo-version 0 ubuntu2204-AARCH64m"
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    ubuntu2204-AARCH64-1:
+      platform: ubuntu-22.04-aarch64
+      hypervisor: vmpooler
+      roles:
+      - agent
+      - master
+  CONFIG:
+    pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
+expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/ubuntu2204-AARCH64m
+++ b/test/fixtures/generated/osinfo-version-1/ubuntu2204-AARCH64m
@@ -1,0 +1,14 @@
+---
+arguments_string: "--osinfo-version 1 ubuntu2204-AARCH64m"
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    ubuntu2204-AARCH64-1:
+      platform: ubuntu-22.04-aarch64
+      hypervisor: vmpooler
+      roles:
+      - agent
+      - master
+  CONFIG:
+    pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
+expected_exception:


### PR DESCRIPTION
I'm not sure if this is needed since there was some data added in https://github.com/voxpupuli/beaker-hostgenerator/pull/248 and released in [1.14.0](https://github.com/voxpupuli/beaker-hostgenerator/blob/master/CHANGELOG.md#1140-2022-05-30), but without any changes to data.rb, these were the fixtures generated with `bundle exec rake generate:fixtures`

Side note, it seems a bit odd that we don't set the template key for the ubuntu platforms here. This must be already be inserted by [beaker-abs](https://github.com/puppetlabs/beaker-abs), but I haven't gone looking