### PR TITLE
Add aix73-power

### DIFF
--- a/lib/beaker-hostgenerator/data.rb
+++ b/lib/beaker-hostgenerator/data.rb
@@ -1066,6 +1066,9 @@ module BeakerHostGenerator
 
     # @api private
     def generate_osinfo
+      # AIX
+      yield %w[aix73-POWER aix-7.3-power]
+
       # Fedora
       (19..38).each do |release|
         # 32 bit support was dropped in Fedora 31

--- a/lib/beaker-hostgenerator/hypervisor/abs.rb
+++ b/lib/beaker-hostgenerator/hypervisor/abs.rb
@@ -25,7 +25,7 @@ module BeakerHostGenerator
         case node_info['ostype']
         when /^(almalinux|centos|oracle|redhat|rocky|scientific)/
           base_config['template'] ||= base_config['platform']&.gsub(/^el/, ::Regexp.last_match(1))
-        when /^amazon/, /^fedora/, /^opensuse/, /^panos/
+        when /^aix/, /^amazon/, /^fedora/, /^opensuse/, /^panos/
           base_config['template'] ||= base_config['platform']
         when /^(debian|ubuntu)/
           os = Regexp.last_match(1)

--- a/test/fixtures/generated/default/aix73-POWERa
+++ b/test/fixtures/generated/default/aix73-POWERa
@@ -1,0 +1,13 @@
+---
+arguments_string: aix73-POWERa
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    aix73-POWER-1:
+      platform: aix-7.3-power
+      hypervisor: vmpooler
+      roles:
+      - agent
+  CONFIG:
+    pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
+expected_exception:

--- a/test/fixtures/generated/multiplatform/aix73-POWERa-archlinux-64-aix73-POWERaulcdfm
+++ b/test/fixtures/generated/multiplatform/aix73-POWERa-archlinux-64-aix73-POWERaulcdfm
@@ -1,0 +1,29 @@
+---
+arguments_string: aix73-POWERa-archlinux-64-aix73-POWERaulcdfm
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    aix73-POWER-1:
+      platform: aix-7.3-power
+      hypervisor: vmpooler
+      roles:
+      - agent
+    archlinux-64-1:
+      platform: archlinux-rolling-x64
+      hypervisor: vmpooler
+      roles:
+      - agent
+    aix73-POWER-2:
+      platform: aix-7.3-power
+      hypervisor: vmpooler
+      roles:
+      - agent
+      - ca
+      - classifier
+      - dashboard
+      - database
+      - frictionless
+      - master
+  CONFIG:
+    pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
+expected_exception:

--- a/test/fixtures/generated/multiplatform/archlinux-64f-aix73-POWER-archlinux-64l
+++ b/test/fixtures/generated/multiplatform/archlinux-64f-aix73-POWER-archlinux-64l
@@ -1,0 +1,25 @@
+---
+arguments_string: archlinux-64f-aix73-POWER-archlinux-64l
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    archlinux-64-1:
+      platform: archlinux-rolling-x64
+      hypervisor: vmpooler
+      roles:
+      - agent
+      - frictionless
+    aix73-POWER-1:
+      platform: aix-7.3-power
+      hypervisor: vmpooler
+      roles:
+      - agent
+    archlinux-64-2:
+      platform: archlinux-rolling-x64
+      hypervisor: vmpooler
+      roles:
+      - agent
+      - classifier
+  CONFIG:
+    pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
+expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/aix73-POWERa
+++ b/test/fixtures/generated/osinfo-version-0/aix73-POWERa
@@ -1,0 +1,13 @@
+---
+arguments_string: "--osinfo-version 0 aix73-POWERa"
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    aix73-POWER-1:
+      platform: aix-7.3-power
+      hypervisor: vmpooler
+      roles:
+      - agent
+  CONFIG:
+    pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
+expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/aix73-POWERa
+++ b/test/fixtures/generated/osinfo-version-1/aix73-POWERa
@@ -1,0 +1,13 @@
+---
+arguments_string: "--osinfo-version 1 aix73-POWERa"
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    aix73-POWER-1:
+      platform: aix-7.3-power
+      hypervisor: vmpooler
+      roles:
+      - agent
+  CONFIG:
+    pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
+expected_exception:


### PR DESCRIPTION
It's worth noting that I intentionally left off the `packaging_platform` value override for 7.3 that was previously done for 7.2. I think that the packaging platform should default to same version, but if it needs overridden, then that can simply be done at build time.