### PR TITLE
Use non library path for rocky 10

### DIFF
--- a/lib/beaker-hostgenerator/hypervisor/docker.rb
+++ b/lib/beaker-hostgenerator/hypervisor/docker.rb
@@ -42,7 +42,8 @@ module BeakerHostGenerator
         when /^ubuntu/
           image.sub!(/(\d{2})/, '\1.')
         when /^rocky/
-          image.sub!(/(\w+)/, 'rockylinux')
+          version = ostype.delete_prefix('rocky')
+          image = "quay.io/rockylinux/rockylinux:#{version}"
         when /^alma/
           image.sub!(/(\w+)/, 'almalinux')
         end


### PR DESCRIPTION
There is no library path for Rocky 10

* `docker://docker.io/rockylinux:10` does not exist
* `docker://docker.io/rockylinux/rockylinux:10` does exist`
* `docker://quay.io/rockylinux/rockylinux:10` does exist`

https://github.com/voxpupuli/puppet-cvmfs/pull/224 shows use of this patch.