### PR TITLE
Add Debian 13 support and make CentOS & Debian easier to maintain

### DIFF
--- a/lib/beaker-hostgenerator/data.rb
+++ b/lib/beaker-hostgenerator/data.rb
@@ -1100,7 +1100,7 @@ module BeakerHostGenerator
       end
 
       # Debian
-      (10..12).each do |release|
+      (10..13).each do |release|
         yield ["debian#{release}-32", "debian-#{release}-i386"] if release < 11
 
         yield ["debian#{release}-64", "debian-#{release}-amd64"]

--- a/lib/beaker-hostgenerator/data.rb
+++ b/lib/beaker-hostgenerator/data.rb
@@ -165,36 +165,6 @@ module BeakerHostGenerator
                           'box_url' => 'https://cloud.centos.org/centos/10-stream/x86_64/images/CentOS-Stream-Vagrant-10-latest.x86_64.vagrant-libvirt.box',
                         },
                       },
-                      'debian10-64' => {
-                        general: {
-                          'platform' => 'debian-10-amd64',
-                        },
-                      },
-                      'debian10-32' => {
-                        general: {
-                          'platform' => 'debian-10-i386',
-                        },
-                      },
-                      'debian11-64' => {
-                        general: {
-                          'platform' => 'debian-11-amd64',
-                        },
-                      },
-                      'debian11-AARCH64' => {
-                        general: {
-                          'platform' => 'debian-11-aarch64',
-                        },
-                      },
-                      'debian12-64' => {
-                        general: {
-                          'platform' => 'debian-12-amd64',
-                        },
-                      },
-                      'debian12-AARCH64' => {
-                        general: {
-                          'platform' => 'debian-12-aarch64',
-                        },
-                      },
                       'panos61-64' => {
                         general: {
                           'platform' => 'palo-alto-6.1.0-x86_64',
@@ -1155,6 +1125,15 @@ module BeakerHostGenerator
     def generate_osinfo
       # AIX
       yield %w[aix73-POWER aix-7.3-power]
+
+      # Debian
+      (10..12).each do |release|
+        yield ["debian#{release}-32", "debian-#{release}-i386"] if release < 11
+
+        yield ["debian#{release}-64", "debian-#{release}-amd64"]
+
+        yield ["debian#{release}-AARCH64", "debian-#{release}-aarch64"] if release >= 11
+      end
 
       # Fedora
       (19..41).each do |release|

--- a/lib/beaker-hostgenerator/data.rb
+++ b/lib/beaker-hostgenerator/data.rb
@@ -142,27 +142,15 @@ module BeakerHostGenerator
                         general: {
                           'platform' => 'el-8-x86_64',
                         },
-                        vagrant: {
-                          'box' => 'centos/stream8',
-                          'box_url' => 'https://cloud.centos.org/centos/8-stream/x86_64/images/CentOS-Stream-Vagrant-8-latest.x86_64.vagrant-libvirt.box',
-                        },
                       },
                       'centos9-64' => {
                         general: {
                           'platform' => 'el-9-x86_64',
                         },
-                        vagrant: {
-                          'box' => 'centos/stream9',
-                          'box_url' => 'https://cloud.centos.org/centos/9-stream/x86_64/images/CentOS-Stream-Vagrant-9-latest.x86_64.vagrant-libvirt.box',
-                        },
                       },
                       'centos10-64' => {
                         general: {
                           'platform' => 'el-10-x86_64',
-                        },
-                        vagrant: {
-                          'box' => 'centos/stream10',
-                          'box_url' => 'https://cloud.centos.org/centos/10-stream/x86_64/images/CentOS-Stream-Vagrant-10-latest.x86_64.vagrant-libvirt.box',
                         },
                       },
                       'panos61-64' => {

--- a/lib/beaker-hostgenerator/data.rb
+++ b/lib/beaker-hostgenerator/data.rb
@@ -169,9 +169,6 @@ module BeakerHostGenerator
                         general: {
                           'platform' => 'debian-10-amd64',
                         },
-                        vagrant: {
-                          'box' => 'debian/buster64',
-                        },
                       },
                       'debian10-32' => {
                         general: {
@@ -182,9 +179,6 @@ module BeakerHostGenerator
                         general: {
                           'platform' => 'debian-11-amd64',
                         },
-                        vagrant: {
-                          'box' => 'debian/bullseye64',
-                        },
                       },
                       'debian11-AARCH64' => {
                         general: {
@@ -194,9 +188,6 @@ module BeakerHostGenerator
                       'debian12-64' => {
                         general: {
                           'platform' => 'debian-12-amd64',
-                        },
-                        vagrant: {
-                          'box' => 'debian/bookworm64',
                         },
                       },
                       'debian12-AARCH64' => {

--- a/lib/beaker-hostgenerator/data.rb
+++ b/lib/beaker-hostgenerator/data.rb
@@ -133,26 +133,6 @@ module BeakerHostGenerator
                           'image' => 'archlinux/archlinux',
                         },
                       },
-                      'centos7-64' => {
-                        general: {
-                          'platform' => 'el-7-x86_64',
-                        },
-                      },
-                      'centos8-64' => {
-                        general: {
-                          'platform' => 'el-8-x86_64',
-                        },
-                      },
-                      'centos9-64' => {
-                        general: {
-                          'platform' => 'el-9-x86_64',
-                        },
-                      },
-                      'centos10-64' => {
-                        general: {
-                          'platform' => 'el-10-x86_64',
-                        },
-                      },
                       'panos61-64' => {
                         general: {
                           'platform' => 'palo-alto-6.1.0-x86_64',
@@ -1113,6 +1093,11 @@ module BeakerHostGenerator
     def generate_osinfo
       # AIX
       yield %w[aix73-POWER aix-7.3-power]
+
+      # CentOS
+      (7..10).each do |release|
+        yield ["centos#{release}-64", "el-#{release}-x86_64"]
+      end
 
       # Debian
       (10..12).each do |release|

--- a/lib/beaker-hostgenerator/hypervisor/vagrant.rb
+++ b/lib/beaker-hostgenerator/hypervisor/vagrant.rb
@@ -7,6 +7,14 @@ module BeakerHostGenerator
     class Vagrant < BeakerHostGenerator::Hypervisor::Interface
       include BeakerHostGenerator::Data
 
+      DEBIAN_VERSION_CODES = {
+        # No newer releases available
+        # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1104105
+        '12' => 'bookworm',
+        '11' => 'bullseye',
+        '10' => 'buster',
+      }.freeze
+
       def generate_node(node_info, base_config, bhg_version)
         base_config['box'] = case node_info['ostype']
                              when /^centos/, /^almalinux/
@@ -16,6 +24,14 @@ module BeakerHostGenerator
                              else
                                "generic/#{node_info['ostype']}"
                              end
+
+        case node_info['platform']
+        when /^debian(\d+)-64/
+          version = Regexp.last_match(1)
+          if (codename = DEBIAN_VERSION_CODES[version])
+            base_config['box'] = "debian/#{codename}64"
+          end
+        end
 
         # We don't use this by default
         base_config['synced_folder'] = 'disabled'

--- a/lib/beaker-hostgenerator/hypervisor/vagrant.rb
+++ b/lib/beaker-hostgenerator/hypervisor/vagrant.rb
@@ -17,7 +17,7 @@ module BeakerHostGenerator
 
       def generate_node(node_info, base_config, bhg_version)
         base_config['box'] = case node_info['ostype']
-                             when /^centos/, /^almalinux/
+                             when /^almalinux/
                                node_info['ostype'].sub(/(\d)/, '/\1')
                              when /^fedora/
                                node_info['ostype'].sub(/(\d)/, '/\1') + '-cloud-base'
@@ -30,6 +30,14 @@ module BeakerHostGenerator
           version = Regexp.last_match(1)
           if (codename = DEBIAN_VERSION_CODES[version])
             base_config['box'] = "debian/#{codename}64"
+          end
+        when /^centos(\d+)-64/
+          version = Regexp.last_match(1)
+          if version.to_i >= 8
+            base_config['box'] = "centos/stream#{version}"
+            base_config['box_url'] = "https://cloud.centos.org/centos/#{version}-stream/x86_64/images/CentOS-Stream-Vagrant-#{version}-latest.x86_64.vagrant-libvirt.box"
+          else
+            base_config = "centos/#{version}"
           end
         end
 


### PR DESCRIPTION
This first refactors Debian's Vagrant boxes to be added by the hypervisor. It then uses this to generate them in a loop. As a  last step it adds Debian 13 by running another loop.