### PR TITLE
(PA-7442) Fix Windows Server 2025 platform entry in beaker-hostgenerator

### DIFF
--- a/lib/beaker-hostgenerator/data.rb
+++ b/lib/beaker-hostgenerator/data.rb
@@ -977,14 +977,14 @@ module BeakerHostGenerator
                           'template' => 'win-2019-core-x86_64',
                         },
                       },
-                      'windows2025_ent-64' => {
+                      'windows2025-64' => {
                         general: {
                           'platform' => 'windows-2025-64',
-                          'packaging_platform' => 'windows-2025-x64',
+                          'packaging_platform' => 'windows-2012-x64',
                           'ruby_arch' => 'x64',
                         },
                         vmpooler: {
-                          'template' => 'win-2025-ent-x64',
+                          'template' => 'win-2025-x64',
                         },
                       },
                       'windows2022-64' => {

--- a/test/fixtures/generated/default/windows2025-64d
+++ b/test/fixtures/generated/default/windows2025-64d
@@ -1,13 +1,13 @@
 ---
-arguments_string: "--osinfo-version 0 windows2025_ent-64d"
+arguments_string: windows2025-64d
 environment_variables: {}
 expected_hash:
   HOSTS:
-    windows2025_ent-64-1:
+    windows2025-64-1:
       platform: windows-2025-64
-      packaging_platform: windows-2025-x64
+      packaging_platform: windows-2012-x64
       ruby_arch: x64
-      template: win-2025-ent-x64
+      template: win-2025-x64
       hypervisor: vmpooler
       roles:
       - agent

--- a/test/fixtures/generated/multiplatform/fedora24-32c-windows2025-64-fedora24-32d
+++ b/test/fixtures/generated/multiplatform/fedora24-32c-windows2025-64-fedora24-32d
@@ -1,5 +1,5 @@
 ---
-arguments_string: fedora24-32c-windows2025_ent-64-fedora24-32d
+arguments_string: fedora24-32c-windows2025-64-fedora24-32d
 environment_variables: {}
 expected_hash:
   HOSTS:
@@ -10,11 +10,11 @@ expected_hash:
       roles:
       - agent
       - dashboard
-    windows2025_ent-64-1:
+    windows2025-64-1:
       platform: windows-2025-64
-      packaging_platform: windows-2025-x64
+      packaging_platform: windows-2012-x64
       ruby_arch: x64
-      template: win-2025-ent-x64
+      template: win-2025-x64
       hypervisor: vmpooler
       roles:
       - agent

--- a/test/fixtures/generated/multiplatform/windows2025-64d-fedora24-32-windows2025-64c
+++ b/test/fixtures/generated/multiplatform/windows2025-64d-fedora24-32-windows2025-64c
@@ -1,13 +1,13 @@
 ---
-arguments_string: windows2025_ent-64d-fedora24-32-windows2025_ent-64c
+arguments_string: windows2025-64d-fedora24-32-windows2025-64c
 environment_variables: {}
 expected_hash:
   HOSTS:
-    windows2025_ent-64-1:
+    windows2025-64-1:
       platform: windows-2025-64
-      packaging_platform: windows-2025-x64
+      packaging_platform: windows-2012-x64
       ruby_arch: x64
-      template: win-2025-ent-x64
+      template: win-2025-x64
       hypervisor: vmpooler
       roles:
       - agent
@@ -18,11 +18,11 @@ expected_hash:
       template: fedora-24-i386
       roles:
       - agent
-    windows2025_ent-64-2:
+    windows2025-64-2:
       platform: windows-2025-64
-      packaging_platform: windows-2025-x64
+      packaging_platform: windows-2012-x64
       ruby_arch: x64
-      template: win-2025-ent-x64
+      template: win-2025-x64
       hypervisor: vmpooler
       roles:
       - agent

--- a/test/fixtures/generated/osinfo-version-0/windows2025-64d
+++ b/test/fixtures/generated/osinfo-version-0/windows2025-64d
@@ -1,13 +1,13 @@
 ---
-arguments_string: "--osinfo-version 1 windows2025_ent-64d"
+arguments_string: "--osinfo-version 0 windows2025-64d"
 environment_variables: {}
 expected_hash:
   HOSTS:
-    windows2025_ent-64-1:
+    windows2025-64-1:
       platform: windows-2025-64
-      packaging_platform: windows-2025-x64
+      packaging_platform: windows-2012-x64
       ruby_arch: x64
-      template: win-2025-ent-x64
+      template: win-2025-x64
       hypervisor: vmpooler
       roles:
       - agent

--- a/test/fixtures/generated/osinfo-version-1/windows2025-64d
+++ b/test/fixtures/generated/osinfo-version-1/windows2025-64d
@@ -1,13 +1,13 @@
 ---
-arguments_string: windows2025_ent-64d
+arguments_string: "--osinfo-version 1 windows2025-64d"
 environment_variables: {}
 expected_hash:
   HOSTS:
-    windows2025_ent-64-1:
+    windows2025-64-1:
       platform: windows-2025-64
-      packaging_platform: windows-2025-x64
+      packaging_platform: windows-2012-x64
       ruby_arch: x64
-      template: win-2025-ent-x64
+      template: win-2025-x64
       hypervisor: vmpooler
       roles:
       - agent


### PR DESCRIPTION
Corrects the packaging_platform and naming convention for the Windows Server 2025 entry in beaker-hostgenerator.

- Changed packaging_platform from `windows-2025-x64` to `windows-2012-x64`
- Updated the platform name from `windows2025_ent-64` to a more accurate and consistent format

Context:
Support for Windows Server 2025 was initially added in PR #396, but it included incorrect values for packaging_platform and name.

This update ensures compatibility and aligns with expected standards for platform representation in test orchestration.

Refs: voxpupuli/beaker-hostgenerator#396