### PR TITLE
Add osx14-64 and osx14-ARM64 support

### DIFF
--- a/lib/beaker-hostgenerator/data.rb
+++ b/lib/beaker-hostgenerator/data.rb
@@ -1134,6 +1134,9 @@ module BeakerHostGenerator
         yield ["opensuse#{release}-32", "opensuse-#{release}-i386"]
         yield ["opensuse#{release}-64", "opensuse-#{release}-x86_64"]
       end
+
+      # macOS
+      yield %w[osx14-64 osx-14-x86_64]
     end
   end
 end

--- a/lib/beaker-hostgenerator/data.rb
+++ b/lib/beaker-hostgenerator/data.rb
@@ -1137,6 +1137,7 @@ module BeakerHostGenerator
 
       # macOS
       yield %w[osx14-64 osx-14-x86_64]
+      yield %w[osx14-ARM64 osx-14-arm64]
     end
   end
 end

--- a/lib/beaker-hostgenerator/hypervisor/abs.rb
+++ b/lib/beaker-hostgenerator/hypervisor/abs.rb
@@ -44,6 +44,8 @@ module BeakerHostGenerator
                    raise "Unknown bits '#{node_info['bits']}' for '#{node_info['ostype']}'"
                  end
           base_config['template'] ||= "#{base_template}-#{arch}"
+        when /^osx/
+          base_config['template'] ||= base_config['platform']&.gsub(/^osx/, 'macos')
         end
 
         base_config

--- a/test/fixtures/generated/default/osx14-64aulcdfm
+++ b/test/fixtures/generated/default/osx14-64aulcdfm
@@ -1,0 +1,19 @@
+---
+arguments_string: osx14-64aulcdfm
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    osx14-64-1:
+      platform: osx-14-x86_64
+      hypervisor: vmpooler
+      roles:
+      - agent
+      - ca
+      - classifier
+      - dashboard
+      - database
+      - frictionless
+      - master
+  CONFIG:
+    pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
+expected_exception:

--- a/test/fixtures/generated/default/osx14-ARM64a
+++ b/test/fixtures/generated/default/osx14-ARM64a
@@ -1,0 +1,13 @@
+---
+arguments_string: osx14-ARM64a
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    osx14-ARM64-1:
+      platform: osx-14-arm64
+      hypervisor: vmpooler
+      roles:
+      - agent
+  CONFIG:
+    pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
+expected_exception:

--- a/test/fixtures/generated/multiplatform/osx14-64aulcdfm-sles11-32-osx14-64a
+++ b/test/fixtures/generated/multiplatform/osx14-64aulcdfm-sles11-32-osx14-64a
@@ -1,0 +1,30 @@
+---
+arguments_string: osx14-64aulcdfm-sles11-32-osx14-64a
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    osx14-64-1:
+      platform: osx-14-x86_64
+      hypervisor: vmpooler
+      roles:
+      - agent
+      - ca
+      - classifier
+      - dashboard
+      - database
+      - frictionless
+      - master
+    sles11-32-1:
+      platform: sles-11-i386
+      template: sles-11-i386
+      hypervisor: vmpooler
+      roles:
+      - agent
+    osx14-64-2:
+      platform: osx-14-x86_64
+      hypervisor: vmpooler
+      roles:
+      - agent
+  CONFIG:
+    pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
+expected_exception:

--- a/test/fixtures/generated/multiplatform/osx14-ARM64a-redhat9-POWER-osx14-ARM64aulcdfm
+++ b/test/fixtures/generated/multiplatform/osx14-ARM64a-redhat9-POWER-osx14-ARM64aulcdfm
@@ -1,0 +1,30 @@
+---
+arguments_string: osx14-ARM64a-redhat9-POWER-osx14-ARM64aulcdfm
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    osx14-ARM64-1:
+      platform: osx-14-arm64
+      hypervisor: vmpooler
+      roles:
+      - agent
+    redhat9-POWER-1:
+      platform: el-9-ppc64le
+      hypervisor: vmpooler
+      template: redhat-9-ppc64le
+      roles:
+      - agent
+    osx14-ARM64-2:
+      platform: osx-14-arm64
+      hypervisor: vmpooler
+      roles:
+      - agent
+      - ca
+      - classifier
+      - dashboard
+      - database
+      - frictionless
+      - master
+  CONFIG:
+    pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
+expected_exception:

