### PR TITLE
Add Debian 13 (Trixie) support for Vagrant hypervisor

### DIFF
--- a/lib/beaker-hostgenerator/hypervisor/vagrant.rb
+++ b/lib/beaker-hostgenerator/hypervisor/vagrant.rb
@@ -10,6 +10,7 @@ module BeakerHostGenerator
       DEBIAN_VERSION_CODES = {
         # No newer releases available
         # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1104105
+        '13' => 'trixie',
         '12' => 'bookworm',
         '11' => 'bullseye',
         '10' => 'buster',


### PR DESCRIPTION
Hi!

I needed to add support for Debian 13 (Trixie) in our Vagrant setup, so here it is.