### PR TITLE
Add amazon-2023-x86_64

### DIFF
--- a/lib/beaker-hostgenerator/data.rb
+++ b/lib/beaker-hostgenerator/data.rb
@@ -1098,6 +1098,9 @@ module BeakerHostGenerator
         yield ["freebsd#{release}-64", "freebsd-#{release}-amd64"]
       end
 
+      # Amazon Linux
+      yield %w[amazon2023-64 amazon-2023-x86_64]
+
       # AlmaLinux and Rocky
       %w[almalinux rocky].each do |os|
         (8..9).each do |release|

--- a/lib/beaker-hostgenerator/hypervisor/abs.rb
+++ b/lib/beaker-hostgenerator/hypervisor/abs.rb
@@ -25,7 +25,7 @@ module BeakerHostGenerator
         case node_info['ostype']
         when /^(almalinux|centos|oracle|redhat|rocky|scientific)/
           base_config['template'] ||= base_config['platform'].gsub(/^el/, ::Regexp.last_match(1))
-        when /^fedora/, /^opensuse/, /^panos/
+        when /^amazon/, /^fedora/, /^opensuse/, /^panos/
           base_config['template'] ||= base_config['platform']
         when /^(debian|ubuntu)/
           os = Regexp.last_match(1)

--- a/test/fixtures/generated/default/amazon2023-64d
+++ b/test/fixtures/generated/default/amazon2023-64d
@@ -1,0 +1,14 @@
+---
+arguments_string: amazon2023-64d
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    amazon2023-64-1:
+      platform: amazon-2023-x86_64
+      hypervisor: vmpooler
+      roles:
+      - agent
+      - database
+  CONFIG:
+    pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
+expected_exception:

--- a/test/fixtures/generated/multiplatform/amazon2023-64d-vro71-64-amazon2023-64c
+++ b/test/fixtures/generated/multiplatform/amazon2023-64d-vro71-64-amazon2023-64c
@@ -1,0 +1,26 @@
+---
+arguments_string: amazon2023-64d-vro71-64-amazon2023-64c
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    amazon2023-64-1:
+      platform: amazon-2023-x86_64
+      hypervisor: vmpooler
+      roles:
+      - agent
+      - database
+    vro71-64-1:
+      platform: sles-11-x86_64
+      template: vro-71-x86_64
+      hypervisor: vmpooler
+      roles:
+      - agent
+    amazon2023-64-2:
+      platform: amazon-2023-x86_64
+      hypervisor: vmpooler
+      roles:
+      - agent
+      - dashboard
+  CONFIG:
+    pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
+expected_exception:

--- a/test/fixtures/generated/multiplatform/vro71-64c-amazon2023-64-vro71-64d
+++ b/test/fixtures/generated/multiplatform/vro71-64c-amazon2023-64-vro71-64d
@@ -1,0 +1,27 @@
+---
+arguments_string: vro71-64c-amazon2023-64-vro71-64d
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    vro71-64-1:
+      platform: sles-11-x86_64
+      template: vro-71-x86_64
+      hypervisor: vmpooler
+      roles:
+      - agent
+      - dashboard
+    amazon2023-64-1:
+      platform: amazon-2023-x86_64
+      hypervisor: vmpooler
+      roles:
+      - agent
+    vro71-64-2:
+      platform: sles-11-x86_64
+      template: vro-71-x86_64
+      hypervisor: vmpooler
+      roles:
+      - agent
+      - database
+  CONFIG:
+    pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
+expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/amazon2023-64d
+++ b/test/fixtures/generated/osinfo-version-0/amazon2023-64d
@@ -1,0 +1,14 @@
+---
+arguments_string: "--osinfo-version 0 amazon2023-64d"
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    amazon2023-64-1:
+      platform: amazon-2023-x86_64
+      hypervisor: vmpooler
+      roles:
+      - agent
+      - database
+  CONFIG:
+    pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
+expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/amazon2023-64d
+++ b/test/fixtures/generated/osinfo-version-1/amazon2023-64d
@@ -1,0 +1,14 @@
+---
+arguments_string: "--osinfo-version 1 amazon2023-64d"
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    amazon2023-64-1:
+      platform: amazon-2023-x86_64
+      hypervisor: vmpooler
+      roles:
+      - agent
+      - database
+  CONFIG:
+    pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
+expected_exception:


### PR DESCRIPTION
This adds support for Amazon Linux 2023.

Additionally, because what is noted in this [AWS blog post](https://aws.amazon.com/blogs/aws/amazon-linux-2023-a-cloud-optimized-linux-distribution-with-long-term-support/) the change also makes Amazon Linux >= 2023 it's own platform moving forward, while Amazon Linux 1 & 2 use the previously used platforms (el-6 and el-7).

Specifically noting:

> Amazon Linux 2023 isn’t directly comparable to any specific Fedora release. The Amazon Linux 2023 GA version includes components from [Fedora 34, 35, and 36](https://getfedora.org/en/server/download/). Some of the components are the same as the components in Fedora, and some are modified. Other components more closely resemble the components in [CentOS Stream 9](https://centos.org/stream9/) or were developed independently. The Amazon Linux kernel, on its side, is sourced from [the long-term support options that are on ](https://www.kernel.org/category/releases.html)[kernel.org](http://kernel.org/)[,](https://www.kernel.org/category/releases.html) chosen independently from the kernel provided by Fedora.