--- a/test/fixtures/generated/multiplatform/redhat9-POWERa-osx14-ARM64-redhat9-POWERaulcdfm
+++ b/test/fixtures/generated/multiplatform/redhat9-POWERa-osx14-ARM64-redhat9-POWERaulcdfm
@@ -1,0 +1,31 @@
+---
+arguments_string: redhat9-POWERa-osx14-ARM64-redhat9-POWERaulcdfm
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    redhat9-POWER-1:
+      platform: el-9-ppc64le
+      hypervisor: vmpooler
+      template: redhat-9-ppc64le
+      roles:
+      - agent
+    osx14-ARM64-1:
+      platform: osx-14-arm64
+      hypervisor: vmpooler
+      roles:
+      - agent
+    redhat9-POWER-2:
+      platform: el-9-ppc64le
+      hypervisor: vmpooler
+      template: redhat-9-ppc64le
+      roles:
+      - agent
+      - ca
+      - classifier
+      - dashboard
+      - database
+      - frictionless
+      - master
+  CONFIG:
+    pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
+expected_exception:

--- a/test/fixtures/generated/multiplatform/sles11-32a-osx14-64-sles11-32aulcdfm
+++ b/test/fixtures/generated/multiplatform/sles11-32a-osx14-64-sles11-32aulcdfm
@@ -1,0 +1,31 @@
+---
+arguments_string: sles11-32a-osx14-64-sles11-32aulcdfm
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    sles11-32-1:
+      platform: sles-11-i386
+      template: sles-11-i386
+      hypervisor: vmpooler
+      roles:
+      - agent
+    osx14-64-1:
+      platform: osx-14-x86_64
+      hypervisor: vmpooler
+      roles:
+      - agent
+    sles11-32-2:
+      platform: sles-11-i386
+      template: sles-11-i386
+      hypervisor: vmpooler
+      roles:
+      - agent
+      - ca
+      - classifier
+      - dashboard
+      - database
+      - frictionless
+      - master
+  CONFIG:
+    pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
+expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/osx14-64aulcdfm
+++ b/test/fixtures/generated/osinfo-version-0/osx14-64aulcdfm
@@ -1,0 +1,19 @@
+---
+arguments_string: "--osinfo-version 0 osx14-64aulcdfm"
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    osx14-64-1:
+      platform: osx-14-x86_64
+      hypervisor: vmpooler
+      roles:
+      - agent
+      - ca
+      - classifier
+      - dashboard
+      - database
+      - frictionless
+      - master
+  CONFIG:
+    pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
+expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/osx14-ARM64a
+++ b/test/fixtures/generated/osinfo-version-0/osx14-ARM64a
@@ -1,0 +1,13 @@
+---
+arguments_string: "--osinfo-version 0 osx14-ARM64a"
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    osx14-ARM64-1:
+      platform: osx-14-arm64
+      hypervisor: vmpooler
+      roles:
+      - agent
+  CONFIG:
+    pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
+expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/osx14-64aulcdfm
+++ b/test/fixtures/generated/osinfo-version-1/osx14-64aulcdfm
@@ -1,0 +1,19 @@
+---
+arguments_string: "--osinfo-version 1 osx14-64aulcdfm"
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    osx14-64-1:
+      platform: osx-14-x86_64
+      hypervisor: vmpooler
+      roles:
+      - agent
+      - ca
+      - classifier
+      - dashboard
+      - database
+      - frictionless
+      - master
+  CONFIG:
+    pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
+expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/osx14-ARM64a
+++ b/test/fixtures/generated/osinfo-version-1/osx14-ARM64a
@@ -1,0 +1,13 @@
+---
+arguments_string: "--osinfo-version 1 osx14-ARM64a"
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    osx14-ARM64-1:
+      platform: osx-14-arm64
+      hypervisor: vmpooler
+      roles:
+      - agent
+  CONFIG:
+    pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
+expected_exception:


### PR DESCRIPTION
Of note, starting with osx14 the macos os data is added to `generate_osinfo`, so the `template` key is not present using the default vmpooler hypervisor. The `template` key for osx/macos is now set appropriately in the abs hypervisor. os data for previous osx versions is unchanged.