### PR TITLE
Fix template name for rocky9 and almalinux9 arm

### DIFF
--- a/lib/beaker-hostgenerator/data.rb
+++ b/lib/beaker-hostgenerator/data.rb
@@ -391,6 +391,48 @@ module BeakerHostGenerator
                           'template' => 'redhat-9-arm64',
                         },
                       },
+                      'rocky8-64' => {
+                        general: {
+                          'platform' => 'el-8-x86_64',
+                        },
+                      },
+                      'rocky9-64' => {
+                        general: {
+                          'platform' => 'el-9-x86_64',
+                        },
+                      },
+                      'rocky9-AARCH64' => {
+                        general: {
+                          'platform' => 'el-9-aarch64',
+                        },
+                        abs: {
+                          'template' => 'rocky-9-arm64',
+                        },
+                        vmpooler: {
+                          'template' => 'rocky-9-arm64',
+                        },
+                      },
+                      'almalinux8-64' => {
+                        general: {
+                          'platform' => 'el-8-x86_64',
+                        },
+                      },
+                      'almalinux9-64' => {
+                        general: {
+                          'platform' => 'el-9-x86_64',
+                        },
+                      },
+                      'almalinux9-AARCH64' => {
+                        general: {
+                          'platform' => 'el-9-aarch64',
+                        },
+                        abs: {
+                          'template' => 'almalinux-9-arm64',
+                        },
+                        vmpooler: {
+                          'template' => 'almalinux-9-arm64',
+                        },
+                      },
                       'redhat9-POWER' => {
                         general: {
                           'platform' => 'el-9-ppc64le',
@@ -1134,14 +1176,6 @@ module BeakerHostGenerator
       yield %w[amazon2-AARCH64 amazon-2-aarch64]
       yield %w[amazon2023-64 amazon-2023-x86_64]
       yield %w[amazon2023-AARCH64 amazon-2023-aarch64]
-
-      # AlmaLinux and Rocky
-      %w[almalinux rocky].each do |os|
-        (8..9).each do |release|
-          yield ["#{os}#{release}-64", "el-#{release}-x86_64"]
-          yield ["#{os}#{release}-AARCH64", "el-#{release}-aarch64"]
-        end
-      end
 
       # Oracle / OracleLinux
       yield ['oracle6-32', 'el-6-i386']

--- a/test/fixtures/generated/default/almalinux9-AARCH64d
+++ b/test/fixtures/generated/default/almalinux9-AARCH64d
@@ -6,7 +6,7 @@ expected_hash:
     almalinux9-AARCH64-1:
       platform: el-9-aarch64
       hypervisor: vmpooler
-      template: almalinux-9-aarch64
+      template: almalinux-9-arm64
       roles:
       - agent
       - database

--- a/test/fixtures/generated/default/rocky9-AARCH64a
+++ b/test/fixtures/generated/default/rocky9-AARCH64a
@@ -6,7 +6,7 @@ expected_hash:
     rocky9-AARCH64-1:
       platform: el-9-aarch64
       hypervisor: vmpooler
-      template: rocky-9-aarch64
+      template: rocky-9-arm64
       roles:
       - agent
   CONFIG:

--- a/test/fixtures/generated/multiplatform/almalinux9-AARCH64d-sles12-S390X-almalinux9-AARCH64c
+++ b/test/fixtures/generated/multiplatform/almalinux9-AARCH64d-sles12-S390X-almalinux9-AARCH64c
@@ -6,7 +6,7 @@ expected_hash:
     almalinux9-AARCH64-1:
       platform: el-9-aarch64
       hypervisor: vmpooler
-      template: almalinux-9-aarch64
+      template: almalinux-9-arm64
       roles:
       - agent
       - database
@@ -18,7 +18,7 @@ expected_hash:
     almalinux9-AARCH64-2:
       platform: el-9-aarch64
       hypervisor: vmpooler
-      template: almalinux-9-aarch64
+      template: almalinux-9-arm64
       roles:
       - agent
       - dashboard

--- a/test/fixtures/generated/multiplatform/rocky9-AARCH64a-sles11-32-rocky9-AARCH64aulcdfm
+++ b/test/fixtures/generated/multiplatform/rocky9-AARCH64a-sles11-32-rocky9-AARCH64aulcdfm
@@ -6,7 +6,7 @@ expected_hash:
     rocky9-AARCH64-1:
       platform: el-9-aarch64
       hypervisor: vmpooler
-      template: rocky-9-aarch64
+      template: rocky-9-arm64
       roles:
       - agent
     sles11-32-1:
@@ -18,7 +18,7 @@ expected_hash:
     rocky9-AARCH64-2:
       platform: el-9-aarch64
       hypervisor: vmpooler
-      template: rocky-9-aarch64
+      template: rocky-9-arm64
       roles:
       - agent
       - ca

--- a/test/fixtures/generated/multiplatform/sles11-32d-rocky9-AARCH64-sles11-32c
+++ b/test/fixtures/generated/multiplatform/sles11-32d-rocky9-AARCH64-sles11-32c
@@ -13,7 +13,7 @@ expected_hash:
     rocky9-AARCH64-1:
       platform: el-9-aarch64
       hypervisor: vmpooler
-      template: rocky-9-aarch64
+      template: rocky-9-arm64
       roles:
       - agent
     sles11-32-2:

--- a/test/fixtures/generated/multiplatform/sles12-S390Xa-almalinux9-AARCH64-sles12-S390Xaulcdfm
+++ b/test/fixtures/generated/multiplatform/sles12-S390Xa-almalinux9-AARCH64-sles12-S390Xaulcdfm
@@ -11,7 +11,7 @@ expected_hash:
     almalinux9-AARCH64-1:
       platform: el-9-aarch64
       hypervisor: vmpooler
-      template: almalinux-9-aarch64
+      template: almalinux-9-arm64
       roles:
       - agent
     sles12-S390X-2:

--- a/test/fixtures/generated/osinfo-version-0/almalinux9-AARCH64d
+++ b/test/fixtures/generated/osinfo-version-0/almalinux9-AARCH64d
@@ -6,7 +6,7 @@ expected_hash:
     almalinux9-AARCH64-1:
       platform: el-9-aarch64
       hypervisor: vmpooler
-      template: almalinux-9-aarch64
+      template: almalinux-9-arm64
       roles:
       - agent
       - database

--- a/test/fixtures/generated/osinfo-version-0/rocky9-AARCH64a
+++ b/test/fixtures/generated/osinfo-version-0/rocky9-AARCH64a
@@ -6,7 +6,7 @@ expected_hash:
     rocky9-AARCH64-1:
       platform: el-9-aarch64
       hypervisor: vmpooler
-      template: rocky-9-aarch64
+      template: rocky-9-arm64
       roles:
       - agent
   CONFIG:

--- a/test/fixtures/generated/osinfo-version-1/almalinux9-AARCH64d
+++ b/test/fixtures/generated/osinfo-version-1/almalinux9-AARCH64d
@@ -6,7 +6,7 @@ expected_hash:
     almalinux9-AARCH64-1:
       platform: el-9-aarch64
       hypervisor: vmpooler
-      template: almalinux-9-aarch64
+      template: almalinux-9-arm64
       roles:
       - agent
       - database

--- a/test/fixtures/generated/osinfo-version-1/rocky9-AARCH64a
+++ b/test/fixtures/generated/osinfo-version-1/rocky9-AARCH64a
@@ -6,7 +6,7 @@ expected_hash:
     rocky9-AARCH64-1:
       platform: el-9-aarch64
       hypervisor: vmpooler
-      template: rocky-9-aarch64
+      template: rocky-9-arm64
       roles:
       - agent
   CONFIG:


### PR DESCRIPTION
Current Behaviour: For Rocky 9 and Almalinux9 ARM we get template as `rocky-9-aarch64` and `almalinux-9-aarch64` respectively.

```
bundle exec beaker-hostgenerator redhat7-64m-rocky9-AARCH64a --hypervisor abs          
---
HOSTS:
  redhat7-64-1:
    platform: el-7-x86_64
    hypervisor: abs
    template: redhat-7-x86_64
    roles:
    - agent
    - master
  rocky9-AARCH64-1:
    platform: el-9-aarch64
    hypervisor: abs
    template: rocky-9-aarch64
    roles:
    - agent
CONFIG: {}
```


Expected behaviour: We need template name as `rocky-9-arm64` and `almalinux-9-arm64` to fetch VMs with ABS.

Result tested on local:

```
bundle exec beaker-hostgenerator --hypervisor abs redhat7-64m-almalinux9-AARCH64a-rocky9-AARCH64a
---
HOSTS:
  redhat7-64-1:
    platform: el-7-x86_64
    hypervisor: abs
    template: redhat-7-x86_64
    roles:
    - agent
    - master
  almalinux9-AARCH64-1:
    platform: el-9-aarch64
    hypervisor: abs
    template: almalinux-9-arm64
    roles:
    - agent
  rocky9-AARCH64-1:
    platform: el-9-aarch64
    hypervisor: abs
    template: rocky-9-arm64
    roles:
    - agent
CONFIG: {}
```
