### PR TITLE
Use latest centos boxes instead of specific dates

### DIFF
--- a/lib/beaker-hostgenerator/data.rb
+++ b/lib/beaker-hostgenerator/data.rb
@@ -152,7 +152,7 @@ module BeakerHostGenerator
                         },
                         vagrant: {
                           'box' => 'centos/stream8',
-                          'box_url' => 'https://cloud.centos.org/centos/8-stream/x86_64/images/CentOS-Stream-Vagrant-8-20230501.0.x86_64.vagrant-libvirt.box',
+                          'box_url' => 'https://cloud.centos.org/centos/8-stream/x86_64/images/CentOS-Stream-Vagrant-8-latest.x86_64.vagrant-libvirt.box',
                         },
                       },
                       'centos9-64' => {
@@ -161,7 +161,7 @@ module BeakerHostGenerator
                         },
                         vagrant: {
                           'box' => 'centos/stream9',
-                          'box_url' => 'https://cloud.centos.org/centos/9-stream/x86_64/images/CentOS-Stream-Vagrant-9-20230410.0.x86_64.vagrant-libvirt.box',
+                          'box_url' => 'https://cloud.centos.org/centos/9-stream/x86_64/images/CentOS-Stream-Vagrant-9-latest.x86_64.vagrant-libvirt.box',
                         },
                       },
                       'debian10-64' => {


### PR DESCRIPTION
The centos/stream8 and centos/stream9 images are still not correct on Vagrant cloud, so it needs to be provided via a box_url. The centos/stream9 box URL is now a 404 so this changes it to latest.