### PR TITLE
Use Red Hat 7 for Amazon Linux 2 x86_64

### DIFF
--- a/lib/beaker-hostgenerator/data.rb
+++ b/lib/beaker-hostgenerator/data.rb
@@ -114,6 +114,14 @@ module BeakerHostGenerator
                           'template' => 'amazon-6-x86_64',
                         },
                       },
+                      'amazon7-64' => {
+                        general: {
+                          'platform' => 'el-7-x86_64',
+                        },
+                        abs: {
+                          'template' => 'amazon-7-x86_64',
+                        },
+                      },
                       'archlinuxrolling-64' => {
                         general: {
                           'platform' => 'archlinux-rolling-x64',


### PR DESCRIPTION
In 4112690, I mapped Amazon Linux 2 (both x86_64 and AARCH64) to their respective ABS/Vanagon targets. This was incorrect, as AL2 x86_64 is still built on Red Hat Enterprise Linux 7.

This commit partially reverts that change and re-adds AL2 x86_64 to be built on RHEL 7.