### PR TITLE
Add redhat support to docker hypervisor

### DIFF
--- a/lib/beaker-hostgenerator/hypervisor/docker.rb
+++ b/lib/beaker-hostgenerator/hypervisor/docker.rb
@@ -20,7 +20,8 @@ module BeakerHostGenerator
         base_config['image'].prepend('amd64/') if
           node_info['bits'] == '64' &&
           !base_config['image'].start_with?('quay.io/') &&
-          !base_config['image'].start_with?('opensuse/')
+          !base_config['image'].start_with?('opensuse/') &&
+          !ostype.start_with?('redhat')
 
         base_generate_node(node_info, base_config, bhg_version, :docker)
       end
@@ -31,6 +32,9 @@ module BeakerHostGenerator
         image = ostype.sub(/(\d)/, ':\1')
 
         case ostype
+        when /^redhat/
+          version = ostype.delete_prefix('redhat')
+          image = "redhat/ubi#{version}-init:latest"
         when /^centos/
           version = ostype.delete_prefix('centos')
           tag = (version.to_i >= 8) ? "stream#{version}" : "centos#{version}"

--- a/test/fixtures/per-host-settings/docker-regex-validation.yaml
+++ b/test/fixtures/per-host-settings/docker-regex-validation.yaml
@@ -1,4 +1,4 @@
-arguments_string: --hypervisor=docker oracle7-64-opensuse15-64-ubuntu2004-64
+arguments_string: --hypervisor=docker oracle7-64-opensuse15-64-redhat10-64-ubuntu2004-64
 environment_variables: {}
 expected_hash:
   HOSTS:
@@ -21,6 +21,14 @@ expected_hash:
       docker_image_commands:
       - cp /bin/true /sbin/agetty
       - zypper install -y cron iproute2 tar wget which
+      hypervisor: docker
+      roles:
+      - agent
+    redhat10-64-1:
+      image: redhat/ubi10-init:latest
+      platform: el-10-x86_64
+      docker_cmd:
+      - "/sbin/init"
       hypervisor: docker
       roles:
       - agent


### PR DESCRIPTION
Hello, picking up and cleaning up the work from #359 to add RHEL/UBI Docker support.

Just added proper handling for Red Hat's Universal Base Images (UBI) in the Docker hypervisor:
- Maps `redhat*` ostypes to the right UBI image (`redhat/ubi*-init:latest`)
- Skips the `amd64/` prefix for RHEL images
- Added a test case to verify it works
