### PR TITLE
Update Amazon Linux 2 bindings

### DIFF
--- a/lib/beaker-hostgenerator/data.rb
+++ b/lib/beaker-hostgenerator/data.rb
@@ -114,22 +114,6 @@ module BeakerHostGenerator
                           'template' => 'amazon-6-x86_64',
                         },
                       },
-                      'amazon7-64' => {
-                        general: {
-                          'platform' => 'el-7-x86_64',
-                        },
-                        abs: {
-                          'template' => 'amazon-7-x86_64',
-                        },
-                      },
-                      'amazon7-ARM64' => {
-                        general: {
-                          'platform' => 'el-7-aarch64',
-                        },
-                        abs: {
-                          'template' => 'amazon-7-arm64',
-                        },
-                      },
                       'archlinuxrolling-64' => {
                         general: {
                           'platform' => 'archlinux-rolling-x64',
@@ -1129,6 +1113,8 @@ module BeakerHostGenerator
       end
 
       # Amazon Linux
+      yield %w[amazon7-64 amazon-7-x86_64]
+      yield %w[amazon7-AARCH64 amazon-7-aarch64]
       yield %w[amazon2023-64 amazon-2023-x86_64]
       yield %w[amazon2023-AARCH64 amazon-2023-aarch64]
 


### PR DESCRIPTION
Previously, Puppet tested Red Hat Enterprise Linux 7 packages against Amazon Linux 2, assuming they were binary-compatible. This commit updates beaker-hostgenerator to map AL2 packages to AL2 testing machines. (Note: AL2 is referred to in Vanagon and ABS as Amazon Linux 7, in reference to the assumed compatibility with RHEL7).