### PR TITLE
Add beaker-hostgenerator support for redhatfips-9-x86_64

### DIFF
--- a/lib/beaker-hostgenerator/data.rb
+++ b/lib/beaker-hostgenerator/data.rb
@@ -371,6 +371,15 @@ module BeakerHostGenerator
                           'platform' => 'el-9-x86_64',
                         },
                       },
+                      'redhatfips9-64' => {
+                        general: {
+                          'platform' => 'el-9-x86_64',
+                          'packaging_platform' => 'redhatfips-9-x86_64',
+                        },
+                        vmpooler: {
+                          'template' => 'redhat-fips-9-x86_64',
+                        },
+                      },
                       'redhat9-AARCH64' => {
                         general: {
                           'platform' => 'el-9-aarch64',

--- a/test/fixtures/generated/default/redhatfips9-64a
+++ b/test/fixtures/generated/default/redhatfips9-64a
@@ -1,0 +1,15 @@
+---
+arguments_string: redhatfips9-64a
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    redhatfips9-64-1:
+      platform: el-9-x86_64
+      packaging_platform: redhatfips-9-x86_64
+      template: redhat-fips-9-x86_64
+      hypervisor: vmpooler
+      roles:
+      - agent
+  CONFIG:
+    pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
+expected_exception:

--- a/test/fixtures/generated/multiplatform/aix71-POWERl-redhatfips9-64-aix71-POWERf
+++ b/test/fixtures/generated/multiplatform/aix71-POWERl-redhatfips9-64-aix71-POWERf
@@ -1,0 +1,27 @@
+---
+arguments_string: aix71-POWERl-redhatfips9-64-aix71-POWERf
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    aix71-POWER-1:
+      platform: aix-7.1-power
+      hypervisor: vmpooler
+      roles:
+      - agent
+      - classifier
+    redhatfips9-64-1:
+      platform: el-9-x86_64
+      packaging_platform: redhatfips-9-x86_64
+      template: redhat-fips-9-x86_64
+      hypervisor: vmpooler
+      roles:
+      - agent
+    aix71-POWER-2:
+      platform: aix-7.1-power
+      hypervisor: vmpooler
+      roles:
+      - agent
+      - frictionless
+  CONFIG:
+    pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
+expected_exception:

--- a/test/fixtures/generated/multiplatform/redhatfips9-64a-aix71-POWER-redhatfips9-64aulcdfm
+++ b/test/fixtures/generated/multiplatform/redhatfips9-64a-aix71-POWER-redhatfips9-64aulcdfm
@@ -1,0 +1,33 @@
+---
+arguments_string: redhatfips9-64a-aix71-POWER-redhatfips9-64aulcdfm
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    redhatfips9-64-1:
+      platform: el-9-x86_64
+      packaging_platform: redhatfips-9-x86_64
+      template: redhat-fips-9-x86_64
+      hypervisor: vmpooler
+      roles:
+      - agent
+    aix71-POWER-1:
+      platform: aix-7.1-power
+      hypervisor: vmpooler
+      roles:
+      - agent
+    redhatfips9-64-2:
+      platform: el-9-x86_64
+      packaging_platform: redhatfips-9-x86_64
+      template: redhat-fips-9-x86_64
+      hypervisor: vmpooler
+      roles:
+      - agent
+      - ca
+      - classifier
+      - dashboard
+      - database
+      - frictionless
+      - master
+  CONFIG:
+    pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
+expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/redhatfips9-64a
+++ b/test/fixtures/generated/osinfo-version-0/redhatfips9-64a
@@ -1,0 +1,15 @@
+---
+arguments_string: "--osinfo-version 0 redhatfips9-64a"
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    redhatfips9-64-1:
+      platform: el-9-x86_64
+      packaging_platform: redhatfips-9-x86_64
+      template: redhat-fips-9-x86_64
+      hypervisor: vmpooler
+      roles:
+      - agent
+  CONFIG:
+    pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
+expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/redhatfips9-64a
+++ b/test/fixtures/generated/osinfo-version-1/redhatfips9-64a
@@ -1,0 +1,15 @@
+---
+arguments_string: "--osinfo-version 1 redhatfips9-64a"
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    redhatfips9-64-1:
+      platform: el-9-x86_64
+      packaging_platform: redhatfips-9-x86_64
+      template: redhat-fips-9-x86_64
+      hypervisor: vmpooler
+      roles:
+      - agent
+  CONFIG:
+    pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
+expected_exception:


### PR DESCRIPTION
- This PR adds support in beaker-hostgenerator for Redhat 9 fips image.