### PR TITLE
Add redhat9-power

### DIFF
--- a/lib/beaker-hostgenerator/data.rb
+++ b/lib/beaker-hostgenerator/data.rb
@@ -382,6 +382,14 @@ module BeakerHostGenerator
                           'template' => 'redhat-9-arm64',
                         },
                       },
+                      'redhat9-POWER' => {
+                        general: {
+                          'platform' => 'el-9-ppc64le',
+                        },
+                        abs: {
+                          'template' => 'redhat-9-power',
+                        },
+                      },
                       'sles11-32' => {
                         general: {
                           'platform' => 'sles-11-i386',

--- a/test/fixtures/generated/default/redhat9-POWERf
+++ b/test/fixtures/generated/default/redhat9-POWERf
@@ -1,0 +1,15 @@
+---
+arguments_string: redhat9-POWERf
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    redhat9-POWER-1:
+      platform: el-9-ppc64le
+      hypervisor: vmpooler
+      template: redhat-9-ppc64le
+      roles:
+      - agent
+      - frictionless
+  CONFIG:
+    pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
+expected_exception:

--- a/test/fixtures/generated/multiplatform/amazon6-64a-redhat9-POWER-amazon6-64aulcdfm
+++ b/test/fixtures/generated/multiplatform/amazon6-64a-redhat9-POWER-amazon6-64aulcdfm
@@ -1,0 +1,30 @@
+---
+arguments_string: amazon6-64a-redhat9-POWER-amazon6-64aulcdfm
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    amazon6-64-1:
+      platform: el-6-x86_64
+      hypervisor: vmpooler
+      roles:
+      - agent
+    redhat9-POWER-1:
+      platform: el-9-ppc64le
+      hypervisor: vmpooler
+      template: redhat-9-ppc64le
+      roles:
+      - agent
+    amazon6-64-2:
+      platform: el-6-x86_64
+      hypervisor: vmpooler
+      roles:
+      - agent
+      - ca
+      - classifier
+      - dashboard
+      - database
+      - frictionless
+      - master
+  CONFIG:
+    pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
+expected_exception:

--- a/test/fixtures/generated/multiplatform/redhat9-POWERf-amazon6-64-redhat9-POWERl
+++ b/test/fixtures/generated/multiplatform/redhat9-POWERf-amazon6-64-redhat9-POWERl
@@ -1,0 +1,27 @@
+---
+arguments_string: redhat9-POWERf-amazon6-64-redhat9-POWERl
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    redhat9-POWER-1:
+      platform: el-9-ppc64le
+      hypervisor: vmpooler
+      template: redhat-9-ppc64le
+      roles:
+      - agent
+      - frictionless
+    amazon6-64-1:
+      platform: el-6-x86_64
+      hypervisor: vmpooler
+      roles:
+      - agent
+    redhat9-POWER-2:
+      platform: el-9-ppc64le
+      hypervisor: vmpooler
+      template: redhat-9-ppc64le
+      roles:
+      - agent
+      - classifier
+  CONFIG:
+    pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
+expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/redhat9-POWERf
+++ b/test/fixtures/generated/osinfo-version-0/redhat9-POWERf
@@ -1,0 +1,15 @@
+---
+arguments_string: "--osinfo-version 0 redhat9-POWERf"
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    redhat9-POWER-1:
+      platform: el-9-ppc64le
+      hypervisor: vmpooler
+      template: redhat-9-ppc64le
+      roles:
+      - agent
+      - frictionless
+  CONFIG:
+    pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
+expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/redhat9-POWERf
+++ b/test/fixtures/generated/osinfo-version-1/redhat9-POWERf
@@ -1,0 +1,15 @@
+---
+arguments_string: "--osinfo-version 1 redhat9-POWERf"
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    redhat9-POWER-1:
+      platform: el-9-ppc64le
+      hypervisor: vmpooler
+      template: redhat-9-ppc64le
+      roles:
+      - agent
+      - frictionless
+  CONFIG:
+    pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
+expected_exception:


### PR DESCRIPTION
It's worth noting that I intentionally left off the CPU generation for the `template` value starting with RHEL9 on Power. This aligns with the format used for AIX, plus we don't specify multiple CPU generations for any vendor/architecture.