### PR TITLE
Add Amazon 2

### DIFF
--- a/lib/beaker-hostgenerator/data.rb
+++ b/lib/beaker-hostgenerator/data.rb
@@ -122,6 +122,14 @@ module BeakerHostGenerator
                           'template' => 'amazon-7-x86_64',
                         },
                       },
+                      'amazon2-AARCH64' => {
+                        general: {
+                          'platform' => 'amazon-2-aarch64',
+                        },
+                        abs: {
+                          'template' => 'amazon-7-arm64',
+                        },
+                      },
                       'archlinuxrolling-64' => {
                         general: {
                           'platform' => 'archlinux-rolling-x64',
@@ -1123,6 +1131,7 @@ module BeakerHostGenerator
       # Amazon Linux
       yield %w[amazon7-64 amazon-7-x86_64]
       yield %w[amazon7-AARCH64 amazon-7-aarch64]
+      yield %w[amazon2-AARCH64 amazon-2-aarch64]
       yield %w[amazon2023-64 amazon-2023-x86_64]
       yield %w[amazon2023-AARCH64 amazon-2023-aarch64]
 

--- a/test/fixtures/generated/default/amazon2-AARCH64f
+++ b/test/fixtures/generated/default/amazon2-AARCH64f
@@ -1,0 +1,14 @@
+---
+arguments_string: amazon2-AARCH64f
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    amazon2-AARCH64-1:
+      platform: amazon-2-aarch64
+      hypervisor: vmpooler
+      roles:
+      - agent
+      - frictionless
+  CONFIG:
+    pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
+expected_exception: 

--- a/test/fixtures/generated/default/amazon2-AARCH64m
+++ b/test/fixtures/generated/default/amazon2-AARCH64m
@@ -1,0 +1,14 @@
+---
+arguments_string: amazon2-AARCH64m
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    amazon2-AARCH64-1:
+      platform: amazon-2-aarch64
+      hypervisor: vmpooler
+      roles:
+      - agent
+      - master
+  CONFIG:
+    pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
+expected_exception: 

--- a/test/fixtures/generated/multiplatform/amazon2-AARCH64f-solaris11-64-amazon2-AARCH64l
+++ b/test/fixtures/generated/multiplatform/amazon2-AARCH64f-solaris11-64-amazon2-AARCH64l
@@ -1,0 +1,26 @@
+---
+arguments_string: amazon2-AARCH64f-solaris11-64-amazon2-AARCH64l
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    amazon2-AARCH64-1:
+      platform: amazon-2-aarch64
+      hypervisor: vmpooler
+      roles:
+      - agent
+      - frictionless
+    solaris11-64-1:
+      platform: solaris-11-i386
+      template: solaris-11-x86_64
+      hypervisor: vmpooler
+      roles:
+      - agent
+    amazon2-AARCH64-2:
+      platform: amazon-2-aarch64
+      hypervisor: vmpooler
+      roles:
+      - agent
+      - classifier
+  CONFIG:
+    pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
+expected_exception: 

--- a/test/fixtures/generated/multiplatform/amazon2-AARCH64m-solaris11-32-amazon2-AARCH64u
+++ b/test/fixtures/generated/multiplatform/amazon2-AARCH64m-solaris11-32-amazon2-AARCH64u
@@ -1,0 +1,26 @@
+---
+arguments_string: amazon2-AARCH64m-solaris11-32-amazon2-AARCH64u
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    amazon2-AARCH64-1:
+      platform: amazon-2-aarch64
+      hypervisor: vmpooler
+      roles:
+      - agent
+      - master
+    solaris11-32-1:
+      platform: solaris-11-i386
+      template: solaris-11-x86_64
+      hypervisor: vmpooler
+      roles:
+      - agent
+    amazon2-AARCH64-2:
+      platform: amazon-2-aarch64
+      hypervisor: vmpooler
+      roles:
+      - agent
+      - ca
+  CONFIG:
+    pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
+expected_exception: 

--- a/test/fixtures/generated/multiplatform/solaris11-32l-amazon2-AARCH64-solaris11-32f
+++ b/test/fixtures/generated/multiplatform/solaris11-32l-amazon2-AARCH64-solaris11-32f
@@ -1,0 +1,27 @@
+---
+arguments_string: solaris11-32l-amazon2-AARCH64-solaris11-32f
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    solaris11-32-1:
+      platform: solaris-11-i386
+      template: solaris-11-x86_64
+      hypervisor: vmpooler
+      roles:
+      - agent
+      - classifier
+    amazon2-AARCH64-1:
+      platform: amazon-2-aarch64
+      hypervisor: vmpooler
+      roles:
+      - agent
+    solaris11-32-2:
+      platform: solaris-11-i386
+      template: solaris-11-x86_64
+      hypervisor: vmpooler
+      roles:
+      - agent
+      - frictionless
+  CONFIG:
+    pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
+expected_exception: 

--- a/test/fixtures/generated/multiplatform/solaris11-64d-amazon2-AARCH64-solaris11-64c
+++ b/test/fixtures/generated/multiplatform/solaris11-64d-amazon2-AARCH64-solaris11-64c
@@ -1,0 +1,27 @@
+---
+arguments_string: solaris11-64d-amazon2-AARCH64-solaris11-64c
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    solaris11-64-1:
+      platform: solaris-11-i386
+      template: solaris-11-x86_64
+      hypervisor: vmpooler
+      roles:
+      - agent
+      - database
+    amazon2-AARCH64-1:
+      platform: amazon-2-aarch64
+      hypervisor: vmpooler
+      roles:
+      - agent
+    solaris11-64-2:
+      platform: solaris-11-i386
+      template: solaris-11-x86_64
+      hypervisor: vmpooler
+      roles:
+      - agent
+      - dashboard
+  CONFIG:
+    pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
+expected_exception: 

--- a/test/fixtures/generated/osinfo-version-0/amazon2-AARCH64f
+++ b/test/fixtures/generated/osinfo-version-0/amazon2-AARCH64f
@@ -1,0 +1,14 @@
+---
+arguments_string: "--osinfo-version 0 amazon2-AARCH64f"
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    amazon2-AARCH64-1:
+      platform: amazon-2-aarch64
+      hypervisor: vmpooler
+      roles:
+      - agent
+      - frictionless
+  CONFIG:
+    pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
+expected_exception: 

--- a/test/fixtures/generated/osinfo-version-0/amazon2-AARCH64m
+++ b/test/fixtures/generated/osinfo-version-0/amazon2-AARCH64m
@@ -1,0 +1,14 @@
+---
+arguments_string: "--osinfo-version 0 amazon2-AARCH64m"
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    amazon2-AARCH64-1:
+      platform: amazon-2-aarch64
+      hypervisor: vmpooler
+      roles:
+      - agent
+      - master
+  CONFIG:
+    pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
+expected_exception: 

--- a/test/fixtures/generated/osinfo-version-1/amazon2-AARCH64f
+++ b/test/fixtures/generated/osinfo-version-1/amazon2-AARCH64f
@@ -1,0 +1,14 @@
+---
+arguments_string: "--osinfo-version 1 amazon2-AARCH64f"
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    amazon2-AARCH64-1:
+      platform: amazon-2-aarch64
+      hypervisor: vmpooler
+      roles:
+      - agent
+      - frictionless
+  CONFIG:
+    pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
+expected_exception: 

--- a/test/fixtures/generated/osinfo-version-1/amazon2-AARCH64m
+++ b/test/fixtures/generated/osinfo-version-1/amazon2-AARCH64m
@@ -1,0 +1,14 @@
+---
+arguments_string: "--osinfo-version 1 amazon2-AARCH64m"
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    amazon2-AARCH64-1:
+      platform: amazon-2-aarch64
+      hypervisor: vmpooler
+      roles:
+      - agent
+      - master
+  CONFIG:
+    pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
+expected_exception: 


### PR DESCRIPTION
Amazon 7 is an implementation detail, the actual OS is Amazon 2:
https://aws.amazon.com/amazon-linux-2 This adds a new target amazon2-AARCH64,
whose ABS template remains the same (amazon-7-aarch64), but platform is
different:

    ❯ bundle exec beaker-hostgenerator amazon2-AARCH64a --hypervisor abs
    ---
    HOSTS:
      amazon2-AARCH64-1:
        platform: amazon-2-aarch64
        template: amazon-7-arm64
        hypervisor: abs
        roles:
        - agent
    CONFIG: {}

    ❯ bundle exec beaker-hostgenerator amazon7-AARCH64a --hypervisor abs
    ---
    HOSTS:
      amazon7-AARCH64-1:
        platform: amazon-7-aarch64
        hypervisor: abs
        template: amazon-7-arm64
        roles:
        - agent
    CONFIG: {}

The `template` is what we request from ABS. The `platform` is what beaker uses
when constructing `Beaker::Platform.new` and allows tests to introspect the
platform they're running on, such as `if host.platform =~ /amazon-/`

```
❯ env | grep BEAKER                                                                                     
BEAKER_VERSION=https://github.com/voxpupuli/beaker#amazon2
BEAKER_PUPPET_VERSION=~> 4.0
BEAKER_HOSTGENERATOR_VERSION=https://github.com/voxpupuli/beaker-hostgenerator#amazon2
❯ cd ~/work/facter/acceptance
❯ bundle update
❯ env SHA=c6c5de5b1457d0cad36bcbb0ee94ec3c3486014d HOSTS=amazon2-AARCH64a bundle exec rake ci:test:setup

  17:32:52$ yum -y  install puppet-agent

...SNIP...

     Dependencies Resolved
    
    ================================================================================
     Package
         Arch    Version
                     Repository                                                Size
    ================================================================================
    Installing:
     puppet-agent
         aarch64 8.6.0.96.gc6c5de5b1-1.amazon2
                     pl-puppet-agent-c6c5de5b1457d0cad36bcbb0ee94ec3c3486014d  26 M
    
    Transaction Summary
    ================================================================================
    Install  1 Package
    Total download size: 26 M
    Installed size: 122 M
    Downloading packages:
    Running transaction check
    Running transaction test
    Transaction test succeeded
    Running transaction
      Installing : puppet-agent-8.6.0.96.gc6c5de5b1-1.amazon2.aarch64           1/1     
      Verifying  : puppet-agent-8.6.0.96.gc6c5de5b1-1.amazon2.aarch64           1/1     
    
    Installed:
      puppet-agent.aarch64 0:8.6.0.96.gc6c5de5b1-1.amazon2                          
    Complete!
```