### PR TITLE
explicitly install cronie on EL8+

### DIFF
--- a/lib/beaker-hostgenerator/hypervisor/docker.rb
+++ b/lib/beaker-hostgenerator/hypervisor/docker.rb
@@ -77,7 +77,7 @@ module BeakerHostGenerator
 
       def el_package_install_command(version)
         if version >= 8
-          'dnf install -y crontabs initscripts iproute openssl wget which glibc-langpack-en hostname'
+          'dnf install -y cronie crontabs initscripts iproute openssl wget which glibc-langpack-en hostname'
         else
           'yum install -y crontabs initscripts iproute openssl wget which sysvinit-tools tar ss'
         end


### PR DESCRIPTION
cronie is a weak dependency of crontabs, and while CentOS and RHEL install weak dependencies by default, other EL systems do not (so much for compatibility, huh?).

install cronie explicitly, to avoid "Could not find a suitable provider for cron" errors on those EL systems.