### PR TITLE
(PA-5948) Update host generator to use aarch64 for amazon linux

### DIFF
--- a/lib/beaker-hostgenerator/data.rb
+++ b/lib/beaker-hostgenerator/data.rb
@@ -1111,7 +1111,7 @@ module BeakerHostGenerator
 
       # Amazon Linux
       yield %w[amazon2023-64 amazon-2023-x86_64]
-      yield %w[amazon2023-AARCH64 amazon-2023-arm64]
+      yield %w[amazon2023-AARCH64 amazon-2023-aarch64]
 
       # AlmaLinux and Rocky
       %w[almalinux rocky].each do |os|

--- a/lib/beaker-hostgenerator/hypervisor/abs.rb
+++ b/lib/beaker-hostgenerator/hypervisor/abs.rb
@@ -25,9 +25,9 @@ module BeakerHostGenerator
         case node_info['ostype']
         when /^(almalinux|centos|oracle|redhat|rocky|scientific)/
           base_config['template'] ||= base_config['platform']&.gsub(/^el/, ::Regexp.last_match(1))
-        when /^aix/, /^amazon/, /^fedora/, /^opensuse/, /^panos/
+        when /^aix/, /^fedora/, /^opensuse/, /^panos/
           base_config['template'] ||= base_config['platform']
-        when /^(debian|ubuntu)/
+        when /^(debian|ubuntu|amazon)/
           os = Regexp.last_match(1)
           base_template = node_info['ostype'].sub(os, "#{os}-")
           arch = case node_info['bits']

--- a/test/fixtures/generated/default/amazon2023-AARCH64aulcdfm
+++ b/test/fixtures/generated/default/amazon2023-AARCH64aulcdfm
@@ -4,7 +4,7 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     amazon2023-AARCH64-1:
-      platform: amazon-2023-arm64
+      platform: amazon-2023-aarch64
       hypervisor: vmpooler
       roles:
       - agent

--- a/test/fixtures/generated/multiplatform/amazon2023-AARCH64aulcdfm-solaris114-64-amazon2023-AARCH64a
+++ b/test/fixtures/generated/multiplatform/amazon2023-AARCH64aulcdfm-solaris114-64-amazon2023-AARCH64a
@@ -4,7 +4,7 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     amazon2023-AARCH64-1:
-      platform: amazon-2023-arm64
+      platform: amazon-2023-aarch64
       hypervisor: vmpooler
       roles:
       - agent
@@ -22,7 +22,7 @@ expected_hash:
       roles:
       - agent
     amazon2023-AARCH64-2:
-      platform: amazon-2023-arm64
+      platform: amazon-2023-aarch64
       hypervisor: vmpooler
       roles:
       - agent

--- a/test/fixtures/generated/multiplatform/solaris114-64f-amazon2023-AARCH64-solaris114-64l
+++ b/test/fixtures/generated/multiplatform/solaris114-64f-amazon2023-AARCH64-solaris114-64l
@@ -12,7 +12,7 @@ expected_hash:
       - agent
       - frictionless
     amazon2023-AARCH64-1:
-      platform: amazon-2023-arm64
+      platform: amazon-2023-aarch64
       hypervisor: vmpooler
       roles:
       - agent

--- a/test/fixtures/generated/osinfo-version-0/amazon2023-AARCH64aulcdfm
+++ b/test/fixtures/generated/osinfo-version-0/amazon2023-AARCH64aulcdfm
@@ -4,7 +4,7 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     amazon2023-AARCH64-1:
-      platform: amazon-2023-arm64
+      platform: amazon-2023-aarch64
       hypervisor: vmpooler
       roles:
       - agent

--- a/test/fixtures/generated/osinfo-version-1/amazon2023-AARCH64aulcdfm
+++ b/test/fixtures/generated/osinfo-version-1/amazon2023-AARCH64aulcdfm
@@ -4,7 +4,7 @@ environment_variables: {}
 expected_hash:
   HOSTS:
     amazon2023-AARCH64-1:
-      platform: amazon-2023-arm64
+      platform: amazon-2023-aarch64
       hypervisor: vmpooler
       roles:
       - agent


### PR DESCRIPTION
Updated data.rb in host-generator to use 'aarch64' like it is using everywhere in project