### PR TITLE
Use the safe operator to avoid crashing

### DIFF
--- a/lib/beaker-hostgenerator/hypervisor/abs.rb
+++ b/lib/beaker-hostgenerator/hypervisor/abs.rb
@@ -24,7 +24,7 @@ module BeakerHostGenerator
 
         case node_info['ostype']
         when /^(almalinux|centos|oracle|redhat|rocky|scientific)/
-          base_config['template'] ||= base_config['platform'].gsub(/^el/, ::Regexp.last_match(1))
+          base_config['template'] ||= base_config['platform']&.gsub(/^el/, ::Regexp.last_match(1))
         when /^amazon/, /^fedora/, /^opensuse/, /^panos/
           base_config['template'] ||= base_config['platform']
         when /^(debian|ubuntu)/

--- a/lib/beaker-hostgenerator/hypervisor/vmpooler.rb
+++ b/lib/beaker-hostgenerator/hypervisor/vmpooler.rb
@@ -19,7 +19,7 @@ module BeakerHostGenerator
 
         case node_info['ostype']
         when /^(almalinux|centos|oracle|redhat|rocky|scientific)/
-          base_config['template'] ||= base_config['platform'].gsub(/^el/, ::Regexp.last_match(1))
+          base_config['template'] ||= base_config['platform']&.gsub(/^el/, ::Regexp.last_match(1))
         when /^fedora/, /^opensuse/, /^panos/
           base_config['template'] ||= base_config['platform']
         when /^(debian|ubuntu)/


### PR DESCRIPTION
When passing an unknown hostspec the platform is unknown. Using the safe operator avoids calling nil.gsub