### PR TITLE
Add support for windowsfips 2016 x64

### DIFF
--- a/lib/beaker-hostgenerator/data.rb
+++ b/lib/beaker-hostgenerator/data.rb
@@ -866,6 +866,16 @@ module BeakerHostGenerator
                           'locale' => 'fr',
                         },
                       },
+                      'windowsfips2016-64' => {
+                        general: {
+                          'platform' => 'windows-2016-64',
+                          'packaging_platform' => 'windowsfips-2016-x64',
+                          'ruby_arch' => 'x64',
+                        },
+                        vmpooler: {
+                          'template' => 'win-2016-fips-x86_64',
+                        },
+                      },
                       'windowsfips2016-6432' => {
                         general: {
                           'platform' => 'windows-2016-64',

--- a/test/fixtures/generated/default/windowsfips2016-64u
+++ b/test/fixtures/generated/default/windowsfips2016-64u
@@ -1,0 +1,17 @@
+---
+arguments_string: windowsfips2016-64u
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    windowsfips2016-64-1:
+      platform: windows-2016-64
+      packaging_platform: windowsfips-2016-x64
+      ruby_arch: x64
+      template: win-2016-fips-x86_64
+      hypervisor: vmpooler
+      roles:
+      - agent
+      - ca
+  CONFIG:
+    pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
+expected_exception:

--- a/test/fixtures/generated/multiplatform/fedora28-64d-windowsfips2016-64-fedora28-64c
+++ b/test/fixtures/generated/multiplatform/fedora28-64d-windowsfips2016-64-fedora28-64c
@@ -1,0 +1,30 @@
+---
+arguments_string: fedora28-64d-windowsfips2016-64-fedora28-64c
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    fedora28-64-1:
+      platform: fedora-28-x86_64
+      hypervisor: vmpooler
+      template: fedora-28-x86_64
+      roles:
+      - agent
+      - database
+    windowsfips2016-64-1:
+      platform: windows-2016-64
+      packaging_platform: windowsfips-2016-x64
+      ruby_arch: x64
+      template: win-2016-fips-x86_64
+      hypervisor: vmpooler
+      roles:
+      - agent
+    fedora28-64-2:
+      platform: fedora-28-x86_64
+      hypervisor: vmpooler
+      template: fedora-28-x86_64
+      roles:
+      - agent
+      - dashboard
+  CONFIG:
+    pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
+expected_exception:

--- a/test/fixtures/generated/multiplatform/windowsfips2016-64u-fedora28-64-windowsfips2016-64m
+++ b/test/fixtures/generated/multiplatform/windowsfips2016-64u-fedora28-64-windowsfips2016-64m
@@ -1,0 +1,32 @@
+---
+arguments_string: windowsfips2016-64u-fedora28-64-windowsfips2016-64m
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    windowsfips2016-64-1:
+      platform: windows-2016-64
+      packaging_platform: windowsfips-2016-x64
+      ruby_arch: x64
+      template: win-2016-fips-x86_64
+      hypervisor: vmpooler
+      roles:
+      - agent
+      - ca
+    fedora28-64-1:
+      platform: fedora-28-x86_64
+      hypervisor: vmpooler
+      template: fedora-28-x86_64
+      roles:
+      - agent
+    windowsfips2016-64-2:
+      platform: windows-2016-64
+      packaging_platform: windowsfips-2016-x64
+      ruby_arch: x64
+      template: win-2016-fips-x86_64
+      hypervisor: vmpooler
+      roles:
+      - agent
+      - master
+  CONFIG:
+    pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
+expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/windowsfips2016-64u
+++ b/test/fixtures/generated/osinfo-version-0/windowsfips2016-64u
@@ -1,0 +1,17 @@
+---
+arguments_string: "--osinfo-version 0 windowsfips2016-64u"
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    windowsfips2016-64-1:
+      platform: windows-2016-64
+      packaging_platform: windowsfips-2016-x64
+      ruby_arch: x64
+      template: win-2016-fips-x86_64
+      hypervisor: vmpooler
+      roles:
+      - agent
+      - ca
+  CONFIG:
+    pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
+expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/windowsfips2016-64u
+++ b/test/fixtures/generated/osinfo-version-1/windowsfips2016-64u
@@ -1,0 +1,17 @@
+---
+arguments_string: "--osinfo-version 1 windowsfips2016-64u"
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    windowsfips2016-64-1:
+      platform: windows-2016-64
+      packaging_platform: windowsfips-2016-x64
+      ruby_arch: x64
+      template: win-2016-fips-x86_64
+      hypervisor: vmpooler
+      roles:
+      - agent
+      - ca
+  CONFIG:
+    pooling_api: https://vmpooler-prod.k8s.infracore.puppet.net/
+expected_exception:


### PR DESCRIPTION
This PR is to add support for windowsfips 2016.
Before:

```
bundle exec beaker-hostgenerator redhat8-64mcd-windowsfips2016-64f
---
HOSTS:
  redhat8-64-1:
    platform: el-8-x86_64
    hypervisor: vmpooler
    template: redhat-8-x86_64
    roles:
    - agent
    - master
    - dashboard
    - database
  windowsfips2016-64-1:
    hypervisor: vmpooler
    roles:
    - agent
    - frictionless
```
With this PR:

```
bundle exec beaker-hostgenerator redhat8-64mcd-windowsfips2016-64f       
---
HOSTS:
  redhat8-64-1:
    platform: el-8-x86_64
    hypervisor: vmpooler
    template: redhat-8-x86_64
    roles:
    - agent
    - master
    - dashboard
    - database
  windowsfips2016-64-1:
    platform: windows-2016-64
    packaging_platform: windowsfips-2016-x64
    ruby_arch: x64
    template: win-2016-fips-x86_64
    hypervisor: vmpooler
    roles:
    - agent
    - frictionless
```
