### PR TITLE
EL8 & newer: Install gnupg2

### DIFF
--- a/lib/beaker-hostgenerator/hypervisor/docker.rb
+++ b/lib/beaker-hostgenerator/hypervisor/docker.rb
@@ -85,7 +85,7 @@ module BeakerHostGenerator
 
       def el_package_install_command(version)
         if version >= 8
-          'dnf install -y cronie crontabs initscripts iproute openssl wget which glibc-langpack-en hostname'
+          'dnf install -y cronie crontabs initscripts iproute openssl wget which glibc-langpack-en hostname gnupg2'
         else
           'yum install -y crontabs initscripts iproute openssl wget which sysvinit-tools tar ss'
         end


### PR DESCRIPTION
gnupg2 is required for handling gpg keys, but some minimal EL10 container images don't have it preinstalled. We don't want to patch multiple modules, so we should handle this in beaker-hostgenerator.